### PR TITLE
Add dark theme support for the popup UI

### DIFF
--- a/src/extension/entrypoints/popup/components/card-button.tsx
+++ b/src/extension/entrypoints/popup/components/card-button.tsx
@@ -8,7 +8,7 @@ type CardButtonProps = {
 export const CardButton: Component<CardButtonProps> = (props) => {
   return (
     <Cell class="flex justify-center items-center py-1.5">
-      <div class="text-blue-500 flex flex-col items-center justify-center gap-0.5 text-[10px] font-medium [&_svg]:w-5 [&_svg]:h-5">
+      <div class="text-blue-500 flex flex-col items-center justify-center gap-0.5 text-[10px] font-medium dark:text-blue-400 [&_svg]:w-5 [&_svg]:h-5">
         {props.children}
       </div>
     </Cell>

--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -16,28 +16,17 @@ interface CellProps {
 }
 
 export const Cell: Component<CellProps> = (props) => {
-  const cellProps = mergeProps({ Component: 'div' }, props);
-
-  const component = (props: any) => {
-    switch (cellProps.component) {
-      case 'button':
-        return <button {...props} />;
-      case 'label':
-        return <label {...props} />;
-      default:
-      case 'div':
-        return <div {...props} />;
-    }
-  };
+  const cellProps = mergeProps({ component: 'div' as const }, props);
 
   return (
     <Dynamic
-      component={component}
+      component={cellProps.component}
       class={cn(
-        'bg-white w-full min-h-9 py-2 rounded-lg text-[13px] flex items-center px-3 cursor-pointer',
-        'transition hover:bg-slate-50 active:bg-slate-100',
-        props.variant === 'primary' && 'text-[#007AFF]',
-        props.variant === 'danger' && 'text-[#E53935]',
+        'bg-white w-full min-h-9 py-2 rounded-lg text-[13px] flex items-center px-3 cursor-pointer text-left text-neutral-950',
+        'transition-colors hover:bg-slate-50 active:bg-slate-100',
+        'dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-700 dark:active:bg-neutral-700',
+        props.variant === 'primary' && 'text-[#007AFF] dark:text-blue-400',
+        props.variant === 'danger' && 'text-[#E53935] dark:text-red-400',
         props.disabled && 'cursor-default pointer-events-none opacity-70',
         props.class,
       )}
@@ -49,8 +38,8 @@ export const Cell: Component<CellProps> = (props) => {
         <span class="truncate">{props.children}</span>
         <span
           class={cn(
-            'text-[11px] text-neutral-500 select-none',
-            props.variant === 'primary' && 'text-blue-500',
+            'text-[11px] text-neutral-500 select-none dark:text-neutral-400',
+            props.variant === 'primary' && 'text-blue-500 dark:text-blue-400',
           )}
         >
           {props.subtitle}

--- a/src/extension/entrypoints/popup/components/header.tsx
+++ b/src/extension/entrypoints/popup/components/header.tsx
@@ -17,7 +17,10 @@ export const Header: Component<HeaderProps> = (props) => {
       )}
     >
       <Show when={props.backHref}>
-        <A href={props.backHref!}>
+        <A
+          href={props.backHref!}
+          class="transition-colors hover:text-blue-500 dark:hover:text-blue-400"
+        >
           <FaSolidArrowLeft />
         </A>
       </Show>

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -25,12 +25,12 @@ export const KeysList: Component<KeysListProps> = (props) => {
                 {/* value may be a status if Spoofing disabled */}
                 <span class="w-1/2 truncate">{value}</span>
               </code>
-              <div class="text-[10px] text-gray-500 flex justify-between">
+              <div class="text-[10px] text-gray-500 flex justify-between dark:text-neutral-400">
                 <a
                   title={mpd || url}
                   target="_blank"
                   href={mpd || url}
-                  class="w-fit truncate hover:underline hover:text-blue-500"
+                  class="w-fit truncate hover:underline hover:text-blue-500 dark:hover:text-blue-400"
                 >
                   {shorten(mpd || url)}
                 </a>

--- a/src/extension/entrypoints/popup/components/layout.tsx
+++ b/src/extension/entrypoints/popup/components/layout.tsx
@@ -1,5 +1,9 @@
 import { Component, JSX } from 'solid-js';
 
 export const Layout: Component<{ children: JSX.Element }> = (props) => {
-  return <main class="px-4 py-4 min-w-[290px] min-h-[360px] bg-[#EFEFF4]">{props.children}</main>;
+  return (
+    <main class="px-4 py-4 min-w-[290px] min-h-[360px] bg-[#EFEFF4] text-neutral-950 transition-colors dark:bg-neutral-950 dark:text-neutral-50">
+      {props.children}
+    </main>
+  );
 };

--- a/src/extension/entrypoints/popup/components/no-keys.tsx
+++ b/src/extension/entrypoints/popup/components/no-keys.tsx
@@ -2,7 +2,7 @@ export const NoKeys = () => {
   return (
     <div class="w-full flex flex-col text-center gap-1 justify-center items-center">
       <h1 class="text-[16px] font-semibold text-center">Keys will appear here</h1>
-      <h2 class="text-[13px] px-8 text-center">
+      <h2 class="text-[13px] px-8 text-center text-neutral-800 dark:text-neutral-300">
         Go to streaming service and play media to get keys
       </h2>
     </div>

--- a/src/extension/entrypoints/popup/components/section.tsx
+++ b/src/extension/entrypoints/popup/components/section.tsx
@@ -1,7 +1,11 @@
 import { Component, JSX } from 'solid-js';
 
 export const SectionFooter: Component<{ children: JSX.Element }> = (props) => {
-  return <footer class="px-3 pt-1.5 pb-1 text-[10px] text-neutral-500">{props.children}</footer>;
+  return (
+    <footer class="px-3 pt-1.5 pb-1 text-[10px] text-neutral-500 dark:text-neutral-400">
+      {props.children}
+    </footer>
+  );
 };
 
 type SectionProps = {
@@ -14,16 +18,16 @@ export const Section: Component<SectionProps> = (props) => {
   return (
     <section>
       <div class="shadow-xs">
-        <header class="px-2 pt-2 pb-1 text-[10px] uppercase text-neutral-500">
+        <header class="px-2 pt-2 pb-1 text-[10px] uppercase text-neutral-500 dark:text-neutral-400">
           {props.header}
         </header>
-        <div class="rounded-[9px] bg-white [&>div]:rounded-none [&>*:first-child]:rounded-t-lg [&>*:last-child]:rounded-b-lg">
+        <div class="rounded-[9px] bg-white dark:bg-neutral-800 [&>*]:rounded-none [&>*:first-child]:rounded-t-lg [&>*:last-child]:rounded-b-lg">
           <For each={props.children}>
             {(child, index) => (
               <>
                 {child}
                 <Show when={props.children && index() < props.children.length - 1}>
-                  <div class="h-px bg-gray-100"></div>
+                  <div class="h-px bg-gray-100 dark:bg-neutral-700 transition-colors"></div>
                 </Show>
               </>
             )}

--- a/src/extension/entrypoints/popup/components/switch.module.css
+++ b/src/extension/entrypoints/popup/components/switch.module.css
@@ -36,7 +36,7 @@
   content: '';
   inset: 0;
 
-  background: #efeff4;
+  background: var(--popup-switch-track);
 }
 
 .control::after {
@@ -58,7 +58,7 @@
     0 3px 1px 0 rgba(0, 0, 0, 0.06),
     0 3px 8px 0 rgba(0, 0, 0, 0.15),
     0 0 0 1px rgba(0, 0, 0, 0.04);
-  background: white;
+  background: var(--popup-switch-thumb);
 }
 
 .input:checked + .control::before {

--- a/src/extension/entrypoints/popup/main.tsx
+++ b/src/extension/entrypoints/popup/main.tsx
@@ -9,19 +9,20 @@ import { Keys } from './routes/keys';
 import { Settings } from './routes/settings';
 import { useSettings, useSyncStateWithStorage } from './utils/state';
 
+const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
 const Popup = () => {
   const [settings] = useSettings();
-  const [prefersDark, setPrefersDark] = createSignal(false);
+  const [prefersDark, setPrefersDark] = createSignal(colorSchemeQuery.matches);
 
   useSyncStateWithStorage();
 
   onMount(() => {
-    const media = window.matchMedia('(prefers-color-scheme: dark)');
-    const syncPreference = () => setPrefersDark(media.matches);
+    const syncPreference = () => setPrefersDark(colorSchemeQuery.matches);
 
     syncPreference();
-    media.addEventListener('change', syncPreference);
-    onCleanup(() => media.removeEventListener('change', syncPreference));
+    colorSchemeQuery.addEventListener('change', syncPreference);
+    onCleanup(() => colorSchemeQuery.removeEventListener('change', syncPreference));
   });
 
   createEffect(() => {

--- a/src/extension/entrypoints/popup/main.tsx
+++ b/src/extension/entrypoints/popup/main.tsx
@@ -1,20 +1,44 @@
 import { render } from 'solid-js/web';
 import { Route, Router } from '@solidjs/router';
+import { createEffect, createSignal, onCleanup, onMount } from 'solid-js';
 
 import './styles.css';
 import { Dashboard } from './routes/dashboard';
 import { Clients } from './routes/clients';
 import { Keys } from './routes/keys';
 import { Settings } from './routes/settings';
+import { useSettings, useSyncStateWithStorage } from './utils/state';
 
-render(
-  () => (
+const Popup = () => {
+  const [settings] = useSettings();
+  const [prefersDark, setPrefersDark] = createSignal(false);
+
+  useSyncStateWithStorage();
+
+  onMount(() => {
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const syncPreference = () => setPrefersDark(media.matches);
+
+    syncPreference();
+    media.addEventListener('change', syncPreference);
+    onCleanup(() => media.removeEventListener('change', syncPreference));
+  });
+
+  createEffect(() => {
+    const useDarkTheme = settings.theme === 'dark' || (settings.theme === 'auto' && prefersDark());
+
+    document.documentElement.classList.toggle('dark', useDarkTheme);
+    document.documentElement.style.colorScheme = useDarkTheme ? 'dark' : 'light';
+  });
+
+  return (
     <Router base="/popup.html">
       <Route path="/" component={Dashboard} />
       <Route path="/clients" component={Clients} />
       <Route path="/keys" component={Keys} />
       <Route path="/settings" component={Settings} />
     </Router>
-  ),
-  document.getElementById('root')!,
-);
+  );
+};
+
+render(() => <Popup />, document.getElementById('root')!);

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -1,12 +1,6 @@
 import { A } from '@solidjs/router';
 import { Cell } from '../components/cell';
-import {
-  useActiveClient,
-  useClients,
-  useRecentKeys,
-  useSettings,
-  useSyncStateWithStorage,
-} from '../utils/state';
+import { useActiveClient, useClients, useRecentKeys, useSettings } from '../utils/state';
 import { Toolbar } from '../components/toolbar';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
@@ -20,8 +14,6 @@ export const Dashboard = () => {
   const [clients] = useClients();
   const [recentKeys] = useRecentKeys();
   const [activeClient, setActiveClient] = useActiveClient();
-
-  useSyncStateWithStorage();
 
   createEffect(() => {
     if (clients().length === 1) {
@@ -56,7 +48,7 @@ export const Dashboard = () => {
               Enable Spoofing in{' '}
               <A
                 href="/settings"
-                class="w-fit truncate text-blue-600 hover:underline hover:text-blue-500"
+                class="w-fit truncate text-blue-600 hover:underline hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
               >
                 Settings
               </A>{' '}

--- a/src/extension/entrypoints/popup/routes/settings.tsx
+++ b/src/extension/entrypoints/popup/routes/settings.tsx
@@ -1,3 +1,4 @@
+import { BsCheckLg } from 'solid-icons/bs';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
 import { List } from '../components/list';
@@ -5,25 +6,41 @@ import { Section } from '../components/section';
 import { Cell } from '../components/cell';
 import { Switch } from '../components/switch';
 import { useSettings } from '../utils/state';
-import { appStorage } from '@/utils/storage';
+import { appStorage, ThemeMode, Settings as AppSettings } from '@/utils/storage';
 
 export const Settings = () => {
   const [settings, setSettings] = useSettings();
 
+  const updateSettings = (nextSettings: Partial<AppSettings>) => {
+    const updatedSettings = { ...settings, ...nextSettings };
+    setSettings(nextSettings);
+    appStorage.settings.setValue(updatedSettings);
+  };
+
   const switchEmeInterception = (checked: boolean) => {
-    setSettings({ emeInterception: checked });
-    appStorage.settings.setValue(settings);
+    updateSettings({
+      emeInterception: checked,
+      ...(!checked && { spoofing: false }),
+    });
   };
 
   const switchSpoofing = (checked: boolean) => {
-    setSettings({ spoofing: checked });
-    appStorage.settings.setValue(settings);
+    updateSettings({ spoofing: checked });
   };
 
   const switchRequestInterception = (checked: boolean) => {
-    setSettings({ requestInterception: checked });
-    appStorage.settings.setValue(settings);
+    updateSettings({ requestInterception: checked });
   };
+
+  const setTheme = (theme: ThemeMode) => {
+    updateSettings({ theme });
+  };
+
+  const themeOptions: { value: ThemeMode; label: string; subtitle?: string }[] = [
+    { value: 'auto', label: 'Auto' },
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
+  ];
 
   return (
     <Layout>
@@ -79,6 +96,24 @@ export const Settings = () => {
               Request interception
             </Cell>,
           ]}
+        </Section>
+        <Section header="Appearance">
+          {themeOptions.map((option) => (
+            <Cell
+              component="button"
+              subtitle={option.subtitle}
+              onClick={() => setTheme(option.value)}
+              after={
+                <div class="w-5 h-5 flex items-center justify-center">
+                  <Show when={settings.theme === option.value}>
+                    <BsCheckLg class="text-blue-500 dark:text-blue-400 w-5 h-5" />
+                  </Show>
+                </div>
+              }
+            >
+              {option.label}
+            </Cell>
+          ))}
         </Section>
       </List>
     </Layout>

--- a/src/extension/entrypoints/popup/styles.css
+++ b/src/extension/entrypoints/popup/styles.css
@@ -2,6 +2,20 @@
 
 @custom-variant dark (&:is(.dark *));
 
+:root {
+  --popup-bg: #efeff4;
+  --popup-fg: #0a0a0a;
+  --popup-switch-track: #efeff4;
+  --popup-switch-thumb: #ffffff;
+}
+
+.dark {
+  --popup-bg: #0a0a0a;
+  --popup-fg: #fafafa;
+  --popup-switch-track: #3f3f46;
+  --popup-switch-thumb: #fafafa;
+}
+
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still
@@ -17,5 +31,18 @@
   ::backdrop,
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
+  }
+
+  html,
+  body,
+  #root {
+    min-width: 290px;
+    min-height: 360px;
+    background: var(--popup-bg);
+    color: var(--popup-fg);
+  }
+
+  body {
+    margin: 0;
   }
 }

--- a/src/extension/entrypoints/popup/utils/state.ts
+++ b/src/extension/entrypoints/popup/utils/state.ts
@@ -1,5 +1,6 @@
 import { appStorage, Client, KeyInfo, Settings } from '@/utils/storage';
-import { createSignal } from 'solid-js';
+import { createSignal, onMount } from 'solid-js';
+import { createStore } from 'solid-js/store';
 
 const clientsSignal = createSignal<Client[]>([]);
 export const useClients = () => clientsSignal;
@@ -14,6 +15,7 @@ const defaultSettings: Settings = {
   emeInterception: true,
   spoofing: false,
   requestInterception: false,
+  theme: 'auto',
 };
 const settingsStore = createStore<Settings>(defaultSettings);
 export const useSettings = () => settingsStore;
@@ -26,8 +28,13 @@ export const useSyncStateWithStorage = () => {
 
   onMount(async () => {
     const settings = await appStorage.settings.getValue();
-    if (settings) setSettings(settings);
-    else appStorage.settings.setValue(defaultSettings);
+    if (settings) {
+      const syncedSettings = { ...defaultSettings, ...settings };
+      setSettings(syncedSettings);
+      if (!settings.theme) appStorage.settings.setValue(syncedSettings);
+    } else {
+      appStorage.settings.setValue(defaultSettings);
+    }
 
     appStorage.clients.getValue().then((clients) => setClients(clients));
     appStorage.recentKeys.getValue().then((recentKeys) => recentKeys && setRecentKeys(recentKeys));

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -17,7 +17,10 @@ export type Settings = {
   spoofing: boolean;
   emeInterception: boolean;
   requestInterception: boolean;
+  theme: ThemeMode;
 };
+
+export type ThemeMode = 'light' | 'dark' | 'auto';
 
 export type Client = WidevineClient | PlayReadyClient;
 export type ClientInfo = { type: 'wvd'; data: string } | { type: 'prd'; data: string };


### PR DESCRIPTION
Fixes #1 

## Summary
- Add a persisted popup theme setting with `Light`, `Dark`, and `Auto` options
- Apply theme state at the popup root so the whole UI follows the selected mode
- Update shared popup components and surfaces for dark-mode styling

## Testing
- `pnpm run compile`
- `pnpm run lint`
- `pnpm run build:chrome`