### PR TITLE
Update recent keys to be scoped by website

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,4 +1,5 @@
 import { appStorage, Client } from '@/utils/storage';
+import type { KeyInfo } from '@/utils/storage';
 import {
   Cdm,
   fromBase64,
@@ -63,19 +64,29 @@ export default defineBackground({
         console.log('[okova] Received message', message);
 
         const settings = await appStorage.settings.getValue();
+        const setRecentKeys = async (keys: KeyInfo[]) => {
+          await appStorage.recentKeys.setValue(keys);
+          await appStorage.recentKeysByDomain.setForUrl(message.url, keys);
+        };
 
         const { initData } = message;
         const allKeys = await appStorage.allKeys.raw.getValue();
-        const keys = allKeys?.filter((keyInfo: any) => keyInfo.pssh === initData);
+        const keys = allKeys?.filter((keyInfo) => keyInfo.pssh === initData);
         const hasKey = !!keys?.length;
         if (hasKey) {
-          await appStorage.recentKeys.setValue(keys);
+          const currentSiteKeys = keys.map((keyInfo: KeyInfo) => ({
+            ...keyInfo,
+            url: message.url ?? keyInfo.url,
+            mpd: message.mpd ?? keyInfo.mpd,
+          }));
+          await setRecentKeys(currentSiteKeys);
           sendResponse();
           return;
         }
 
         if (settings?.emeInterception && message.action === 'keystatuseschange') {
-          const keys = Object.entries(message.keyStatuses).map(([id, status]: any) => ({
+          const keyStatuses = message.keyStatuses as Record<string, string>;
+          const keys = Object.entries(keyStatuses).map(([id, status]) => ({
             id: fromBase64(id).toHex(),
             value: status,
             url: message.url,
@@ -83,8 +94,8 @@ export default defineBackground({
             pssh: message.initData,
             createdAt: new Date().getTime(),
           }));
-          appStorage.recentKeys.setValue(keys);
-          appStorage.allKeys.add(...keys);
+          await setRecentKeys(keys);
+          await appStorage.allKeys.add(...keys);
           sendResponse();
           return;
         }
@@ -182,8 +193,8 @@ export default defineBackground({
 
             const results = keys?.map((key) => toKey(key)) ?? [];
             console.log('[okova] Received keys', results);
-            appStorage.recentKeys.setValue(results);
-            appStorage.allKeys.add(...results);
+            await setRecentKeys(results);
+            await appStorage.allKeys.add(...results);
             sendResponse({ keys: results });
           }
         }

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -1,19 +1,43 @@
 import { A } from '@solidjs/router';
 import { Cell } from '../components/cell';
-import { useActiveClient, useClients, useRecentKeys, useSettings } from '../utils/state';
+import {
+  useActiveClient,
+  useActiveTabUrl,
+  useClients,
+  useRecentKeys,
+  useRecentKeysByDomain,
+  useSettings,
+} from '../utils/state';
 import { Toolbar } from '../components/toolbar';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
 import { CellImportClient } from '../components/cell-import-client';
 import { NoKeys } from '../components/no-keys';
 import { KeysList } from '../components/keys-list';
-import { appStorage } from '@/utils/storage';
+import { appStorage, getWebsiteDomain } from '@/utils/storage';
 
 export const Dashboard = () => {
   const [settings] = useSettings();
   const [clients] = useClients();
   const [recentKeys] = useRecentKeys();
+  const [recentKeysByDomain] = useRecentKeysByDomain();
+  const [activeTabUrl] = useActiveTabUrl();
   const [activeClient, setActiveClient] = useActiveClient();
+  const activeDomain = createMemo(() => getWebsiteDomain(activeTabUrl()));
+  const recentKeysHeader = createMemo(() =>
+    activeDomain() ? `Recent Keys for ${activeDomain()}` : 'Recent Keys',
+  );
+  const activeDomainRecentKeys = createMemo(() => {
+    const domain = activeDomain();
+    if (!domain) return [];
+
+    const scopedKeys = recentKeysByDomain()[domain];
+    if (scopedKeys) return scopedKeys;
+
+    const legacyKeys = recentKeys();
+    const legacyDomain = getWebsiteDomain(legacyKeys[0]?.url);
+    return legacyDomain === domain ? legacyKeys : [];
+  });
 
   createEffect(() => {
     if (clients().length === 1) {
@@ -40,8 +64,12 @@ export const Dashboard = () => {
         </Show>
 
         <KeysList
-          keys={recentKeys}
-          header="Recent Keys"
+          keys={activeDomainRecentKeys}
+          header={
+            <span class="block truncate" title={recentKeysHeader()}>
+              {recentKeysHeader()}
+            </span>
+          }
           footer={
             <Show when={!settings.spoofing}>
               Enable Spoofing in{' '}
@@ -56,7 +84,7 @@ export const Dashboard = () => {
           }
         />
 
-        <Show when={recentKeys().length === 0}>
+        <Show when={activeDomainRecentKeys().length === 0}>
           <footer class="w-full flex flex-col items-center justify-center text-center gap-1 mt-auto py-2">
             <NoKeys />
           </footer>

--- a/src/extension/entrypoints/popup/utils/state.ts
+++ b/src/extension/entrypoints/popup/utils/state.ts
@@ -1,4 +1,4 @@
-import { appStorage, Client, KeyInfo, Settings } from '@/utils/storage';
+import { appStorage, Client, KeyInfo, RecentKeysByDomain, Settings } from '@/utils/storage';
 import { createSignal, onMount } from 'solid-js';
 import { createStore } from 'solid-js/store';
 
@@ -10,6 +10,12 @@ export const useActiveClient = () => activeClientSignal;
 
 const recentKeysSignal = createSignal<KeyInfo[]>([]);
 export const useRecentKeys = () => recentKeysSignal;
+
+const recentKeysByDomainSignal = createSignal<RecentKeysByDomain>({});
+export const useRecentKeysByDomain = () => recentKeysByDomainSignal;
+
+const activeTabUrlSignal = createSignal<string | null>(null);
+export const useActiveTabUrl = () => activeTabUrlSignal;
 
 const defaultSettings: Settings = {
   emeInterception: true,
@@ -25,6 +31,8 @@ export const useSyncStateWithStorage = () => {
   const [, setClients] = useClients();
   const [, setActiveClient] = useActiveClient();
   const [, setRecentKeys] = useRecentKeys();
+  const [, setRecentKeysByDomain] = useRecentKeysByDomain();
+  const [, setActiveTabUrl] = useActiveTabUrl();
 
   onMount(async () => {
     const settings = await appStorage.settings.getValue();
@@ -37,8 +45,17 @@ export const useSyncStateWithStorage = () => {
     }
 
     appStorage.clients.getValue().then((clients) => setClients(clients));
+    browser.tabs
+      .query({ active: true, currentWindow: true })
+      .then(([tab]) => setActiveTabUrl(tab?.url ?? null));
     appStorage.recentKeys.getValue().then((recentKeys) => recentKeys && setRecentKeys(recentKeys));
     appStorage.recentKeys.watch((newKeys) => setRecentKeys(newKeys || []));
+    appStorage.recentKeysByDomain
+      .getValue()
+      .then((recentKeysByDomain) => setRecentKeysByDomain(recentKeysByDomain || {}));
+    appStorage.recentKeysByDomain.watch((newKeysByDomain) =>
+      setRecentKeysByDomain(newKeysByDomain || {}),
+    );
     appStorage.clients.active
       .getValue()
       .then((activeClient) => activeClient && setActiveClient(activeClient));

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -13,6 +13,19 @@ export type KeyInfo = {
   createdAt: number;
 };
 
+export type RecentKeysByDomain = Record<string, KeyInfo[]>;
+
+export const getWebsiteDomain = (url?: string | null) => {
+  if (!url) return null;
+
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return hostname.startsWith('www.') ? hostname.slice(4) : hostname;
+  } catch {
+    return null;
+  }
+};
+
 export type Settings = {
   spoofing: boolean;
   emeInterception: boolean;
@@ -46,6 +59,30 @@ export const appStorage = {
   settings: asJson(storage.defineItem<Settings>('local:settings')),
 
   recentKeys: asJson(storage.defineItem<KeyInfo[]>('local:recent-keys')),
+  recentKeysByDomain: {
+    raw: asJson(storage.defineItem<RecentKeysByDomain>('local:recent-keys-by-domain')),
+    setValue: async (keys: RecentKeysByDomain) => {
+      await appStorage.recentKeysByDomain.raw.setValue(keys);
+    },
+    getValue: async () => {
+      return appStorage.recentKeysByDomain.raw.getValue();
+    },
+    watch: (
+      callback: (newValue: RecentKeysByDomain | null, oldValue: RecentKeysByDomain | null) => void,
+    ) => {
+      return appStorage.recentKeysByDomain.raw.watch(callback);
+    },
+    clear: async () => {
+      await appStorage.recentKeysByDomain.raw.setValue({});
+    },
+    setForUrl: async (url: string | undefined, keys: KeyInfo[]) => {
+      const domain = getWebsiteDomain(url);
+      if (!domain) return;
+
+      const keysByDomain = (await appStorage.recentKeysByDomain.getValue()) || {};
+      await appStorage.recentKeysByDomain.setValue({ ...keysByDomain, [domain]: keys });
+    },
+  },
   allKeys: {
     raw: asJson(storage.defineItem<KeyInfo[]>('local:all-keys')),
     setValue: async (keys: KeyInfo[]) => {
@@ -57,6 +94,7 @@ export const appStorage = {
     clear: async () => {
       await appStorage.allKeys.raw.setValue([]);
       await appStorage.recentKeys.setValue([]);
+      await appStorage.recentKeysByDomain.clear();
     },
     add: async (...newKeys: KeyInfo[]) => {
       const keys = (await appStorage.allKeys.getValue()) || [];


### PR DESCRIPTION
## Summary
- Store recent keys in a domain-indexed bucket alongside the existing global recent list
- Resolve the active popup tab hostname and show only the matching site's recent keys on the dashboard
- Keep the all-keys view unchanged and clear the per-domain recent cache when keys are deleted

## Testing
- Not run (not requested)