### PR TITLE
Add domain-aware toolbar badge counter

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -81,27 +81,45 @@ export default defineBackground({
       });
     };
 
+    const updateBadgeForTabInBackground = (tab?: Browser.tabs.Tab | null) => {
+      void updateBadgeForTab(tab).catch((error) => {
+        console.warn('[okova] Unable to update extension badge', error);
+      });
+    };
+
     const updateBadgeForTabId = async (tabId: number) => {
       try {
         await updateBadgeForTab(await browser.tabs.get(tabId));
-      } catch {
+      } catch (error) {
         // The tab may have been closed before the async badge update runs.
+        console.warn('[okova] Unable to update extension badge', error);
       }
     };
 
     const updateActiveTabBadges = async () => {
       const activeTabs = await browser.tabs.query({ active: true });
-      await Promise.all(activeTabs.map(updateBadgeForTab));
+      const results = await Promise.allSettled(activeTabs.map(updateBadgeForTab));
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          console.warn('[okova] Unable to update extension badge', result.reason);
+        }
+      }
     };
 
-    void updateActiveTabBadges();
+    const updateActiveTabBadgesInBackground = () => {
+      void updateActiveTabBadges().catch((error) => {
+        console.warn('[okova] Unable to update extension badge', error);
+      });
+    };
+
+    updateActiveTabBadgesInBackground();
 
     appStorage.recentKeys.watch(() => {
-      void updateActiveTabBadges();
+      updateActiveTabBadgesInBackground();
     });
 
     appStorage.recentKeysByDomain.watch(() => {
-      void updateActiveTabBadges();
+      updateActiveTabBadgesInBackground();
     });
 
     browser.tabs.onActivated.addListener(({ tabId }) => {
@@ -110,13 +128,13 @@ export default defineBackground({
 
     browser.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
       if (changeInfo.url || changeInfo.status === 'complete') {
-        void updateBadgeForTab(tab);
+        updateBadgeForTabInBackground(tab);
       }
     });
 
     browser.windows.onFocusChanged.addListener((windowId) => {
       if (windowId === browser.windows.WINDOW_ID_NONE) return;
-      void updateActiveTabBadges();
+      updateActiveTabBadgesInBackground();
     });
 
     const parseBinary = (data: Record<string, number>) => new Uint8Array(Object.values(data));
@@ -129,7 +147,7 @@ export default defineBackground({
         const setRecentKeys = async (keys: KeyInfo[]) => {
           await appStorage.recentKeys.setValue(keys);
           await appStorage.recentKeysByDomain.setForUrl(message.url, keys);
-          await updateBadgeForTab(sender.tab);
+          updateBadgeForTabInBackground(sender.tab);
         };
 
         const { initData } = message;

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { appStorage, Client } from '@/utils/storage';
+import { appStorage, Client, getRecentKeysForUrl } from '@/utils/storage';
 import type { KeyInfo } from '@/utils/storage';
 import {
   Cdm,
@@ -57,6 +57,68 @@ export default defineBackground({
       }
     };
 
+    const getBadgeText = (count: number) => {
+      if (count === 0) return '';
+      if (count > 99) return '99+';
+      return String(count);
+    };
+
+    const getKeysCountForUrl = async (url?: string | null) => {
+      const [recentKeys, recentKeysByDomain] = await Promise.all([
+        appStorage.recentKeys.getValue(),
+        appStorage.recentKeysByDomain.getValue(),
+      ]);
+      return getRecentKeysForUrl(url, recentKeysByDomain, recentKeys).length;
+    };
+
+    const updateBadgeForTab = async (tab?: Browser.tabs.Tab | null) => {
+      if (typeof tab?.id !== 'number') return;
+
+      const count = await getKeysCountForUrl(tab.url);
+      await browser.action.setBadgeText({
+        tabId: tab.id,
+        text: getBadgeText(count),
+      });
+    };
+
+    const updateBadgeForTabId = async (tabId: number) => {
+      try {
+        await updateBadgeForTab(await browser.tabs.get(tabId));
+      } catch {
+        // The tab may have been closed before the async badge update runs.
+      }
+    };
+
+    const updateActiveTabBadges = async () => {
+      const activeTabs = await browser.tabs.query({ active: true });
+      await Promise.all(activeTabs.map(updateBadgeForTab));
+    };
+
+    void updateActiveTabBadges();
+
+    appStorage.recentKeys.watch(() => {
+      void updateActiveTabBadges();
+    });
+
+    appStorage.recentKeysByDomain.watch(() => {
+      void updateActiveTabBadges();
+    });
+
+    browser.tabs.onActivated.addListener(({ tabId }) => {
+      void updateBadgeForTabId(tabId);
+    });
+
+    browser.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
+      if (changeInfo.url || changeInfo.status === 'complete') {
+        void updateBadgeForTab(tab);
+      }
+    });
+
+    browser.windows.onFocusChanged.addListener((windowId) => {
+      if (windowId === browser.windows.WINDOW_ID_NONE) return;
+      void updateActiveTabBadges();
+    });
+
     const parseBinary = (data: Record<string, number>) => new Uint8Array(Object.values(data));
 
     browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -67,6 +129,7 @@ export default defineBackground({
         const setRecentKeys = async (keys: KeyInfo[]) => {
           await appStorage.recentKeys.setValue(keys);
           await appStorage.recentKeysByDomain.setForUrl(message.url, keys);
+          await updateBadgeForTab(sender.tab);
         };
 
         const { initData } = message;

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -14,7 +14,7 @@ import { Header } from '../components/header';
 import { CellImportClient } from '../components/cell-import-client';
 import { NoKeys } from '../components/no-keys';
 import { KeysList } from '../components/keys-list';
-import { appStorage, getWebsiteDomain } from '@/utils/storage';
+import { appStorage, getRecentKeysForUrl, getWebsiteDomain } from '@/utils/storage';
 
 export const Dashboard = () => {
   const [settings] = useSettings();
@@ -28,15 +28,7 @@ export const Dashboard = () => {
     activeDomain() ? `Recent Keys for ${activeDomain()}` : 'Recent Keys',
   );
   const activeDomainRecentKeys = createMemo(() => {
-    const domain = activeDomain();
-    if (!domain) return [];
-
-    const scopedKeys = recentKeysByDomain()[domain];
-    if (scopedKeys) return scopedKeys;
-
-    const legacyKeys = recentKeys();
-    const legacyDomain = getWebsiteDomain(legacyKeys[0]?.url);
-    return legacyDomain === domain ? legacyKeys : [];
+    return getRecentKeysForUrl(activeTabUrl(), recentKeysByDomain(), recentKeys());
   });
 
   createEffect(() => {

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -26,6 +26,22 @@ export const getWebsiteDomain = (url?: string | null) => {
   }
 };
 
+export const getRecentKeysForUrl = (
+  url: string | undefined | null,
+  recentKeysByDomain: RecentKeysByDomain | null | undefined,
+  recentKeys: KeyInfo[] | null | undefined,
+) => {
+  const domain = getWebsiteDomain(url);
+  if (!domain) return [];
+
+  const scopedKeys = recentKeysByDomain?.[domain];
+  if (scopedKeys) return scopedKeys;
+
+  const legacyKeys = recentKeys ?? [];
+  const legacyDomain = getWebsiteDomain(legacyKeys[0]?.url);
+  return legacyDomain === domain ? legacyKeys : [];
+};
+
 export type Settings = {
   spoofing: boolean;
   emeInterception: boolean;


### PR DESCRIPTION
Closes #23 

## Summary
- Add shared domain-scoped recent-key lookup for the popup and background worker
- Update the extension badge from the active tab’s domain and refresh it on tab/domain changes
- Keep the badge in sync when recent keys are written to storage

## Testing
- TypeScript compile
- UI testing not run (not requested)