### PR TITLE
fix(extension): correlate DRM bridge requests and handle failures

### DIFF
--- a/src/extension/entrypoints/content.ts
+++ b/src/extension/entrypoints/content.ts
@@ -36,15 +36,25 @@ export default defineContentScript({
     // Listen for event from injected script
     window.addEventListener(
       'message',
-      (event) => {
-        if (event.source != window) return;
-        if (event.data.type !== 'drm-message') return;
+      async (event) => {
+        if (event.source !== window) return;
+        if (event.data?.type !== 'drm-message') return;
+        if (typeof event.data.requestId !== 'string') return;
         if (!event.data.log) return;
-        const message = event.data.log;
-        message.url = window.location.href;
-        browser.runtime.sendMessage(message).then((response) => {
-          window.dispatchEvent(new CustomEvent('drm-message-response', { detail: response }));
-        });
+        const { requestId, log } = event.data;
+        const message = { ...log, url: window.location.href };
+        try {
+          const body = await browser.runtime.sendMessage(message);
+          window.dispatchEvent(
+            new CustomEvent('drm-message-response', { detail: { requestId, body } }),
+          );
+        } catch (error) {
+          window.dispatchEvent(
+            new CustomEvent('drm-message-response', {
+              detail: { requestId, error: error instanceof Error ? error.message : String(error) },
+            }),
+          );
+        }
       },
       false,
     );

--- a/src/extension/entrypoints/content.ts
+++ b/src/extension/entrypoints/content.ts
@@ -45,13 +45,19 @@ export default defineContentScript({
         const message = { ...log, url: window.location.href };
         try {
           const body = await browser.runtime.sendMessage(message);
+          // Firefox blocks page scripts from reading object detail created in a content script.
           window.dispatchEvent(
-            new CustomEvent('drm-message-response', { detail: { requestId, body } }),
+            new CustomEvent('drm-message-response', {
+              detail: JSON.stringify({ requestId, body }),
+            }),
           );
         } catch (error) {
           window.dispatchEvent(
             new CustomEvent('drm-message-response', {
-              detail: { requestId, error: error instanceof Error ? error.message : String(error) },
+              detail: JSON.stringify({
+                requestId,
+                error: error instanceof Error ? error.message : String(error),
+              }),
             }),
           );
         }

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -1,3 +1,5 @@
+import { sendDrmMessage } from '@/utils/drm-bridge';
+
 declare global {
   interface MediaKeySession {
     initData?: string;
@@ -12,15 +14,13 @@ export default defineUnlistedScript(() => {
     stringify: (b: any) => btoa(String.fromCharCode(...new Uint8Array(b))),
   };
 
-  const send = async (data: any) => {
-    window.postMessage({ type: 'drm-message', log: data }, '*');
-    return new Promise<any>((resolve) => {
-      window.addEventListener(
-        'drm-message-response',
-        (event) => resolve((event as any).detail),
-        false,
-      );
-    });
+  const send = async (data: Record<string, unknown>): Promise<any> => {
+    try {
+      return await sendDrmMessage(data);
+    } catch (error) {
+      console.warn('[okova] DRM bridge request failed', error);
+      return undefined;
+    }
   };
 
   const patchEncryptedMediaExtensions = async () => {

--- a/src/extension/utils/drm-bridge.ts
+++ b/src/extension/utils/drm-bridge.ts
@@ -1,0 +1,38 @@
+type DrmResponse = {
+  requestId: string;
+  body?: unknown;
+  error?: string;
+};
+
+export const sendDrmMessage = (data: Record<string, unknown>): Promise<unknown> => {
+  return new Promise((resolve, reject) => {
+    const requestId = crypto.randomUUID();
+    const cleanup = () => {
+      window.removeEventListener('drm-message-response', onResponse);
+      clearTimeout(timer);
+    };
+    const onResponse = (event: Event) => {
+      const detail = (event as CustomEvent<DrmResponse | null>).detail;
+      if (!detail || detail.requestId !== requestId) return;
+
+      cleanup();
+      if (typeof detail.error === 'string') {
+        reject(new Error(detail.error));
+      } else {
+        resolve(detail.body);
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for DRM response to "${data.action}" (${requestId})`));
+    }, 30_000);
+
+    window.addEventListener('drm-message-response', onResponse);
+    try {
+      window.postMessage({ type: 'drm-message', requestId, log: data }, '*');
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+};

--- a/src/extension/utils/drm-bridge.ts
+++ b/src/extension/utils/drm-bridge.ts
@@ -1,9 +1,3 @@
-type DrmResponse = {
-  requestId: string;
-  body?: unknown;
-  error?: string;
-};
-
 export const sendDrmMessage = (data: Record<string, unknown>): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     const requestId = crypto.randomUUID();
@@ -12,14 +6,28 @@ export const sendDrmMessage = (data: Record<string, unknown>): Promise<unknown> 
       clearTimeout(timer);
     };
     const onResponse = (event: Event) => {
-      const detail = (event as CustomEvent<DrmResponse | null>).detail;
-      if (!detail || detail.requestId !== requestId) return;
+      const detail = (event as CustomEvent<unknown>).detail;
+      if (typeof detail !== 'string') return;
+
+      let response: unknown;
+      try {
+        response = JSON.parse(detail);
+      } catch {
+        return;
+      }
+      if (
+        typeof response !== 'object' ||
+        response === null ||
+        !('requestId' in response) ||
+        response.requestId !== requestId
+      )
+        return;
 
       cleanup();
-      if (typeof detail.error === 'string') {
-        reject(new Error(detail.error));
+      if ('error' in response && typeof response.error === 'string') {
+        reject(new Error(response.error));
       } else {
-        resolve(detail.body);
+        resolve('body' in response ? response.body : undefined);
       }
     };
     const timer = setTimeout(() => {

--- a/test/drm-bridge.test.ts
+++ b/test/drm-bridge.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { browser } from 'wxt/browser';
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+import content from '../src/extension/entrypoints/content';
+import { sendDrmMessage } from '../src/extension/utils/drm-bridge';
+
+vi.mock('../src/extension/utils/storage', () => ({
+  appStorage: { settings: { getValue: async () => ({}) } },
+}));
+
+const postMessage = vi.fn<(message: { requestId: string }, origin: string) => void>();
+const sendMessage = vi.fn<(message: unknown) => Promise<unknown>>();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal(
+    'window',
+    Object.assign(new EventTarget(), {
+      postMessage,
+      location: { href: 'https://example.com/video' },
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+const respond = (requestId: string, body?: unknown) => {
+  window.dispatchEvent(new CustomEvent('drm-message-response', { detail: { requestId, body } }));
+};
+
+test('matches concurrent requests to their own out-of-order responses and cleans up', async () => {
+  const removeListener = vi.spyOn(window, 'removeEventListener');
+  const onFirst = vi.fn();
+  const onSecond = vi.fn();
+  const first = sendDrmMessage({ action: 'license-request' }).then(onFirst);
+  const second = sendDrmMessage({ action: 'license-request' }).then(onSecond);
+  const acknowledgement = sendDrmMessage({ action: 'generateRequest' });
+  const firstId = postMessage.mock.calls[0]![0].requestId;
+  const secondId = postMessage.mock.calls[1]![0].requestId;
+  const acknowledgementId = postMessage.mock.calls[2]![0].requestId;
+  expect(new Set([firstId, secondId, acknowledgementId]).size).toBe(3);
+
+  window.dispatchEvent(new CustomEvent('drm-message-response', { detail: 'legacy response' }));
+  respond('unknown-request', 'unrelated response');
+  respond(acknowledgementId);
+  await expect(acknowledgement).resolves.toBeUndefined();
+  expect(onFirst).not.toHaveBeenCalled();
+  expect(onSecond).not.toHaveBeenCalled();
+
+  respond(secondId, 'second challenge');
+  await second;
+  expect(onSecond).toHaveBeenCalledExactlyOnceWith('second challenge');
+  expect(onFirst).not.toHaveBeenCalled();
+
+  respond(secondId, 'duplicate response');
+  respond(firstId, 'first challenge');
+  await first;
+  expect(onFirst).toHaveBeenCalledExactlyOnceWith('first challenge');
+  expect(removeListener).toHaveBeenCalledTimes(3);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test('registers the response listener before posting the request', async () => {
+  postMessage.mockImplementation(({ requestId }) => respond(requestId, 'challenge'));
+  await expect(sendDrmMessage({ action: 'license-request' })).resolves.toBe('challenge');
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test('times out and removes the listener without affecting a later request', async () => {
+  const removeListener = vi.spyOn(window, 'removeEventListener');
+  const request = sendDrmMessage({ action: 'license-request' });
+  const timedOutId = postMessage.mock.calls[0]![0].requestId;
+  const rejected = expect(request).rejects.toThrow('Timed out waiting for DRM response');
+  await vi.advanceTimersByTimeAsync(30_000);
+  await rejected;
+  expect(removeListener).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+
+  const onResponse = vi.fn();
+  const next = sendDrmMessage({ action: 'license-request' }).then(onResponse);
+  respond(timedOutId, 'late response');
+  await Promise.resolve();
+  expect(onResponse).not.toHaveBeenCalled();
+  respond(postMessage.mock.calls[1]![0].requestId, 'next challenge');
+  await next;
+  expect(onResponse).toHaveBeenCalledExactlyOnceWith('next challenge');
+});
+
+test('cleans up when posting the request throws', async () => {
+  const removeListener = vi.spyOn(window, 'removeEventListener');
+  postMessage.mockImplementation(() => {
+    throw new Error('Unable to clone message');
+  });
+  await expect(sendDrmMessage({ action: 'update' })).rejects.toThrow('Unable to clone message');
+  expect(removeListener).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+const startContentBridge = async () => {
+  vi.spyOn(browser.runtime, 'sendMessage').mockImplementation(sendMessage);
+  vi.spyOn(browser.runtime, 'getURL').mockImplementation((path) => path);
+  vi.stubGlobal('document', {
+    createElement: () => ({}),
+    head: { appendChild: vi.fn() },
+  });
+  await content.main({} as ContentScriptContext);
+  postMessage.mockImplementation((data) => {
+    // Node's MessageEvent requires a MessagePort source, so attach the page window separately.
+    const event = new MessageEvent('message', { data });
+    Object.defineProperty(event, 'source', { value: window });
+    window.dispatchEvent(event);
+  });
+};
+
+test('content bridge preserves request IDs for acknowledgements and license responses', async () => {
+  await startContentBridge();
+  const licenseResponse = Promise.withResolvers<unknown>();
+  sendMessage.mockReturnValueOnce(licenseResponse.promise).mockResolvedValueOnce(undefined);
+
+  const onLicense = vi.fn();
+  const license = sendDrmMessage({ action: 'license-request' }).then(onLicense);
+  await expect(sendDrmMessage({ action: 'generateRequest' })).resolves.toBeUndefined();
+  expect(onLicense).not.toHaveBeenCalled();
+  expect(sendMessage).toHaveBeenNthCalledWith(1, {
+    action: 'license-request',
+    url: 'https://example.com/video',
+  });
+
+  licenseResponse.resolve('license challenge');
+  await license;
+  expect(onLicense).toHaveBeenCalledExactlyOnceWith('license challenge');
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test('content bridge correlates runtime errors and the request cleans up', async () => {
+  await startContentBridge();
+  const removeListener = vi.spyOn(window, 'removeEventListener');
+  sendMessage.mockRejectedValueOnce(new Error('Extension context invalidated'));
+  await expect(sendDrmMessage({ action: 'update' })).rejects.toThrow(
+    'Extension context invalidated',
+  );
+  expect(removeListener).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/test/drm-bridge.test.ts
+++ b/test/drm-bridge.test.ts
@@ -30,7 +30,9 @@ afterEach(() => {
 });
 
 const respond = (requestId: string, body?: unknown) => {
-  window.dispatchEvent(new CustomEvent('drm-message-response', { detail: { requestId, body } }));
+  window.dispatchEvent(
+    new CustomEvent('drm-message-response', { detail: JSON.stringify({ requestId, body }) }),
+  );
 };
 
 test('matches concurrent requests to their own out-of-order responses and cleans up', async () => {
@@ -45,7 +47,9 @@ test('matches concurrent requests to their own out-of-order responses and cleans
   const acknowledgementId = postMessage.mock.calls[2]![0].requestId;
   expect(new Set([firstId, secondId, acknowledgementId]).size).toBe(3);
 
-  window.dispatchEvent(new CustomEvent('drm-message-response', { detail: 'legacy response' }));
+  for (const detail of ['legacy response', 'null', '42', '{}', { requestId: firstId }]) {
+    window.dispatchEvent(new CustomEvent('drm-message-response', { detail }));
+  }
   respond('unknown-request', 'unrelated response');
   respond(acknowledgementId);
   await expect(acknowledgement).resolves.toBeUndefined();
@@ -139,11 +143,30 @@ test('content bridge preserves request IDs for acknowledgements and license resp
 
 test('content bridge correlates runtime errors and the request cleans up', async () => {
   await startContentBridge();
+  const onResponse = vi.fn();
+  window.addEventListener('drm-message-response', onResponse);
   const removeListener = vi.spyOn(window, 'removeEventListener');
   sendMessage.mockRejectedValueOnce(new Error('Extension context invalidated'));
   await expect(sendDrmMessage({ action: 'update' })).rejects.toThrow(
     'Extension context invalidated',
   );
+  const response = onResponse.mock.calls[0]![0] as CustomEvent<unknown>;
+  expect(typeof response.detail).toBe('string');
   expect(removeListener).toHaveBeenCalledTimes(1);
   expect(vi.getTimerCount()).toBe(0);
 });
+
+test.each([undefined, 'license challenge', { keys: [{ id: 'key-id', value: 'key-value' }] }])(
+  'content bridge sends string-only event detail and preserves body %j',
+  async (body) => {
+    await startContentBridge();
+    const onResponse = vi.fn();
+    window.addEventListener('drm-message-response', onResponse);
+    sendMessage.mockResolvedValueOnce(body);
+
+    await expect(sendDrmMessage({ action: 'update' })).resolves.toEqual(body);
+    const response = onResponse.mock.calls[0]![0] as CustomEvent<unknown>;
+    expect(typeof response.detail).toBe('string');
+    expect(vi.getTimerCount()).toBe(0);
+  },
+);


### PR DESCRIPTION
## Summary

- Correlate concurrent DRM bridge requests with unique request IDs.
- Handle bridge timeouts, posting failures, and runtime errors with cleanup.
- Add comprehensive DRM bridge correlation and failure tests.

## Testing

- Added Vitest coverage for concurrent out-of-order responses, timeouts, posting errors, acknowledgements, and runtime errors.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791199218&installation_model_id=424872&pr_number=34&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F34&signature=d622d23b7f79d35357fc5707d5050460035bb4a669cafe502f7c3b507f057314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->