### PR TITLE
fix(extension): preserve captured keys over EME statuses

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { appStorage, Client, getRecentKeysForUrl } from '@/utils/storage';
+import { appStorage, Client, getRecentKeysForUrl, isCapturedKey } from '@/utils/storage';
 import type { KeyInfo } from '@/utils/storage';
 import {
   fromBase64,
@@ -153,7 +153,9 @@ export default defineBackground({
 
         const { initData } = message;
         const allKeys = await appStorage.allKeys.raw.getValue();
-        const keys = allKeys?.filter((keyInfo) => keyInfo.pssh === initData);
+        const keys = allKeys?.filter(
+          (keyInfo) => keyInfo.pssh === initData && isCapturedKey(keyInfo),
+        );
         const hasKey = !!keys?.length;
         if (hasKey) {
           const currentSiteKeys = keys.map((keyInfo: KeyInfo) => ({

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -15,6 +15,9 @@ export type KeyInfo = {
 
 export type RecentKeysByDomain = Record<string, KeyInfo[]>;
 
+// History also contains EME statuses, which cannot be reused as content keys.
+export const isCapturedKey = (key: KeyInfo) => /^[0-9a-f]{32}$/i.test(key.value);
+
 export const getWebsiteDomain = (url?: string | null) => {
   if (!url) return null;
 
@@ -115,9 +118,12 @@ export const appStorage = {
     add: async (...newKeys: KeyInfo[]) => {
       const keys = (await appStorage.allKeys.getValue()) || [];
       for (const newKey of newKeys) {
-        const added = keys.some((key) => key.id === newKey.id);
-        if (added) continue;
-        keys.push(newKey);
+        const index = keys.findIndex((key) => key.id === newKey.id);
+        if (index === -1) {
+          keys.push(newKey);
+        } else if (!isCapturedKey(keys[index]!) && isCapturedKey(newKey)) {
+          keys[index] = newKey;
+        }
       }
       await appStorage.allKeys.setValue(keys);
     },

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing';
+import background from '../src/extension/entrypoints/background';
+import { appStorage, type KeyInfo } from '../src/extension/utils/storage';
+import { fromHex, Widevine } from '../src/lib';
+import { Session, setSupportedEngines } from '../src/lib/api';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+
+// No device credentials or license server are needed to exercise the background flow.
+vi.mock('../src/lib/widevine/device-credentials', () => ({
+  WidevineDeviceCredentials: class {},
+}));
+
+const key: KeyInfo = {
+  id: '00112233445566778899aabbccddeeff',
+  value: 'ffeeddccbbaa99887766554433221100',
+  url: 'https://example.com/video',
+  mpd: 'https://example.com/manifest.mpd',
+  pssh: 'cHNzaA==',
+  createdAt: 1,
+};
+
+beforeEach(() => {
+  fakeBrowser.reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setSupportedEngines([]);
+});
+
+test.each(['usable', 'expired', 'output-restricted', 'status-pending'])(
+  'replaces a stored %s status with a captured key and its metadata',
+  async (value) => {
+    await appStorage.allKeys.setValue([{ ...key, value }]);
+    const capturedKey = { ...key, url: 'https://example.com/replay', createdAt: 2 };
+
+    await appStorage.allKeys.add(capturedKey);
+
+    expect(await appStorage.allKeys.getValue()).toEqual([capturedKey]);
+  },
+);
+
+test('preserves captured keys when later statuses or duplicate keys arrive', async () => {
+  await appStorage.allKeys.add(key);
+  await appStorage.allKeys.add({ ...key, value: 'usable' }, { ...key, createdAt: 2 });
+
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+});
+
+test('upgrades a status within the same batch while retaining distinct key IDs', async () => {
+  const otherKey = { ...key, id: '112233445566778899aabbccddeeff00' };
+  await appStorage.allKeys.add({ ...key, value: 'usable' }, otherKey, key);
+
+  expect(await appStorage.allKeys.getValue()).toEqual([key, otherKey]);
+});
+
+const startBackground = () => {
+  const addListener = vi.spyOn(browser.runtime.onMessage, 'addListener');
+  vi.spyOn(browser.tabs, 'query').mockImplementation(async () => []);
+  background.main();
+  const listener = addListener.mock.calls[0]![0];
+
+  return (message: Record<string, unknown>) =>
+    new Promise<unknown>((resolve) => {
+      listener({ url: key.url, mpd: key.mpd, initData: key.pssh, ...message }, {}, resolve);
+    });
+};
+
+test('captures keys after logging a status with spoofing disabled', async () => {
+  const settings = {
+    spoofing: false,
+    emeInterception: true,
+    requestInterception: false,
+    theme: 'auto',
+  } as const;
+  await appStorage.settings.setValue(settings);
+  const loadClient = vi
+    .spyOn(appStorage.clients.active, 'getValue')
+    .mockResolvedValue(new WidevineDeviceCredentials(new Uint8Array()));
+  const createSession = vi.spyOn(Widevine.prototype, 'createSession');
+  const generateRequest = vi.spyOn(Session.prototype, 'generateRequest').mockResolvedValue();
+  vi.spyOn(Session.prototype, 'update').mockResolvedValue();
+  vi.spyOn(Session.prototype, 'waitForKeyStatusesChange').mockResolvedValue(
+    new Map([[key.id, key.value]]),
+  );
+  const sendMessage = startBackground();
+
+  await sendMessage({
+    action: 'keystatuseschange',
+    keyStatuses: { [fromHex(key.id).toBase64()]: 'usable' },
+  });
+  expect(await appStorage.allKeys.getValue()).toEqual([
+    { ...key, value: 'usable', createdAt: expect.any(Number) },
+  ]);
+  expect(loadClient).not.toHaveBeenCalled();
+
+  await appStorage.settings.setValue({ ...settings, spoofing: true });
+  await sendMessage({ action: 'generateRequest', initDataType: 'cenc' });
+  expect(createSession).toHaveBeenCalledOnce();
+  expect(generateRequest).toHaveBeenCalledExactlyOnceWith('cenc', new TextEncoder().encode('pssh'));
+
+  // SignedMessage type LICENSE (2); license parsing itself is stubbed above.
+  const response = await sendMessage({ action: 'update', message: { 0: 8, 1: 2 } });
+  const capturedKeys = [{ ...key, createdAt: expect.any(Number) }];
+  expect(response).toEqual({ keys: capturedKeys });
+  expect(await appStorage.allKeys.getValue()).toEqual(capturedKeys);
+  expect(await appStorage.recentKeys.getValue()).toEqual(capturedKeys);
+
+  await sendMessage({ action: 'generateRequest', initDataType: 'cenc' });
+  expect(createSession).toHaveBeenCalledOnce();
+});
+
+test('cache hits expose only captured keys matching the PSSH with current site metadata', async () => {
+  await appStorage.allKeys.setValue([
+    { ...key, value: 'usable' },
+    { ...key, id: '112233445566778899aabbccddeeff00' },
+    { ...key, id: '2233445566778899aabbccddeeff0011', pssh: 'other-pssh' },
+  ]);
+  const loadClient = vi.spyOn(appStorage.clients.active, 'getValue');
+  const sendMessage = startBackground();
+  const url = 'https://other.example/video';
+  const mpd = 'https://other.example/manifest.mpd';
+
+  await sendMessage({ action: 'generateRequest', initDataType: 'cenc', url, mpd });
+
+  const cachedKeys = [{ ...key, id: '112233445566778899aabbccddeeff00', url, mpd }];
+  expect(await appStorage.recentKeys.getValue()).toEqual(cachedKeys);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'other.example': cachedKeys });
+  expect(loadClient).not.toHaveBeenCalled();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import { WxtVitest } from 'wxt/testing';
 
 export default defineConfig({
   plugins: [WxtVitest()],
+  resolve: {
+    alias: {
+      '@okova/lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- Preserve captured content keys when later EME status updates use the same key ID.
- Filter cached key responses to include only valid captured keys.
- Add regression coverage for key history, cache hits, and background flow handling.

## Testing

- Not run (tests added but not executed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791200233&installation_model_id=424872&pr_number=35&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F35&signature=8e4a417fe1991aa961b0c2ed8534dccaa61497b24e489ca41265c7d02c1bac13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->