### PR TITLE
fix(extension): isolate EME sessions and clean up abandoned sessions

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -3,7 +3,6 @@ import type { KeyInfo } from '@/utils/storage';
 import {
   fromBase64,
   fromBuffer,
-  type MediaKeysEngine,
   PlayReady,
   requestMediaKeySystemAccess,
   setSupportedEngines,
@@ -22,16 +21,34 @@ export default defineBackground({
     });
 
     const state: {
-      cdm: MediaKeysEngine | null;
       client: Client | null;
-      sessions: Map<string, Session>;
-      events: Map<string, MediaKeyMessageEvent[]>;
+      sessions: Map<
+        string,
+        { session: Session; tabId: number | undefined; timer: ReturnType<typeof setTimeout> }
+      >;
     } = {
-      cdm: null,
       client: null,
       sessions: new Map(),
-      events: new Map<string, MediaKeyMessageEvent[]>(),
     };
+
+    const closeSession = async (id: string) => {
+      const entry = state.sessions.get(id);
+      if (!entry) return;
+      state.sessions.delete(id);
+      clearTimeout(entry.timer);
+      try {
+        await entry.session.close();
+      } catch (error) {
+        console.warn('[okova] Unable to close DRM session', error);
+      }
+    };
+
+    const closeTabSessions = (tabId: number) => {
+      for (const [id, entry] of state.sessions) {
+        if (entry.tabId === tabId) void closeSession(id);
+      }
+    };
+    browser.tabs.onRemoved.addListener(closeTabSessions);
 
     const loadClient = async () => {
       if (state.client) return state.client;
@@ -127,7 +144,8 @@ export default defineBackground({
       void updateBadgeForTabId(tabId);
     });
 
-    browser.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
+    browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+      if (changeInfo.status === 'loading') closeTabSessions(tabId);
       if (changeInfo.url || changeInfo.status === 'complete') {
         updateBadgeForTabInBackground(tab);
       }
@@ -141,7 +159,21 @@ export default defineBackground({
     const parseBinary = (data: Record<string, number>) => new Uint8Array(Object.values(data));
 
     browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+      const sessionKey =
+        typeof message.sessionToken === 'string' && message.sessionToken
+          ? JSON.stringify([
+              sender.tab?.id,
+              sender.frameId,
+              sender.documentId,
+              message.sessionToken,
+            ])
+          : undefined;
       (async () => {
+        if (message.action === 'close') {
+          if (sessionKey) await closeSession(sessionKey);
+          sendResponse();
+          return;
+        }
         console.log('[okova] Received message', message);
 
         const settings = await appStorage.settings.getValue();
@@ -157,7 +189,7 @@ export default defineBackground({
           (keyInfo) => keyInfo.pssh === initData && isCapturedKey(keyInfo),
         );
         const hasKey = !!keys?.length;
-        if (hasKey) {
+        if (hasKey && (!sessionKey || !state.sessions.has(sessionKey))) {
           const currentSiteKeys = keys.map((keyInfo: KeyInfo) => ({
             ...keyInfo,
             url: message.url ?? keyInfo.url,
@@ -190,105 +222,76 @@ export default defineBackground({
           return;
         }
 
-        const cdm = await loadCdm();
-        if (!cdm) {
+        if (!sessionKey) {
           sendResponse();
           return;
         }
 
-        setSupportedEngines([cdm]);
-        const keySystemAccess = requestMediaKeySystemAccess(cdm.keySystem, []);
-        const mediaKeys = await keySystemAccess.createMediaKeys();
-
         if (message.action === 'generateRequest') {
-          const { initDataType, initData } = message;
-          const keySession = mediaKeys.createSession();
-          state.sessions.set(initData, keySession);
-          if (!state.events.has(keySession.sessionId)) state.events.set(keySession.sessionId, []);
-          keySession.addEventListener(
-            'message',
-            (event) => {
-              const messageEvent = event as MediaKeyMessageEvent;
-              console.log(messageEvent);
-              state.events.get(keySession.sessionId)?.push(messageEvent);
-            },
-            false,
-          );
-          await keySession.generateRequest(initDataType, fromBase64(initData).toBuffer());
+          if (state.sessions.has(sessionKey)) {
+            sendResponse();
+            return;
+          }
+          const cdm = await loadCdm();
+          if (!cdm) {
+            sendResponse();
+            return;
+          }
+          setSupportedEngines([cdm]);
+          const keySystemAccess = requestMediaKeySystemAccess(cdm.keySystem, []);
+          const mediaKeys = await keySystemAccess.createMediaKeys();
+          const session = mediaKeys.createSession();
+          // Bound abandoned requests, including frames removed without closing their sessions.
+          const timer = setTimeout(() => void closeSession(sessionKey), 5 * 60_000);
+          state.sessions.set(sessionKey, { session, tabId: sender.tab?.id, timer });
+          await session.generateRequest(message.initDataType, fromBase64(initData).toBuffer());
           sendResponse();
-        } else if (message.action === 'individualization-request') {
-          // TODO: Handle individualization request
+          return;
+        }
+
+        const session = state.sessions.get(sessionKey)?.session;
+        if (!session) {
           sendResponse();
-        } else if (message.action === 'license-request') {
-          const { initData } = message;
-          const session = state.sessions.get(initData);
-          console.log('[okova] Received message license-request', session);
-          if (!session) return;
-          const event = state.events
-            .get(session.sessionId)
-            ?.find((e) => e.messageType === 'license-request');
-          if (!event?.message) return console.log(`[okova] No message`);
-          const messageBase64 = fromBuffer(new Uint8Array(event.message)).toBase64();
-          console.log(state.events.get(session.sessionId));
-          console.log(`[okova] Sending challenge`, messageBase64, event);
-          sendResponse(messageBase64);
+          return;
+        }
+
+        if (message.action === 'license-request') {
+          const challenge = await session.waitForLicenseRequest();
+          sendResponse(fromBuffer(challenge).toBase64());
         } else if (message.action === 'update') {
-          const { initData } = message;
-
-          let isServiceCertificate = false;
-          if (cdm instanceof Widevine) {
-            console.log(`[okova] Checking for service certificate`);
-            let type: number | undefined;
-            try {
-              type = getMessageType(parseBinary(message.message));
-            } catch (error) {
-              console.error('[okova] Failed to parse Widevine message', error);
-              sendResponse();
-              return;
-            }
-            const serviceCertificateMessageType = 5;
-            isServiceCertificate = type === serviceCertificateMessageType;
-            console.log({ isServiceCertificate });
-            // if (type === serviceCertificateMessageType) {
-            //   console.log('[okova] Service certificate. Skipping');
-            //   sendResponse();
-            // }
-          }
-
-          const session = state.sessions.get(initData);
-          if (!session) {
-            console.log('[okova] Unable to find session');
-            sendResponse();
-          }
-
+          const response = parseBinary(message.message);
+          const isServiceCertificate =
+            session.engine instanceof Widevine && getMessageType(response) === 5;
+          await session.update(response);
           if (isServiceCertificate) {
-            console.log(`[okova] Updating session with service certificate`, message.messageBase64);
-            session?.update(parseBinary(message.message));
             sendResponse();
-          } else {
-            console.log(`[okova] Updating session`, message.messageBase64);
-            session?.update(parseBinary(message.message));
-            console.log(`[okova] Waiting for keys`);
-            const keys = await session?.waitForKeyStatusesChange();
-            console.log(keys);
+            return;
+          }
 
-            const results = keys
-              ? Array.from(keys, ([id, value]) => ({
-                  id,
-                  value,
-                  url: message.url,
-                  mpd: message.mpd,
-                  pssh: message.initData,
-                  createdAt: new Date().getTime(),
-                }))
-              : [];
-            console.log('[okova] Received keys', results);
+          try {
+            const keys = await session.waitForKeyStatusesChange();
+            const results = Array.from(keys, ([id, value]) => ({
+              id,
+              value,
+              url: message.url,
+              mpd: message.mpd,
+              pssh: message.initData,
+              createdAt: new Date().getTime(),
+            }));
             await setRecentKeys(results);
             await appStorage.allKeys.add(...results);
             sendResponse({ keys: results });
+          } finally {
+            await closeSession(sessionKey);
           }
+        } else {
+          sendResponse();
         }
-      })();
+      })().catch(async (error: unknown) => {
+        if (sessionKey) await closeSession(sessionKey);
+        console.warn('[okova] DRM request failed', error);
+        sendResponse();
+      });
       return true;
     });
   },

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -13,6 +13,8 @@ import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credential
 import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
 import { Session } from '@okova/lib/api';
 
+const SESSION_IDLE_TIMEOUT_MS = 5 * 60_000;
+
 export default defineBackground({
   type: 'module',
   main: () => {
@@ -174,6 +176,11 @@ export default defineBackground({
           sendResponse();
           return;
         }
+        const entry = sessionKey ? state.sessions.get(sessionKey) : undefined;
+        if (sessionKey && entry) {
+          clearTimeout(entry.timer);
+          entry.timer = setTimeout(() => void closeSession(sessionKey), SESSION_IDLE_TIMEOUT_MS);
+        }
         console.log('[okova] Received message', message);
 
         const settings = await appStorage.settings.getValue();
@@ -241,8 +248,8 @@ export default defineBackground({
           const keySystemAccess = requestMediaKeySystemAccess(cdm.keySystem, []);
           const mediaKeys = await keySystemAccess.createMediaKeys();
           const session = mediaKeys.createSession();
-          // Bound abandoned requests, including frames removed without closing their sessions.
-          const timer = setTimeout(() => void closeSession(sessionKey), 5 * 60_000);
+          // Close after five minutes of inactivity, including silently removed frames.
+          const timer = setTimeout(() => void closeSession(sessionKey), SESSION_IDLE_TIMEOUT_MS);
           state.sessions.set(sessionKey, { session, tabId: sender.tab?.id, timer });
           await session.generateRequest(message.initDataType, fromBase64(initData).toBuffer());
           sendResponse();

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -23,6 +23,11 @@ export default defineUnlistedScript(() => {
     }
   };
 
+  const sessionRequests = new WeakMap<
+    MediaKeySession,
+    { token: string; ready: Promise<unknown> }
+  >();
+
   const patchEncryptedMediaExtensions = async () => {
     const onGenerateRequest = async (
       initDataType: string,
@@ -32,12 +37,22 @@ export default defineUnlistedScript(() => {
       session.initDataType = initDataType;
       session.initData = base64.stringify(initData);
       session.messages = new Map();
-      send({
+      const token = crypto.randomUUID();
+      const ready = send({
+        sessionToken: token,
         action: 'generateRequest',
         sessionId: session.sessionId,
         initDataType,
         initData: session.initData,
       });
+
+      sessionRequests.set(session, { token, ready });
+      void session.closed.then(async () => {
+        await ready;
+        await send({ action: 'close', sessionToken: token });
+        sessionRequests.delete(session);
+      });
+      await ready;
 
       console.groupCollapsed(`[okova] [${session.sessionId}] Generated request`);
       console.log(`Initialization Data Type: ${session.initDataType}`);
@@ -58,6 +73,7 @@ export default defineUnlistedScript(() => {
       }
 
       await send({
+        sessionToken: sessionRequests.get(session)?.token,
         sessionId: session.sessionId,
         action: 'keystatuseschange',
         initData: session.initData,
@@ -87,7 +103,10 @@ export default defineUnlistedScript(() => {
         return;
       }
 
+      const request = sessionRequests.get(session);
+      await request?.ready;
       const response = await send({
+        sessionToken: request?.token,
         action: messageType,
         initData: session.initData,
         initDataType: session.initDataType,
@@ -144,7 +163,10 @@ export default defineUnlistedScript(() => {
       console.log(`Response: ${messageBase64}`);
       console.groupEnd();
 
+      const request = sessionRequests.get(session);
+      await request?.ready;
       const result = await send({
+        sessionToken: request?.token,
         sessionId,
         action: 'update',
         initData: session.initData,
@@ -157,7 +179,7 @@ export default defineUnlistedScript(() => {
       if (result) {
         const { keys } = result;
         console.groupCollapsed(`[okova] [${session.sessionId}] Received keys from our CDM`);
-        for (const [id, value] of keys) console.log(`${id}:${value}`);
+        for (const { id, value } of keys) console.log(`${id}:${value}`);
         console.groupEnd();
       } else {
         setTimeout(() => {
@@ -225,7 +247,7 @@ export default defineUnlistedScript(() => {
       'generateRequest',
       async (generateRequest, session, [initDataType, initData]) => {
         await generateRequest.apply(session, [initDataType, initData]);
-        onGenerateRequest(initDataType, initData, session);
+        await onGenerateRequest(initDataType, initData, session);
       },
     );
 

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import eme from '../src/extension/entrypoints/eme';
+import { sendDrmMessage } from '../src/extension/utils/drm-bridge';
+
+vi.mock('../src/extension/utils/drm-bridge', () => ({ sendDrmMessage: vi.fn() }));
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('uses distinct tokens despite empty native IDs and waits for background creation', async () => {
+  class NativeSession extends EventTarget {
+    sessionId = '';
+    closedResult = Promise.withResolvers<MediaKeySessionClosedReason>();
+    closed = this.closedResult.promise;
+    keyStatuses = new Map();
+    async generateRequest(type: string, data: BufferSource) {
+      expect(type).toBe('cenc');
+      expect(data).toBeInstanceOf(Uint8Array);
+    }
+    async update(response: BufferSource) {
+      expect(response).toBeInstanceOf(Uint8Array);
+    }
+  }
+  class NativeKeys {
+    async setServerCertificate() {
+      return true;
+    }
+  }
+  vi.stubGlobal('MediaKeySession', NativeSession);
+  vi.stubGlobal('MediaKeys', NativeKeys);
+  vi.stubGlobal('window', { MPD_LIST: new Map() });
+  const creations = [Promise.withResolvers<unknown>(), Promise.withResolvers<unknown>()];
+  let creationIndex = 0;
+  vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
+    if (message.action === 'generateRequest') return creations[creationIndex++]!.promise;
+    if (message.action === 'license-request') return btoa('challenge');
+    if (message.action === 'update') return { keys: [] };
+  });
+  eme.main();
+
+  const first = new NativeSession();
+  const second = new NativeSession();
+  const initData = new TextEncoder().encode('same pssh');
+  const generating = [
+    first.generateRequest('cenc', initData),
+    second.generateRequest('cenc', initData),
+  ];
+  await Promise.resolve();
+  const tokens = vi.mocked(sendDrmMessage).mock.calls.map(([message]) => message.sessionToken);
+  expect(tokens).toHaveLength(2);
+  expect(tokens[0]).toEqual(expect.any(String));
+  expect(tokens[1]).not.toBe(tokens[0]);
+
+  const handled = Promise.withResolvers<void>();
+  first.addEventListener('message', () => handled.resolve());
+  first.dispatchEvent(
+    Object.assign(new Event('message'), {
+      messageType: 'license-request',
+      message: initData.buffer,
+    }),
+  );
+  await Promise.resolve();
+  expect(sendDrmMessage).toHaveBeenCalledTimes(2);
+  creations[1]!.resolve(undefined);
+  await generating[1];
+  expect(sendDrmMessage).toHaveBeenCalledTimes(2);
+  creations[0]!.resolve(undefined);
+  await Promise.all([generating[0], handled.promise]);
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      action: 'license-request',
+      sessionToken: tokens[0],
+    }),
+  );
+
+  await second.update(initData);
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      action: 'update',
+      sessionToken: tokens[1],
+    }),
+  );
+  first.closedResult.resolve('closed-by-application');
+  await first.closed;
+  await Promise.resolve();
+  expect(sendDrmMessage).toHaveBeenLastCalledWith({ action: 'close', sessionToken: tokens[0] });
+});

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -64,7 +64,17 @@ const startBackground = () => {
 
   return (message: Record<string, unknown>) =>
     new Promise<unknown>((resolve) => {
-      listener({ url: key.url, mpd: key.mpd, initData: key.pssh, ...message }, {}, resolve);
+      listener(
+        {
+          sessionToken: 'test-session',
+          url: key.url,
+          mpd: key.mpd,
+          initData: key.pssh,
+          ...message,
+        },
+        {},
+        resolve,
+      );
     });
 };
 

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -144,6 +144,37 @@ test('cleans up failed generation, explicit close and abandoned sessions', async
   expect(vi.getTimerCount()).toBe(0);
 });
 
+test.each(['license-request', 'update', 'keystatuseschange'])(
+  'refreshes only the active session timeout on %s',
+  async (action) => {
+    const send = startBackground();
+    await send('generateRequest', 'active');
+    await send('generateRequest', 'idle');
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
+    await send(
+      action,
+      'active',
+      {},
+      {
+        message: { 0: 8, 1: 5 }, // A service certificate keeps the license flow open.
+        keyStatuses: {},
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(Session.prototype.close).toHaveBeenCalledOnce();
+    expect(vi.mocked(Session.prototype.close).mock.contexts[0]).toBe(sessions[1]);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(4 * 60_000 - 1);
+    expect(Session.prototype.close).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(Session.prototype.close).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(Session.prototype.close).mock.contexts[1]).toBe(sessions[0]);
+    expect(vi.getTimerCount()).toBe(0);
+  },
+);
+
 test.each(['navigation', 'removal'])('cleans up only the affected tab on %s', async (action) => {
   const updated = vi.spyOn(browser.tabs.onUpdated, 'addListener');
   const removed = vi.spyOn(browser.tabs.onRemoved, 'addListener');

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { browser, type Browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing';
+import background from '../src/extension/entrypoints/background';
+import { appStorage } from '../src/extension/utils/storage';
+import { Session, setSupportedEngines } from '../src/lib/api';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+
+vi.mock('../src/lib/widevine/device-credentials', () => ({
+  WidevineDeviceCredentials: class {},
+}));
+
+const sessions: Session[] = [];
+const tab = (id: number): Browser.tabs.Tab => ({
+  id,
+  index: 0,
+  pinned: false,
+  highlighted: false,
+  windowId: 1,
+  active: true,
+  incognito: false,
+  selected: true,
+  discarded: false,
+  autoDiscardable: true,
+  groupId: -1,
+  frozen: false,
+});
+
+beforeEach(async () => {
+  fakeBrowser.reset();
+  vi.useFakeTimers();
+  await appStorage.settings.setValue({
+    spoofing: true,
+    emeInterception: true,
+    requestInterception: false,
+    theme: 'auto',
+  });
+  vi.spyOn(appStorage.clients.active, 'getValue').mockResolvedValue(
+    new WidevineDeviceCredentials(new Uint8Array()),
+  );
+  vi.spyOn(browser.tabs, 'query').mockImplementation(async () => []);
+  vi.spyOn(browser.action, 'setBadgeText').mockResolvedValue();
+  sessions.length = 0;
+  vi.spyOn(Session.prototype, 'generateRequest').mockImplementation(async function (this: Session) {
+    sessions.push(this);
+  });
+  vi.spyOn(Session.prototype, 'close').mockResolvedValue();
+  vi.spyOn(Session.prototype, 'update').mockResolvedValue();
+  vi.spyOn(Session.prototype, 'waitForLicenseRequest').mockImplementation(
+    async function (this: Session) {
+      return new TextEncoder().encode(this.sessionId);
+    },
+  );
+  vi.spyOn(Session.prototype, 'waitForKeyStatusesChange').mockResolvedValue(
+    new Map([['00112233445566778899aabbccddeeff', 'ffeeddccbbaa99887766554433221100']]),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  setSupportedEngines([]);
+});
+
+const startBackground = () => {
+  const addListener = vi.spyOn(browser.runtime.onMessage, 'addListener');
+  background.main();
+  const listener = addListener.mock.calls[0]![0];
+  return (
+    action: string,
+    sessionToken: string,
+    sender: Browser.runtime.MessageSender = {},
+    message: Record<string, unknown> = {},
+  ) =>
+    new Promise<unknown>((resolve) => {
+      listener(
+        {
+          action,
+          sessionToken,
+          initData: 'cHNzaA==',
+          initDataType: 'cenc',
+          url: 'https://example.com/video',
+          message: { 0: 8, 1: 2 },
+          ...message,
+        },
+        sender,
+        resolve,
+      );
+    });
+};
+
+test('same-PSSH sessions keep their challenges and updates across tabs, frames and documents', async () => {
+  const send = startBackground();
+  const owners = [
+    { token: 'first', sender: { tab: tab(1), frameId: 0, documentId: 'one' } },
+    { token: 'second', sender: { tab: tab(1), frameId: 0, documentId: 'one' } },
+    { token: 'first', sender: { tab: tab(2), frameId: 0, documentId: 'two' } },
+    { token: 'first', sender: { tab: tab(1), frameId: 1, documentId: 'three' } },
+    { token: 'first', sender: { tab: tab(1), frameId: 0, documentId: 'four' } },
+  ];
+  await Promise.all(owners.map(({ token, sender }) => send('generateRequest', token, sender)));
+  expect(new Set(sessions).size).toBe(owners.length);
+
+  for (const [index, { token, sender }] of owners.entries()) {
+    await expect(send('license-request', token, sender)).resolves.toBe(
+      btoa(sessions[index]!.sessionId),
+    );
+  }
+  for (const [index, { token, sender }] of [...owners.entries()].reverse()) {
+    await expect(send('update', token, sender)).resolves.toMatchObject({ keys: expect.any(Array) });
+    expect(vi.mocked(Session.prototype.update).mock.contexts.at(-1)).toBe(sessions[index]);
+    expect(vi.mocked(Session.prototype.close).mock.contexts.at(-1)).toBe(sessions[index]);
+  }
+  expect(Session.prototype.close).toHaveBeenCalledTimes(owners.length);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test('retains the session for a service certificate and cleans up failed license parsing', async () => {
+  const send = startBackground();
+  await send('generateRequest', 'one');
+  await send('update', 'one', {}, { message: { 0: 8, 1: 5 } });
+  expect(Session.prototype.close).not.toHaveBeenCalled();
+  await expect(send('license-request', 'one')).resolves.toEqual(expect.any(String));
+
+  vi.mocked(Session.prototype.update).mockRejectedValueOnce(new Error('Invalid license'));
+  await expect(send('update', 'one')).resolves.toBeUndefined();
+  expect(Session.prototype.close).toHaveBeenCalledOnce();
+  await expect(send('license-request', 'one')).resolves.toBeUndefined();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test('cleans up failed generation, explicit close and abandoned sessions', async () => {
+  const send = startBackground();
+  vi.mocked(Session.prototype.generateRequest).mockRejectedValueOnce(new Error('Invalid PSSH'));
+  await expect(send('generateRequest', 'failed')).resolves.toBeUndefined();
+  expect(Session.prototype.close).toHaveBeenCalledOnce();
+  await send('generateRequest', 'closed');
+  await send('close', 'closed');
+  await expect(send('license-request', 'closed')).resolves.toBeUndefined();
+  await send('generateRequest', 'abandoned');
+  await vi.advanceTimersByTimeAsync(5 * 60_000);
+  await expect(send('license-request', 'abandoned')).resolves.toBeUndefined();
+  expect(Session.prototype.close).toHaveBeenCalledTimes(3);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test.each(['navigation', 'removal'])('cleans up only the affected tab on %s', async (action) => {
+  const updated = vi.spyOn(browser.tabs.onUpdated, 'addListener');
+  const removed = vi.spyOn(browser.tabs.onRemoved, 'addListener');
+  const send = startBackground();
+  await send('generateRequest', 'one', { tab: tab(1) });
+  await send('generateRequest', 'two', { tab: tab(2) });
+  if (action === 'navigation') {
+    updated.mock.calls[0]![0](1, { status: 'loading' }, tab(1));
+  } else {
+    removed.mock.calls[0]![0](1, { windowId: 1, isWindowClosing: false });
+  }
+  await expect(send('license-request', 'one', { tab: tab(1) })).resolves.toBeUndefined();
+  await expect(send('license-request', 'two', { tab: tab(2) })).resolves.toEqual(
+    expect.any(String),
+  );
+  expect(Session.prototype.close).toHaveBeenCalledOnce();
+  await send('close', 'two', { tab: tab(2) });
+});


### PR DESCRIPTION
## Summary

- Isolate DRM sessions by tab, frame, document, and generated token.
- Clean up sessions on close, navigation, tab removal, failures, and timeout.
- Preserve service-certificate sessions while closing completed sessions.
- Add coverage for session isolation and lifecycle cleanup.

## Testing

- Not run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791201058&installation_model_id=424872&pr_number=36&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F36&signature=9d6f7a38aed1bc4e20fd7587d4e3f4fa2cb6e1147d610eec74a2565ff44437c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->