### PR TITLE
fix(extension): preserve Widevine service certificates per session

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,10 +297,6 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@babel/helper-string-parser@8.0.0-rc.5':
     resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -308,10 +304,6 @@ packages:
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.3':
-    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-identifier@8.0.0-rc.5':
     resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
@@ -328,11 +320,6 @@ packages:
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   '@babel/parser@8.0.0-rc.4':
@@ -367,10 +354,6 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@8.0.0-rc.3':
-    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@babel/types@8.0.0-rc.5':
     resolution: {integrity: sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -391,14 +374,8 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
-
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -624,9 +601,6 @@ packages:
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
-
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
@@ -935,34 +909,16 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.2':
     resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.2':
@@ -971,36 +927,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.2':
     resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
@@ -1009,13 +946,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1023,24 +953,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -1051,26 +967,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
@@ -1079,33 +981,16 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.2':
     resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
     resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
@@ -1113,20 +998,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.2':
     resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -1270,9 +1146,6 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
-
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
@@ -1317,9 +1190,6 @@ packages:
   '@webext-core/match-patterns@1.0.3':
     resolution: {integrity: sha512-NY39ACqCxdKBmHgw361M9pfJma8e4AZo20w9AY+5ZjIj1W2dvXC8J31G5fjfOGbulW9w4WKpT8fPooi0mLkn9A==}
 
-  '@wxt-dev/browser@0.1.40':
-    resolution: {integrity: sha512-h2/v/Hpkj5sz//h84ProqBaAcTsDFRKp9b/JVHOK/r7LT0XLE+ZDs5YN1BnFLUEHdM7G3fUjTyBG84cayXQshQ==}
-
   '@wxt-dev/browser@0.1.42':
     resolution: {integrity: sha512-BSb0H09i4+0WlqFnN7LnZW0M6uCPH9KndciGx7mwOFKRVjNCorqwPk3hiVB58yQ+cyJNpDvYWL6IoPBxvP8qEA==}
 
@@ -1334,6 +1204,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -1843,10 +1714,6 @@ packages:
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
-    engines: {node: '>=16.9.0'}
-
   hono@4.12.22:
     resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
@@ -2011,6 +1878,7 @@ packages:
 
   jsrsasign@11.1.3:
     resolution: {integrity: sha512-nPnK5D/4lv0Dwr7TlzrKtAd8JlLZwFTqTUUB3NQCbtdobcRcohGFxjbPySDVh74iWUudcCsapYT6OxoyhJLhhA==}
+    deprecated: This package is no longer maintained.
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -2212,11 +2080,6 @@ packages:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2351,10 +2214,6 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2472,11 +2331,6 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.0.2:
     resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2505,11 +2359,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.1:
@@ -2668,10 +2517,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.2:
     resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
@@ -2758,9 +2603,6 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
-
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -2823,49 +2665,6 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -3045,9 +2844,6 @@ packages:
   zip-dir@2.0.0:
     resolution: {integrity: sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3146,13 +2942,9 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.3': {}
-
   '@babel/helper-string-parser@8.0.0-rc.5': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.5': {}
 
@@ -3166,10 +2958,6 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/parser@8.0.0-rc.3':
-    dependencies:
-      '@babel/types': 8.0.0-rc.3
 
   '@babel/parser@8.0.0-rc.4':
     dependencies:
@@ -3209,11 +2997,6 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babel/types@8.0.0-rc.3':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
-
   '@babel/types@8.0.0-rc.5':
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.5
@@ -3241,18 +3024,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.9.2':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3340,18 +3112,18 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.14)':
+  '@hono/node-server@1.19.14(hono@4.12.22)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.22
 
   '@hono/node-server@2.0.4(hono@4.12.22)':
     dependencies:
       hono: 4.12.22
 
-  '@hono/zod-validator@0.7.6(hono@4.12.14)(zod@4.3.6)':
+  '@hono/zod-validator@0.7.6(hono@4.12.22)(zod@4.4.3)':
     dependencies:
-      hono: 4.12.14
-      zod: 4.3.6
+      hono: 4.12.22
+      zod: 4.4.3
 
   '@hono/zod-validator@0.8.0(hono@4.12.22)(zod@4.4.3)':
     dependencies:
@@ -3384,13 +3156,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@noble/ciphers@2.2.0': {}
 
   '@noble/curves@1.9.7':
@@ -3404,8 +3169,6 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.2.0': {}
-
-  '@oxc-project/types@0.124.0': {}
 
   '@oxc-project/types@0.132.0': {}
 
@@ -3593,83 +3356,40 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.2':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.2':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.2':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.2':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.2':
@@ -3679,19 +3399,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -3767,7 +3479,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.10
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tybys/wasm-util@0.10.1':
@@ -3816,10 +3528,6 @@ snapshots:
   '@types/jsesc@2.5.1': {}
 
   '@types/minimatch@3.0.5': {}
-
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
 
   '@types/node@25.9.1':
     dependencies:
@@ -3878,11 +3586,6 @@ snapshots:
 
   '@webext-core/match-patterns@1.0.3': {}
 
-  '@wxt-dev/browser@0.1.40':
-    dependencies:
-      '@types/filesystem': 0.0.36
-      '@types/har-format': 1.2.16
-
   '@wxt-dev/browser@0.1.42':
     dependencies:
       '@types/filesystem': 0.0.36
@@ -3900,7 +3603,7 @@ snapshots:
 
   '@wxt-dev/storage@1.2.8':
     dependencies:
-      '@wxt-dev/browser': 0.1.40
+      '@wxt-dev/browser': 0.1.42
       async-mutex: 0.5.0
       dequal: 2.0.3
 
@@ -3944,7 +3647,7 @@ snapshots:
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.5
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -4056,7 +3759,7 @@ snapshots:
 
   chrome-launcher@1.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -4352,8 +4055,6 @@ snapshots:
 
   growly@1.3.0: {}
 
-  hono@4.12.14: {}
-
   hono@4.12.22: {}
 
   hookable@6.1.1: {}
@@ -4473,7 +4174,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.8.1
 
   jsrsasign@11.1.3: {}
 
@@ -4663,8 +4364,6 @@ snapshots:
 
   nano-spawn@2.1.0: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   nanospinner@1.2.2:
@@ -4679,7 +4378,7 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.7.4
+      semver: 7.8.1
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -4696,7 +4395,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
 
   obug@2.1.1: {}
 
@@ -4710,15 +4409,15 @@ snapshots:
 
   okova@0.10.5:
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      '@hono/zod-validator': 0.7.6(hono@4.12.14)(zod@4.3.6)
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      '@hono/zod-validator': 0.7.6(hono@4.12.22)(zod@4.4.3)
       '@noble/curves': 1.9.7
       '@xmldom/xmldom': 0.9.10
       barsic: 0.2.0
-      hono: 4.12.14
+      hono: 4.12.22
       jsrsasign: 11.1.3
       protobufjs: 7.5.5
-      zod: 4.3.6
+      zod: 4.4.3
 
   on-exit-leak-free@2.1.2: {}
 
@@ -4794,7 +4493,7 @@ snapshots:
       ky: 1.14.3
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
-      semver: 7.7.4
+      semver: 7.8.1
 
   pako@1.0.11: {}
 
@@ -4852,12 +4551,6 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
@@ -4893,7 +4586,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.6.0
+      '@types/node': 25.9.1
       long: 5.3.2
 
   protobufjs@8.6.0:
@@ -4910,7 +4603,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       listr2: 10.2.1
       ofetch: 1.5.1
-      zod: 4.3.6
+      zod: 4.4.3
 
   pupa@3.3.0:
     dependencies:
@@ -4989,27 +4682,6 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.15:
-    dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
-
   rolldown@1.0.2:
     dependencies:
       '@oxc-project/types': 0.132.0
@@ -5044,8 +4716,6 @@ snapshots:
   scule@1.3.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.7.4: {}
 
   semver@7.8.1: {}
 
@@ -5190,8 +4860,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.1.1: {}
-
   tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
@@ -5219,7 +4887,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.2
       rolldown-plugin-dts: 0.25.1(rolldown@1.0.2)(typescript@6.0.3)
-      semver: 7.7.4
+      semver: 7.8.1
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
@@ -5250,8 +4918,6 @@ snapshots:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
-
-  undici-types@7.19.2: {}
 
   undici-types@7.24.6: {}
 
@@ -5301,7 +4967,7 @@ snapshots:
       is-npm: 6.1.0
       latest-version: 9.0.0
       pupa: 3.3.0
-      semver: 7.7.4
+      semver: 7.8.1
       xdg-basedir: 5.1.0
 
   util-deprecate@1.0.2: {}
@@ -5314,7 +4980,7 @@ snapshots:
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -5357,19 +5023,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vite@8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.9.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-
   vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)):
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
@@ -5391,7 +5044,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
@@ -5521,7 +5174,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.16
       unimport: 6.1.0
-      vite: 8.0.8(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
       vite-node: 6.0.0(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)
       web-ext-run: 0.2.4
     transitivePeerDependencies:
@@ -5569,7 +5222,5 @@ snapshots:
     dependencies:
       async: 3.2.6
       jszip: 3.10.1
-
-  zod@4.3.6: {}
 
   zod@4.4.3: {}

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -6,8 +6,11 @@ import {
   PlayReady,
   requestMediaKeySystemAccess,
   setSupportedEngines,
+  toBufferSource,
   Widevine,
 } from '@okova/lib';
+import { parseCertificate } from '@okova/lib/widevine/certificate';
+import { SignedDrmCertificate, SignedMessage } from '@okova/lib/widevine/proto';
 import { getMessageType } from '@okova/lib/widevine/message';
 import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
@@ -285,9 +288,17 @@ export default defineBackground({
             typeof serverCertificate === 'string' &&
             serverCertificate !== sessionEntry.serverCertificate
           ) {
-            await session.engine.setServerCertificate(fromBase64(serverCertificate).toBuffer());
+            const { signedDrmCertificate } = await parseCertificate(serverCertificate);
+            // Replace any session-level override and regenerate with the new certificate.
+            await session.update(
+              toBufferSource(
+                SignedMessage.encode({
+                  type: SignedMessage.MessageType.SERVICE_CERTIFICATE,
+                  msg: SignedDrmCertificate.encode(signedDrmCertificate).finish(),
+                }).finish(),
+              ),
+            );
             sessionEntry.serverCertificate = serverCertificate;
-            await session.generateRequest(message.initDataType, fromBase64(initData).toBuffer());
           }
           const challenge = await session.waitForLicenseRequest();
           sendResponse(fromBuffer(challenge).toBase64());

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -15,6 +15,13 @@ import { Session } from '@okova/lib/api';
 
 const SESSION_IDLE_TIMEOUT_MS = 5 * 60_000;
 
+type SessionEntry = {
+  session: Session;
+  tabId: number | undefined;
+  timer: ReturnType<typeof setTimeout>;
+  serverCertificate: string | undefined;
+};
+
 export default defineBackground({
   type: 'module',
   main: () => {
@@ -24,10 +31,7 @@ export default defineBackground({
 
     const state: {
       client: Client | null;
-      sessions: Map<
-        string,
-        { session: Session; tabId: number | undefined; timer: ReturnType<typeof setTimeout> }
-      >;
+      sessions: Map<string, SessionEntry>;
     } = {
       client: null,
       sessions: new Map(),
@@ -244,25 +248,47 @@ export default defineBackground({
             sendResponse();
             return;
           }
+          const serverCertificate =
+            typeof message.serverCertificate === 'string' ? message.serverCertificate : undefined;
+          if (serverCertificate && cdm instanceof Widevine) {
+            await cdm.setServerCertificate(fromBase64(serverCertificate).toBuffer());
+          }
           setSupportedEngines([cdm]);
           const keySystemAccess = requestMediaKeySystemAccess(cdm.keySystem, []);
           const mediaKeys = await keySystemAccess.createMediaKeys();
           const session = mediaKeys.createSession();
           // Close after five minutes of inactivity, including silently removed frames.
           const timer = setTimeout(() => void closeSession(sessionKey), SESSION_IDLE_TIMEOUT_MS);
-          state.sessions.set(sessionKey, { session, tabId: sender.tab?.id, timer });
+          const entry: SessionEntry = {
+            session,
+            tabId: sender.tab?.id,
+            timer,
+            serverCertificate,
+          };
+          state.sessions.set(sessionKey, entry);
           await session.generateRequest(message.initDataType, fromBase64(initData).toBuffer());
           sendResponse();
           return;
         }
 
-        const session = state.sessions.get(sessionKey)?.session;
-        if (!session) {
+        const sessionEntry = state.sessions.get(sessionKey);
+        if (!sessionEntry) {
           sendResponse();
           return;
         }
 
+        const { session } = sessionEntry;
         if (message.action === 'license-request') {
+          const serverCertificate = message.serverCertificate;
+          if (
+            session.engine instanceof Widevine &&
+            typeof serverCertificate === 'string' &&
+            serverCertificate !== sessionEntry.serverCertificate
+          ) {
+            await session.engine.setServerCertificate(fromBase64(serverCertificate).toBuffer());
+            sessionEntry.serverCertificate = serverCertificate;
+            await session.generateRequest(message.initDataType, fromBase64(initData).toBuffer());
+          }
           const challenge = await session.waitForLicenseRequest();
           sendResponse(fromBuffer(challenge).toBase64());
         } else if (message.action === 'update') {

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -11,7 +11,12 @@ declare global {
 export default defineUnlistedScript(() => {
   const base64 = {
     parse: (s: any) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0)),
-    stringify: (b: any) => btoa(String.fromCharCode(...new Uint8Array(b))),
+    stringify: (buffer: BufferSource) => {
+      const bytes = ArrayBuffer.isView(buffer)
+        ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+        : new Uint8Array(buffer);
+      return btoa(String.fromCharCode(...bytes));
+    },
   };
 
   const send = async (data: Record<string, unknown>): Promise<any> => {
@@ -21,6 +26,13 @@ export default defineUnlistedScript(() => {
       console.warn('[okova] DRM bridge request failed', error);
       return undefined;
     }
+  };
+
+  const mediaKeysCertificates = new WeakMap<MediaKeys, string>();
+  const sessionMediaKeys = new WeakMap<MediaKeySession, MediaKeys>();
+  const getServerCertificate = (session: MediaKeySession) => {
+    const mediaKeys = sessionMediaKeys.get(session);
+    return mediaKeys ? mediaKeysCertificates.get(mediaKeys) : undefined;
   };
 
   const sessionRequests = new WeakMap<
@@ -41,6 +53,7 @@ export default defineUnlistedScript(() => {
       const ready = send({
         sessionToken: token,
         action: 'generateRequest',
+        serverCertificate: getServerCertificate(session),
         sessionId: session.sessionId,
         initDataType,
         initData: session.initData,
@@ -103,9 +116,13 @@ export default defineUnlistedScript(() => {
         return;
       }
 
+      // Widevine's service-certificate request must reach the license server unchanged.
+      if (messageType === 'license-request' && base64.stringify(message) === 'CAQ=') return;
+
       const request = sessionRequests.get(session);
       await request?.ready;
       const response = await send({
+        serverCertificate: getServerCertificate(session),
         sessionToken: request?.token,
         action: messageType,
         initData: session.initData,
@@ -154,7 +171,9 @@ export default defineUnlistedScript(() => {
       session: MediaKeySession,
     ): Promise<BufferSource | undefined> => {
       const sessionId = session.sessionId;
-      const message = new Uint8Array(ArrayBuffer.isView(response) ? response.buffer : response);
+      const message = ArrayBuffer.isView(response)
+        ? new Uint8Array(response.buffer, response.byteOffset, response.byteLength)
+        : new Uint8Array(response);
       const messageBase64 = base64.stringify(message);
 
       console.groupCollapsed(`[okova] [${session.sessionId}] Update session with response`);
@@ -237,9 +256,21 @@ export default defineUnlistedScript(() => {
       });
     }
 
-    interceptMethod(MediaKeys.prototype, 'setServerCertificate', (_target, _this, _args) => {
-      console.log(`[okova] Setting server certificate`, _this, _args);
-      return _target.apply(_this, _args);
+    interceptMethod(
+      MediaKeys.prototype,
+      'setServerCertificate',
+      async (setServerCertificate, mediaKeys, [certificate]) => {
+        const encodedCertificate = base64.stringify(certificate);
+        const result = await setServerCertificate.call(mediaKeys, certificate);
+        if (result) mediaKeysCertificates.set(mediaKeys, encodedCertificate);
+        return result;
+      },
+    );
+
+    interceptMethod(MediaKeys.prototype, 'createSession', (createSession, mediaKeys, args) => {
+      const session = createSession.apply(mediaKeys, args);
+      sessionMediaKeys.set(session, mediaKeys);
+      return session;
     });
 
     interceptMethod(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -380,7 +380,8 @@ export class Session extends EventTarget implements MediaKeySession {
   }
 
   async waitForLicenseRequest() {
-    const queuedMessage = this.#messageQueue.find(
+    // A service certificate can replace an earlier, unencrypted challenge.
+    const queuedMessage = this.#messageQueue.findLast(
       (message) => message.messageType === 'license-request',
     );
     if (queuedMessage) return queuedMessage.message;

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -7,7 +7,63 @@ vi.mock('../src/extension/utils/drm-bridge', () => ({ sendDrmMessage: vi.fn() })
 afterEach(() => {
   vi.resetAllMocks();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
+
+test.each(['captured keys', 'rejected license', 'bridge failure'])(
+  'passes the original response to native update after %s',
+  async (result) => {
+    vi.useFakeTimers();
+    const nativeUpdate = vi.fn<(response: BufferSource) => Promise<void>>().mockResolvedValue();
+    class NativeSession extends EventTarget {
+      sessionId = 'native-session';
+      keyStatuses = new Map();
+      update(response: BufferSource) {
+        return nativeUpdate.call(this, response);
+      }
+      async generateRequest() {}
+    }
+    class NativeKeys {
+      createSession() {
+        return new NativeSession();
+      }
+      async setServerCertificate() {
+        return true;
+      }
+    }
+    vi.stubGlobal('MediaKeySession', NativeSession);
+    vi.stubGlobal('MediaKeys', NativeKeys);
+    vi.stubGlobal('window', { MPD_LIST: new Map() });
+    const capture = Promise.withResolvers<unknown>();
+    vi.mocked(sendDrmMessage).mockReturnValue(capture.promise);
+    eme.main();
+
+    const session = new NativeSession();
+    const response = new Uint8Array([8, 2]);
+    const updating = session.update(response);
+    await Promise.resolve();
+    expect(sendDrmMessage).toHaveBeenCalledWith(expect.objectContaining({ action: 'update' }));
+    expect(nativeUpdate).not.toHaveBeenCalled();
+
+    if (result === 'captured keys') {
+      capture.resolve({
+        keys: [
+          { id: '00112233445566778899aabbccddeeff', value: 'ffeeddccbbaa99887766554433221100' },
+        ],
+      });
+    } else if (result === 'bridge failure') {
+      capture.reject(new Error('DRM bridge failed'));
+    } else {
+      capture.resolve(undefined);
+    }
+
+    await expect(updating).resolves.toBeUndefined();
+    expect(nativeUpdate).toHaveBeenCalledExactlyOnceWith(response);
+    expect(nativeUpdate.mock.calls[0]?.[0]).toBe(response);
+    expect(nativeUpdate.mock.contexts[0]).toBe(session);
+    await vi.runAllTimersAsync();
+  },
+);
 
 test('uses distinct tokens despite empty native IDs and waits for background creation', async () => {
   class NativeSession extends EventTarget {
@@ -24,6 +80,9 @@ test('uses distinct tokens despite empty native IDs and waits for background cre
     }
   }
   class NativeKeys {
+    createSession() {
+      return new NativeSession();
+    }
     async setServerCertificate() {
       return true;
     }
@@ -86,4 +145,100 @@ test('uses distinct tokens despite empty native IDs and waits for background cre
   await first.closed;
   await Promise.resolve();
   expect(sendDrmMessage).toHaveBeenLastCalledWith({ action: 'close', sessionToken: tokens[0] });
+});
+
+test('associates accepted certificate views with MediaKeys and preserves certificate requests', async () => {
+  const nativeSetCertificate = vi
+    .fn<(certificate: BufferSource) => Promise<boolean>>()
+    .mockResolvedValue(true);
+  class NativeSession extends EventTarget {
+    sessionId = '';
+    closed = new Promise<MediaKeySessionClosedReason>(() => {});
+    keyStatuses = new Map();
+    async generateRequest(type: string, data: BufferSource) {
+      expect(type).toBe('cenc');
+      expect(data).toBeInstanceOf(Uint8Array);
+    }
+    async update(response: BufferSource) {
+      expect(response).toBeInstanceOf(Uint8Array);
+    }
+  }
+  class NativeKeys {
+    createSession() {
+      return new NativeSession();
+    }
+    setServerCertificate(certificate: BufferSource) {
+      return nativeSetCertificate(certificate);
+    }
+  }
+  vi.stubGlobal('MediaKeySession', NativeSession);
+  vi.stubGlobal('MediaKeys', NativeKeys);
+  vi.stubGlobal('window', { MPD_LIST: new Map() });
+  vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
+    if (message.action === 'license-request') return btoa('encrypted challenge');
+  });
+  eme.main();
+
+  const keys = new NativeKeys();
+  const session = keys.createSession();
+  const certificate = new DataView(new Uint8Array([99, 1, 2, 3, 99]).buffer, 1, 3);
+  await expect(keys.setServerCertificate(certificate)).resolves.toBe(true);
+  expect(nativeSetCertificate).toHaveBeenCalledWith(certificate);
+  const initData = new Uint8Array([1]);
+  await session.generateRequest('cenc', initData);
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      action: 'generateRequest',
+      serverCertificate: btoa('\x01\x02\x03'),
+    }),
+  );
+  await new NativeKeys().createSession().generateRequest('cenc', initData);
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      action: 'generateRequest',
+      serverCertificate: undefined,
+    }),
+  );
+
+  nativeSetCertificate.mockResolvedValueOnce(false);
+  await expect(keys.setServerCertificate(new Uint8Array([4]))).resolves.toBe(false);
+  nativeSetCertificate.mockRejectedValueOnce(new Error('Invalid certificate'));
+  await expect(keys.setServerCertificate(new Uint8Array([5]))).rejects.toThrow(
+    'Invalid certificate',
+  );
+  const sibling = keys.createSession();
+  await sibling.generateRequest('cenc', initData);
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      serverCertificate: btoa('\x01\x02\x03'),
+    }),
+  );
+
+  const certificateRequest = Object.assign(new Event('message'), {
+    messageType: 'license-request',
+    message: new Uint8Array([8, 4]).buffer,
+  });
+  const received = Promise.withResolvers<Event>();
+  session.addEventListener('message', received.resolve);
+  const callCount = vi.mocked(sendDrmMessage).mock.calls.length;
+  session.dispatchEvent(certificateRequest);
+  expect(await received.promise).toBe(certificateRequest);
+  expect(sendDrmMessage).toHaveBeenCalledTimes(callCount);
+
+  await keys.setServerCertificate(new Uint8Array([6]));
+  const handled = Promise.withResolvers<void>();
+  sibling.addEventListener('message', () => handled.resolve());
+  sibling.dispatchEvent(
+    Object.assign(new Event('message'), {
+      messageType: 'license-request',
+      message: new Uint8Array([8, 1, 2]).buffer,
+    }),
+  );
+  await handled.promise;
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      action: 'license-request',
+      serverCertificate: btoa('\x06'),
+    }),
+  );
 });

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -3,6 +3,13 @@ import { browser, type Browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing';
 import background from '../src/extension/entrypoints/background';
 import { appStorage } from '../src/extension/utils/storage';
+import { fromBase64 } from '../src/lib/utils';
+import {
+  ClientIdentification,
+  EncryptedClientIdentification,
+  LicenseRequest,
+  SignedMessage,
+} from '../src/lib/widevine/proto';
 import { Session, setSupportedEngines } from '../src/lib/api';
 import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
 
@@ -120,10 +127,23 @@ test('retains the session for a service certificate and cleans up failed license
   await send('generateRequest', 'one');
   await send('update', 'one', {}, { message: { 0: 8, 1: 5 } });
   expect(Session.prototype.close).not.toHaveBeenCalled();
+  expect(Session.prototype.waitForKeyStatusesChange).not.toHaveBeenCalled();
   await expect(send('license-request', 'one')).resolves.toEqual(expect.any(String));
 
-  vi.mocked(Session.prototype.update).mockRejectedValueOnce(new Error('Invalid license'));
-  await expect(send('update', 'one')).resolves.toBeUndefined();
+  const licenseUpdate = Promise.withResolvers<void>();
+  const updateStarted = Promise.withResolvers<void>();
+  vi.mocked(Session.prototype.update).mockImplementationOnce(() => {
+    updateStarted.resolve();
+    return licenseUpdate.promise;
+  });
+  const updating = send('update', 'one');
+  await updateStarted.promise;
+  expect(Session.prototype.waitForKeyStatusesChange).not.toHaveBeenCalled();
+  expect(Session.prototype.close).not.toHaveBeenCalled();
+
+  licenseUpdate.reject(new Error('Invalid license'));
+  await expect(updating).resolves.toBeUndefined();
+  expect(Session.prototype.waitForKeyStatusesChange).not.toHaveBeenCalled();
   expect(Session.prototype.close).toHaveBeenCalledOnce();
   await expect(send('license-request', 'one')).resolves.toBeUndefined();
   expect(vi.getTimerCount()).toBe(0);
@@ -193,3 +213,74 @@ test.each(['navigation', 'removal'])('cleans up only the affected tab on %s', as
   expect(Session.prototype.close).toHaveBeenCalledOnce();
   await send('close', 'two', { tab: tab(2) });
 });
+
+const SERVICE_CERTIFICATE = `CAUSxQUKvwIIAxIQKHA0VMAI9jYYredEPbbEyBiL5/mQBSKOAjCCAQoCggEBALUhErjQXQI/zF2V4sJRwcZJtBd82NK+7zVbsGdD3mYePSq8MYK3mUbVX9wI3+lUB4FemmJ0syKix/XgZ7tfCsB6idRa6pSyUW8HW2bvgR0NJuG5priU8rmFeWKqFxxPZmMNPkxgJxiJf14e+baq9a1Nuip+FBdt8TSh0xhbWiGKwFpMQfCB7/+Ao6BAxQsJu8dA7tzY8U1nWpGYD5LKfdxkagatrVEB90oOSYzAHwBTK6wheFC9kF6QkjZWt9/v70JIZ2fzPvYoPU9CVKtyWJOQvuVYCPHWaAgNRdiTwryi901goMDQoJk87wFgRwMzTDY4E5SGvJ2vJP1noH+a2UMCAwEAAToSc3RhZ2luZy5nb29nbGUuY29tEoADmD4wNSZ19AunFfwkm9rl1KxySaJmZSHkNlVzlSlyH/iA4KrvxeJ7yYDa6tq/P8OG0ISgLIJTeEjMdT/0l7ARp9qXeIoA4qprhM19ccB6SOv2FgLMpaPzIDCnKVww2pFbkdwYubyVk7jei7UPDe3BKTi46eA5zd4Y+oLoG7AyYw/pVdhaVmzhVDAL9tTBvRJpZjVrKH1lexjOY9Dv1F/FJp6X6rEctWPlVkOyb/SfEJwhAa/K81uDLyiPDZ1Flg4lnoX7XSTb0s+Cdkxd2b9yfvvpyGH4aTIfat4YkF9Nkvmm2mU224R1hx0WjocLsjA89wxul4TJPS3oRa2CYr5+DU4uSgdZzvgtEJ0lksckKfjAF0K64rPeytvDPD5fS69eFuy3Tq26/LfGcF96njtvOUA4P5xRFtICogySKe6WnCUZcYMDtQ0BMMM1LgawFNg4VA+KDCJ8ABHg9bOOTimO0sswHrRWSWX1XF15dXolCk65yEqz5lOfa2/fVomeopkU`;
+
+test.each(['setServerCertificate', 'update', 'late certificate'])(
+  'returns the encrypted challenge after %s without leaking into another session',
+  async (delivery) => {
+    vi.mocked(Session.prototype.generateRequest).mockRestore();
+    vi.mocked(Session.prototype.waitForLicenseRequest).mockRestore();
+    vi.mocked(Session.prototype.update).mockRestore();
+    const encryptId = vi.fn(async () =>
+      EncryptedClientIdentification.create({
+        providerId: 'staging.google.com',
+        encryptedClientId: new Uint8Array([1, 2, 3]),
+      }),
+    );
+    vi.mocked(appStorage.clients.active.getValue).mockResolvedValue(
+      Object.assign(new WidevineDeviceCredentials(new Uint8Array()), {
+        id: ClientIdentification.create({}),
+        encryptId,
+        signWithKey: async () => new Uint8Array([0xaa]),
+      }),
+    );
+    const send = startBackground();
+    const initData =
+      'AAAAW3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADsIARIQ62dqu8s0Xpa7z2FmMPGj2hoNd2lkZXZpbmVfdGVzdCIQZmtqM2xqYVNkZmFsa3IzaioCSEQyAA==';
+    await send(
+      'generateRequest',
+      'private',
+      {},
+      {
+        initData,
+        serverCertificate: delivery === 'setServerCertificate' ? SERVICE_CERTIFICATE : undefined,
+      },
+    );
+    await send('generateRequest', 'other', {}, { initData });
+    if (delivery === 'update') {
+      await send(
+        'update',
+        'private',
+        {},
+        {
+          message: fromBase64(SERVICE_CERTIFICATE).toBuffer(),
+        },
+      );
+    }
+    const readChallenge = async (token: string) => {
+      const response = await send(
+        'license-request',
+        token,
+        {},
+        {
+          initData,
+          serverCertificate:
+            token === 'private' && delivery !== 'update' ? SERVICE_CERTIFICATE : undefined,
+        },
+      );
+      if (typeof response !== 'string') throw new Error('Missing challenge');
+      return LicenseRequest.decode(SignedMessage.decode(fromBase64(response).toBuffer()).msg);
+    };
+    const challenge = await readChallenge('private');
+    expect(challenge.clientId).toBeNull();
+    expect(challenge.encryptedClientId?.providerId).toBe('staging.google.com');
+    expect(await readChallenge('private')).toEqual(challenge);
+    expect(encryptId).toHaveBeenCalledTimes(1);
+    const otherChallenge = await readChallenge('other');
+    expect(otherChallenge.clientId).not.toBeNull();
+    expect(otherChallenge.encryptedClientId).toBeNull();
+    await send('close', 'private');
+    await send('close', 'other');
+  },
+);

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -3,9 +3,12 @@ import { browser, type Browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing';
 import background from '../src/extension/entrypoints/background';
 import { appStorage } from '../src/extension/utils/storage';
-import { fromBase64 } from '../src/lib/utils';
+import * as certificateUtils from '../src/lib/widevine/certificate';
+import { fromBase64, fromBuffer } from '../src/lib/utils';
 import {
   ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
   EncryptedClientIdentification,
   LicenseRequest,
   SignedMessage,
@@ -216,15 +219,21 @@ test.each(['navigation', 'removal'])('cleans up only the affected tab on %s', as
 
 const SERVICE_CERTIFICATE = `CAUSxQUKvwIIAxIQKHA0VMAI9jYYredEPbbEyBiL5/mQBSKOAjCCAQoCggEBALUhErjQXQI/zF2V4sJRwcZJtBd82NK+7zVbsGdD3mYePSq8MYK3mUbVX9wI3+lUB4FemmJ0syKix/XgZ7tfCsB6idRa6pSyUW8HW2bvgR0NJuG5priU8rmFeWKqFxxPZmMNPkxgJxiJf14e+baq9a1Nuip+FBdt8TSh0xhbWiGKwFpMQfCB7/+Ao6BAxQsJu8dA7tzY8U1nWpGYD5LKfdxkagatrVEB90oOSYzAHwBTK6wheFC9kF6QkjZWt9/v70JIZ2fzPvYoPU9CVKtyWJOQvuVYCPHWaAgNRdiTwryi901goMDQoJk87wFgRwMzTDY4E5SGvJ2vJP1noH+a2UMCAwEAAToSc3RhZ2luZy5nb29nbGUuY29tEoADmD4wNSZ19AunFfwkm9rl1KxySaJmZSHkNlVzlSlyH/iA4KrvxeJ7yYDa6tq/P8OG0ISgLIJTeEjMdT/0l7ARp9qXeIoA4qprhM19ccB6SOv2FgLMpaPzIDCnKVww2pFbkdwYubyVk7jei7UPDe3BKTi46eA5zd4Y+oLoG7AyYw/pVdhaVmzhVDAL9tTBvRJpZjVrKH1lexjOY9Dv1F/FJp6X6rEctWPlVkOyb/SfEJwhAa/K81uDLyiPDZ1Flg4lnoX7XSTb0s+Cdkxd2b9yfvvpyGH4aTIfat4YkF9Nkvmm2mU224R1hx0WjocLsjA89wxul4TJPS3oRa2CYr5+DU4uSgdZzvgtEJ0lksckKfjAF0K64rPeytvDPD5fS69eFuy3Tq26/LfGcF96njtvOUA4P5xRFtICogySKe6WnCUZcYMDtQ0BMMM1LgawFNg4VA+KDCJ8ABHg9bOOTimO0sswHrRWSWX1XF15dXolCk65yEqz5lOfa2/fVomeopkU`;
 
-test.each(['setServerCertificate', 'update', 'late certificate'])(
+test.each([
+  'setServerCertificate',
+  'update',
+  'late certificate',
+  'replacement wrapped',
+  'replacement unwrapped',
+])(
   'returns the encrypted challenge after %s without leaking into another session',
   async (delivery) => {
     vi.mocked(Session.prototype.generateRequest).mockRestore();
     vi.mocked(Session.prototype.waitForLicenseRequest).mockRestore();
     vi.mocked(Session.prototype.update).mockRestore();
-    const encryptId = vi.fn(async () =>
+    const encryptId = vi.fn(async (certificate: SignedDrmCertificate) =>
       EncryptedClientIdentification.create({
-        providerId: 'staging.google.com',
+        providerId: DrmCertificate.decode(certificate.drmCertificate).providerId,
         encryptedClientId: new Uint8Array([1, 2, 3]),
       }),
     );
@@ -248,6 +257,36 @@ test.each(['setServerCertificate', 'update', 'late certificate'])(
       },
     );
     await send('generateRequest', 'other', {}, { initData });
+    const isReplacement = delivery.startsWith('replacement');
+    if (isReplacement) {
+      const { signedDrmCertificate, drmCertificate } =
+        await certificateUtils.parseCertificate(SERVICE_CERTIFICATE);
+      drmCertificate.providerId = 'previous.example.com';
+      signedDrmCertificate.drmCertificate = DrmCertificate.encode(drmCertificate).finish();
+      // Only the synthetic previous certificate bypasses signature verification.
+      vi.spyOn(certificateUtils, 'verifyCertificate').mockResolvedValueOnce(true);
+      await send(
+        'update',
+        'private',
+        {},
+        {
+          message: SignedMessage.encode({
+            type: SignedMessage.MessageType.SERVICE_CERTIFICATE,
+            msg: SignedDrmCertificate.encode(signedDrmCertificate).finish(),
+          }).finish(),
+        },
+      );
+      expect(encryptId).toHaveBeenCalledTimes(1);
+      await expect(encryptId.mock.results[0]?.value).resolves.toMatchObject({
+        providerId: 'previous.example.com',
+      });
+    }
+    const replacementCertificate =
+      delivery === 'replacement unwrapped'
+        ? fromBuffer(
+            SignedMessage.decode(fromBase64(SERVICE_CERTIFICATE).toBuffer()).msg,
+          ).toBase64()
+        : SERVICE_CERTIFICATE;
     if (delivery === 'update') {
       await send(
         'update',
@@ -266,7 +305,7 @@ test.each(['setServerCertificate', 'update', 'late certificate'])(
         {
           initData,
           serverCertificate:
-            token === 'private' && delivery !== 'update' ? SERVICE_CERTIFICATE : undefined,
+            token === 'private' && delivery !== 'update' ? replacementCertificate : undefined,
         },
       );
       if (typeof response !== 'string') throw new Error('Missing challenge');
@@ -276,7 +315,7 @@ test.each(['setServerCertificate', 'update', 'late certificate'])(
     expect(challenge.clientId).toBeNull();
     expect(challenge.encryptedClientId?.providerId).toBe('staging.google.com');
     expect(await readChallenge('private')).toEqual(challenge);
-    expect(encryptId).toHaveBeenCalledTimes(1);
+    expect(encryptId).toHaveBeenCalledTimes(isReplacement ? 2 : 1);
     const otherChallenge = await readChallenge('other');
     expect(otherChallenge.clientId).not.toBeNull();
     expect(otherChallenge.encryptedClientId).toBeNull();


### PR DESCRIPTION
## Summary

- Track Widevine service certificates per `MediaKeys` and extension session.
- Forward certificates with EME requests and regenerate challenges when certificates change.
- Preserve service-certificate license requests and select the latest queued challenge.
- Refresh the pnpm lockfile dependencies.

## Testing

- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791202299&installation_model_id=424872&pr_number=37&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F37&signature=ab796012e17dc9177beb2dbf7a6e9b46e5d218a7179e98ab1e3174fbe8e3ee36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->