### PR TITLE
fix(extension): load the current DRM client per session

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { appStorage, Client, getRecentKeysForUrl, isCapturedKey } from '@/utils/storage';
+import { appStorage, getRecentKeysForUrl, isCapturedKey } from '@/utils/storage';
 import type { KeyInfo } from '@/utils/storage';
 import {
   fromBase64,
@@ -33,10 +33,8 @@ export default defineBackground({
     });
 
     const state: {
-      client: Client | null;
       sessions: Map<string, SessionEntry>;
     } = {
-      client: null,
       sessions: new Map(),
     };
 
@@ -60,12 +58,11 @@ export default defineBackground({
     browser.tabs.onRemoved.addListener(closeTabSessions);
 
     const loadClient = async () => {
-      if (state.client) return state.client;
       console.log('[okova] Loading DRM client...');
-      state.client = await appStorage.clients.active.getValue();
-      if (state.client) {
+      const client = await appStorage.clients.active.getValue();
+      if (client) {
         console.log('[okova] DRM client loaded');
-        return state.client;
+        return client;
       } else {
         console.log('[okova] Unable to load client');
         return null;

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/lib/widevine/proto';
 import { Session, setSupportedEngines } from '../src/lib/api';
 import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import { Widevine } from '../src/lib/widevine/engine';
 
 vi.mock('../src/lib/widevine/device-credentials', () => ({
   WidevineDeviceCredentials: class {},
@@ -98,6 +99,68 @@ const startBackground = () => {
       );
     });
 };
+
+const getSessionClient = (index: number) => {
+  const engine = sessions[index]?.engine;
+  if (!(engine instanceof Widevine)) throw new Error('Expected a Widevine session');
+  return engine.deviceCredentials;
+};
+
+test('new sessions use the current client while existing sessions retain their credentials', async () => {
+  const firstClient = new WidevineDeviceCredentials(new Uint8Array());
+  const secondClient = new WidevineDeviceCredentials(new Uint8Array());
+  const getClient = vi.mocked(appStorage.clients.active.getValue);
+  getClient.mockResolvedValue(firstClient);
+  const send = startBackground();
+  await send('generateRequest', 'first');
+  expect(getSessionClient(0)).toBe(firstClient);
+
+  getClient.mockResolvedValue(secondClient);
+  await send('generateRequest', 'second');
+  expect(getSessionClient(1)).toBe(secondClient);
+  await expect(send('license-request', 'first')).resolves.toBe(btoa(sessions[0]!.sessionId));
+  expect(getSessionClient(0)).toBe(firstClient);
+
+  getClient.mockResolvedValue(null);
+  await send('generateRequest', 'unselected');
+  expect(sessions).toHaveLength(2);
+  await expect(send('license-request', 'unselected')).resolves.toBeUndefined();
+
+  getClient.mockResolvedValue(firstClient);
+  await send('generateRequest', 'reselected');
+  expect(sessions).toHaveLength(3);
+  expect(getSessionClient(2)).toBe(firstClient);
+  await send('close', 'first');
+  await send('close', 'second');
+  await send('close', 'reselected');
+});
+
+test('a pending client load cannot replace the selection used by later sessions', async () => {
+  const firstClient = new WidevineDeviceCredentials(new Uint8Array());
+  const secondClient = new WidevineDeviceCredentials(new Uint8Array());
+  const pendingClient = Promise.withResolvers<WidevineDeviceCredentials>();
+  const loadStarted = Promise.withResolvers<void>();
+  vi.mocked(appStorage.clients.active.getValue)
+    .mockImplementationOnce(() => {
+      loadStarted.resolve();
+      return pendingClient.promise;
+    })
+    .mockResolvedValue(secondClient);
+  const send = startBackground();
+  const firstRequest = send('generateRequest', 'first');
+  await loadStarted.promise;
+  await send('generateRequest', 'second');
+  expect(getSessionClient(0)).toBe(secondClient);
+
+  pendingClient.resolve(firstClient);
+  await firstRequest;
+  await send('generateRequest', 'third');
+  expect(sessions).toHaveLength(3);
+  expect(getSessionClient(2)).toBe(secondClient);
+  await send('close', 'first');
+  await send('close', 'second');
+  await send('close', 'third');
+});
 
 test('same-PSSH sessions keep their challenges and updates across tabs, frames and documents', async () => {
   const send = startBackground();


### PR DESCRIPTION
## Summary
- Load the active DRM client whenever a new session is created.
- Preserve each existing session's credentials after client changes.
- Add coverage for client reselection and pending client loads.

## Testing
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791203867&installation_model_id=424872&pr_number=39&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F39&signature=13648480450653b8f74f6baee07b47a54b68ee100543c8d673a7ae8cfcf80529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->