### PR TITLE
fix(extension): inspect network responses without blocking requests

### DIFF
--- a/src/extension/entrypoints/network.tsx
+++ b/src/extension/entrypoints/network.tsx
@@ -1,6 +1,7 @@
 export default defineUnlistedScript(() => {
+  const MAX_SIZE = 1024 * 1024 * 1; // 1 MB
+
   const filterHead = (url: string, headers: Record<string, string>) => {
-    const MAX_SIZE = 1024 * 1024 * 1; // 1 MB
     const size = headers['content-length'];
     const isSizeOk = Number(size) < MAX_SIZE;
     if (size && !isSizeOk) return false;
@@ -111,7 +112,9 @@ export default defineUnlistedScript(() => {
             text = this.responseText;
             break;
           case 'arraybuffer':
-            if (!(response instanceof ArrayBuffer)) return;
+            if (!(response instanceof ArrayBuffer) || response.byteLength >= MAX_SIZE) return;
+            // A timer task lets all page load handlers finish before decoding.
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
             text = new TextDecoder().decode(response);
             break;
           case 'blob':

--- a/src/extension/entrypoints/network.tsx
+++ b/src/extension/entrypoints/network.tsx
@@ -45,22 +45,23 @@ export default defineUnlistedScript(() => {
     return worker;
   };
 
+  const inspectFetchResponse = async (response: Response) => {
+    const url = response.url;
+    const headers = Object.fromEntries(response.headers.entries());
+    if (!filterHead(url, headers)) return;
+
+    const text = await response.clone().text();
+    if (filterData(url, text)) postMessage(url, headers, text);
+  };
+
   const patchFetch = () => {
     if (typeof fetch === 'function') {
       const originalFetch = fetch;
       const cachedFetch = async function fetch(resource: URL | RequestInfo, options?: RequestInit) {
         const response = await originalFetch(resource, options);
-
-        const clone = response.clone();
-        const url = clone.url;
-        const headers = Object.fromEntries(clone.headers.entries());
-        const hasHeadMatch = filterHead(url, headers);
-        if (hasHeadMatch) {
-          const text = await clone.text();
-          const hasDataMatch = filterData(url, text);
-          if (hasDataMatch) postMessage(url, headers, text);
-        }
-
+        void inspectFetchResponse(response).catch((error) => {
+          console.warn('[okova] Fetch response inspection failed', error);
+        });
         return response;
       };
       Object.assign(cachedFetch, originalFetch);
@@ -81,10 +82,14 @@ export default defineUnlistedScript(() => {
     class PatchedXHR extends XMLHttpRequest {
       constructor() {
         super();
-        this.addEventListener('load', this.#handleResponse.bind(this));
+        this.addEventListener('load', () => {
+          void this.#handleResponse().catch((error) => {
+            console.warn('[okova] XHR response inspection failed', error);
+          });
+        });
       }
 
-      #handleResponse() {
+      async #handleResponse() {
         const url = this.responseURL;
         const headersString = this.getAllResponseHeaders();
         const headersArray = headersString.trim().split(/[\r\n]+/);
@@ -96,12 +101,31 @@ export default defineUnlistedScript(() => {
           const value = parts.join(': ');
           headers[header] = value;
         }
-        const hasHeadMatch = filterHead(url, headers);
-        if (hasHeadMatch && this.responseType === 'text') {
-          const text = this.response;
-          const hasDataMatch = filterData(url, text);
-          if (hasDataMatch) postMessage(url, headers, text);
+        if (!filterHead(url, headers)) return;
+
+        const response: unknown = this.response;
+        let text: string;
+        switch (this.responseType) {
+          case '':
+          case 'text':
+            text = this.responseText;
+            break;
+          case 'arraybuffer':
+            if (!(response instanceof ArrayBuffer)) return;
+            text = new TextDecoder().decode(response);
+            break;
+          case 'blob':
+            if (!(response instanceof Blob)) return;
+            text = await response.text();
+            break;
+          case 'document':
+            if (!this.responseXML) return;
+            text = new XMLSerializer().serializeToString(this.responseXML);
+            break;
+          default:
+            return;
         }
+        if (filterData(url, text)) postMessage(url, headers, text);
       }
     }
     window.XMLHttpRequest = PatchedXHR;
@@ -130,17 +154,18 @@ export default defineUnlistedScript(() => {
           fetch = async function(...args) {
             const response = await originalFetch.apply(this, args);
 
-            const size = response.headers.get('content-length');
-            const MAX_SIZE = 1024 * 1024 * 1; // 1 MB
-            const isSizeOk = Number(size) < MAX_SIZE;
-            if (size && !isSizeOk) return response;
+            const inspectResponse = async () => {
+              const size = response.headers.get('content-length');
+              const MAX_SIZE = 1024 * 1024 * 1; // 1 MB
+              const isSizeOk = Number(size) < MAX_SIZE;
+              if (size && !isSizeOk) return;
 
-            const type = response.headers.get('content-type');
-            const isTypeOk = type?.includes('xml') || type?.includes('dash') || type?.includes('octet-stream');
-            if (!isTypeOk) return response;
+              const type = response.headers.get('content-type');
+              const isTypeOk = type?.includes('xml') || type?.includes('dash') || type?.includes('octet-stream');
+              if (!isTypeOk) return;
 
-            const clone = response.clone();
-            clone.text().then(text => {
+              const clone = response.clone();
+              const text = await clone.text();
               const message = {
                 jsonrpc: '2.0',
                 method: 'response',
@@ -156,6 +181,9 @@ export default defineUnlistedScript(() => {
               } else {
                 window.postMessage(message, '*');
               }
+            };
+            void inspectResponse().catch(error => {
+              console.warn('[okova] Fetch response inspection failed', error);
             });
             return response;
           };

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -47,6 +47,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   vi.resetAllMocks();
@@ -78,6 +79,61 @@ test.each(['', 'text', 'arraybuffer', 'blob', 'document'] satisfies XMLHttpReque
       }),
       '*',
     );
+  },
+);
+
+test('decodes array buffers after load dispatch and preserves the completed response', async () => {
+  vi.useFakeTimers();
+  const decode = vi.spyOn(TextDecoder.prototype, 'decode');
+  const response = new TextEncoder().encode(manifest).buffer;
+  const xhr = new XMLHttpRequest();
+  Object.assign(xhr, { responseType: 'arraybuffer', response });
+  const onLoad = vi.fn(() => {
+    const decodeCount = decode.mock.calls.length;
+    const messageCount = postMessage.mock.calls.length;
+    // A page can reuse the XHR from its load handler.
+    Object.assign(xhr, { response: null, responseURL: 'https://example.com/next' });
+    return { decodeCount, messageCount };
+  });
+  xhr.addEventListener('load', onLoad);
+  xhr.dispatchEvent(new Event('load'));
+  expect(onLoad).toHaveBeenCalledOnce();
+  expect(onLoad).toHaveReturnedWith({ decodeCount: 0, messageCount: 0 });
+  await Promise.resolve();
+  expect(decode).not.toHaveBeenCalled();
+  await vi.runAllTimersAsync();
+  expect(decode).toHaveBeenCalledExactlyOnceWith(response);
+  expect(postMessage).toHaveBeenCalledWith(
+    expect.objectContaining({ params: expect.objectContaining({ url, text: manifest }) }),
+    '*',
+  );
+});
+
+test.each([
+  { sizeBytes: 1024 * 1024 - 1, shouldDecode: true },
+  { sizeBytes: 1024 * 1024, shouldDecode: false },
+  { sizeBytes: 1024 * 1024 + 1, shouldDecode: false },
+])(
+  'checks the actual array-buffer size of $sizeBytes bytes',
+  async ({ sizeBytes, shouldDecode }) => {
+    vi.useFakeTimers();
+    const decode = vi.spyOn(TextDecoder.prototype, 'decode');
+    for (const contentLength of ['', 'content-length: 1\r\n']) {
+      decode.mockClear();
+      postMessage.mockClear();
+      const response = new Uint8Array(sizeBytes);
+      response.set(new TextEncoder().encode(manifest));
+      const xhr = new XMLHttpRequest();
+      Object.assign(xhr, {
+        responseType: 'arraybuffer',
+        response: response.buffer,
+        headers: `content-type: application/octet-stream\r\n${contentLength}`,
+      });
+      xhr.dispatchEvent(new Event('load'));
+      await vi.runAllTimersAsync();
+      expect(decode).toHaveBeenCalledTimes(shouldDecode ? 1 : 0);
+      expect(postMessage).toHaveBeenCalledTimes(shouldDecode ? 1 : 0);
+    }
   },
 );
 

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -1,0 +1,172 @@
+import { runInNewContext } from 'node:vm';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import network from '../src/extension/entrypoints/network';
+
+const manifest = '<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"/>';
+const url = 'https://example.com/manifest.mpd';
+const postMessage = vi.fn();
+const nativeFetch = vi.fn<typeof fetch>();
+const nativeCreateObjectURL = vi.fn<typeof URL.createObjectURL>();
+
+// Node lacks XMLHttpRequest. Model its response getters and load events.
+class NativeXHR extends EventTarget {
+  responseType: XMLHttpRequestResponseType = '';
+  response: unknown = manifest;
+  responseXML: unknown = null;
+  responseURL = url;
+  headers = 'content-type: application/dash+xml\r\n';
+  get responseText() {
+    if (this.responseType !== '' && this.responseType !== 'text') {
+      throw new Error('responseText is unavailable for this response type');
+    }
+    return this.response;
+  }
+  getAllResponseHeaders() {
+    return this.headers;
+  }
+  overrideMimeType() {}
+  open() {}
+  send() {
+    this.response = '';
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('window', globalThis);
+  vi.stubGlobal('Worker', class {});
+  vi.stubGlobal('XMLHttpRequest', NativeXHR);
+  vi.stubGlobal('XMLSerializer', XMLSerializer);
+  vi.stubGlobal('postMessage', postMessage);
+  vi.stubGlobal('fetch', nativeFetch);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  // Restore the object URL patch after each test.
+  vi.spyOn(URL, 'createObjectURL').mockImplementation(nativeCreateObjectURL);
+  network.main();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetAllMocks();
+});
+
+test.each(['', 'text', 'arraybuffer', 'blob', 'document'] satisfies XMLHttpRequestResponseType[])(
+  'captures XHR manifests with responseType "%s"',
+  async (responseType) => {
+    const xhr = new XMLHttpRequest();
+    Object.assign(xhr, {
+      responseType,
+      response:
+        responseType === 'arraybuffer'
+          ? new TextEncoder().encode(manifest).buffer
+          : responseType === 'blob'
+            ? new Blob([manifest])
+            : manifest,
+      responseXML:
+        responseType === 'document'
+          ? new DOMParser().parseFromString(manifest, 'application/xml')
+          : null,
+    });
+    xhr.dispatchEvent(new Event('load'));
+    await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'response',
+        params: { url, text: manifest, headers: { 'content-type': 'application/dash+xml' } },
+      }),
+      '*',
+    );
+  },
+);
+
+test('contains XHR body inspection failures while delivering load events', async () => {
+  const error = new Error('Blob read failed');
+  const blob = new Blob([manifest]);
+  vi.spyOn(blob, 'text').mockRejectedValue(error);
+  const xhr = new XMLHttpRequest();
+  Object.assign(xhr, { responseType: 'blob', response: blob });
+  const onLoad = vi.fn();
+  xhr.addEventListener('load', onLoad);
+  xhr.dispatchEvent(new Event('load'));
+  expect(onLoad).toHaveBeenCalledOnce();
+  await vi.waitFor(() => expect(console.warn).toHaveBeenCalledWith(expect.any(String), error));
+  expect(postMessage).not.toHaveBeenCalled();
+});
+
+const makeResponse = () =>
+  new Response(manifest, { headers: { 'content-type': 'application/dash+xml' } });
+
+// Execute the actual generated blob worker script with Node's real fetch body types.
+const useWorkerFetch = async () => {
+  let workerBlob: Blob | undefined;
+  const patchedCreateObjectURL = URL.createObjectURL;
+  nativeCreateObjectURL.mockImplementation((blob) => {
+    if (blob instanceof Blob) workerBlob = blob;
+    return 'blob:test';
+  });
+  patchedCreateObjectURL(new Blob([''], { type: 'text/javascript' }));
+  if (!workerBlob) throw new Error('Worker script was not generated');
+  class WorkerGlobalScope {
+    postMessage = postMessage;
+  }
+  const context = { fetch: nativeFetch, console, WorkerGlobalScope, self: new WorkerGlobalScope() };
+  runInNewContext(await workerBlob.text(), context);
+  vi.stubGlobal('fetch', context.fetch);
+};
+
+test.each(['page', 'worker'])('%s fetch returns before inspection finishes', async (context) => {
+  if (context === 'worker') await useWorkerFetch();
+  const response = makeResponse();
+  const inspection = Promise.withResolvers<string>();
+  const clone = response.clone();
+  vi.spyOn(clone, 'text').mockReturnValue(inspection.promise);
+  vi.spyOn(response, 'clone').mockReturnValue(clone);
+  nativeFetch.mockResolvedValue(response);
+  const options = { credentials: 'include' } satisfies RequestInit;
+  expect(await fetch(url, options)).toBe(response);
+  expect(nativeFetch).toHaveBeenCalledWith(url, options);
+  expect(postMessage).not.toHaveBeenCalled();
+  expect(await response.text()).toBe(manifest);
+  inspection.resolve(manifest);
+  await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce());
+});
+
+test.each([
+  ['page', 'clone'],
+  ['page', 'body'],
+  ['page', 'message'],
+  ['worker', 'clone'],
+  ['worker', 'body'],
+  ['worker', 'message'],
+])('%s fetch contains %s inspection failures', async (context, failure) => {
+  if (context === 'worker') await useWorkerFetch();
+  const response = makeResponse();
+  const error = new Error('Inspection failed');
+  if (failure === 'clone') {
+    vi.spyOn(response, 'clone').mockImplementation(() => {
+      throw error;
+    });
+  } else if (failure === 'body') {
+    const clone = response.clone();
+    vi.spyOn(clone, 'text').mockRejectedValue(error);
+    vi.spyOn(response, 'clone').mockReturnValue(clone);
+  } else {
+    postMessage.mockImplementation(() => {
+      throw error;
+    });
+  }
+  nativeFetch.mockResolvedValue(response);
+  expect(await fetch(url)).toBe(response);
+  expect(await response.text()).toBe(manifest);
+  await vi.waitFor(() => expect(console.warn).toHaveBeenCalledWith(expect.any(String), error));
+});
+
+test.each(['page', 'worker'])('%s fetch preserves network failures', async (context) => {
+  if (context === 'worker') await useWorkerFetch();
+  const error = new TypeError('Network failure');
+  nativeFetch.mockRejectedValue(error);
+  await expect(fetch(url)).rejects.toBe(error);
+  expect(console.warn).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

- Inspect Fetch and XHR responses asynchronously so native requests return immediately.
- Support text, ArrayBuffer, Blob, and document XHR response types.
- Contain inspection failures without interrupting network or load events.
- Add coverage for page and worker fetch behavior, response types, and failure handling.

## Testing

- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791203961&installation_model_id=424872&pr_number=40&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F40&signature=e9b781b518105e204d92e72408082f24b7f09036beef7f999adb8d2989aeb94b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->