### PR TITLE
fix(extension): close decryption sessions after license flow

### DIFF
--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -72,7 +72,12 @@ const fetchDecryptionKeys = async (params: FetchDecryptionKeysParams) => {
     return await Promise.race([keysReady, flowFailed]);
   } finally {
     session.removeEventListener('message', handleMessage);
-    await session.close();
+    try {
+      await session.close();
+    } catch (error) {
+      // Cleanup must not replace acquired keys or the original license-flow error.
+      params.logger?.warn('Failed to close decryption session', error);
+    }
   }
 };
 

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -72,6 +72,7 @@ const fetchDecryptionKeys = async (params: FetchDecryptionKeysParams) => {
     return await Promise.race([keysReady, flowFailed]);
   } finally {
     session.removeEventListener('message', handleMessage);
+    await session.close();
   }
 };
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,6 @@
 import { cbc, ctr } from '@noble/ciphers/aes.js';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { fetchDecryptionKeys } from '../src/lib/main';
 import {
   BaseMediaKeysEngine,
   BaseMediaKeysEngineSession,
@@ -70,6 +71,50 @@ class FakeEngine extends BaseMediaKeysEngine {
     return new FakeEngineSession(sessionType);
   }
 }
+
+describe('fetchDecryptionKeys', () => {
+  test.each(['success', 'generateRequest', 'fetch', 'update'] as const)(
+    'closes its session after %s',
+    async (outcome) => {
+      const engine = new FakeEngine();
+      const session = new FakeEngineSession();
+      vi.spyOn(engine, 'createSession').mockResolvedValue(session);
+      const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response());
+      const failure = new Error('License flow failed');
+      if (outcome === 'fetch') {
+        fetchImpl.mockRejectedValue(failure);
+      } else if (outcome !== 'success') {
+        vi.spyOn(session, outcome).mockRejectedValue(failure);
+      }
+
+      const { promise: closeFinished, resolve: finishClose } = Promise.withResolvers<void>();
+      const { promise: closeStarted, resolve: startClose } = Promise.withResolvers<void>();
+      const close = vi.spyOn(session, 'close').mockImplementation(async () => {
+        startClose();
+        await closeFinished;
+      });
+      let isSettled = false;
+      const result = fetchDecryptionKeys({
+        cdm: engine,
+        pssh: 'AQ==',
+        server: 'https://license.example.test',
+        fetch: fetchImpl,
+      }).finally(() => {
+        isSettled = true;
+      });
+      const assertion =
+        outcome === 'success'
+          ? expect(result).resolves.toEqual(new Map([[KEY_ID, KEY_VALUE]]))
+          : expect(result).rejects.toBe(failure);
+
+      await closeStarted;
+      expect(isSettled).toBe(false);
+      finishClose();
+      await assertion;
+      expect(close).toHaveBeenCalledOnce();
+    },
+  );
+});
 
 describe('waitForKeys', () => {
   test('resolves immediately when keys already exist', async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -72,7 +72,7 @@ class FakeEngine extends BaseMediaKeysEngine {
   }
 }
 
-describe('fetchDecryptionKeys', () => {
+describe.each(['successful', 'failed'])('fetchDecryptionKeys with %s cleanup', (cleanup) => {
   test.each(['success', 'generateRequest', 'fetch', 'update'] as const)(
     'closes its session after %s',
     async (outcome) => {
@@ -92,6 +92,7 @@ describe('fetchDecryptionKeys', () => {
       const close = vi.spyOn(session, 'close').mockImplementation(async () => {
         startClose();
         await closeFinished;
+        if (cleanup === 'failed') throw new Error('Session close failed');
       });
       let isSettled = false;
       const result = fetchDecryptionKeys({

--- a/test/playready.test.ts
+++ b/test/playready.test.ts
@@ -3,7 +3,7 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import * as utils from '@noble/curves/utils.js';
 import { afterEach } from 'vitest';
 import { expect, test, vi } from 'vitest';
-import { fromBase64, toBufferSource } from '../src/lib';
+import { fetchDecryptionKeys, fromBase64, toBufferSource } from '../src/lib';
 import { requestMediaKeySystemAccess, setSupportedEngines } from '../src/lib/api';
 import * as common from '../src/lib/crypto/common';
 import { EccKey } from '../src/lib/crypto/ecc-key';
@@ -428,6 +428,17 @@ test('playready pause and resume preserve key identifiers', async () => {
 
   expect(resumedSession.keys).toEqual(session.keys);
   expect(resumedSession.keyStatuses).toEqual(session.keyStatuses);
+});
+
+test('fetchDecryptionKeys releases playready sessions after invalid initialization data', async () => {
+  const cdm = createPlayReady();
+
+  for (let index = 0; index <= PlayReady.MAX_NUM_OF_SESSIONS; index++) {
+    await expect(
+      fetchDecryptionKeys({ cdm, pssh: 'AQ==', server: 'https://license.example.test' }),
+    ).rejects.toThrow();
+    expect(cdm.sessions.size).toBe(0);
+  }
 });
 
 test('playready engine rejects opening more than 16 sessions', () => {


### PR DESCRIPTION
## Summary

- Close DRM sessions after license flows complete or fail.
- Add coverage for session cleanup across success and error paths.
- Verify PlayReady sessions are released after invalid initialization data.

## Testing

- `pnpm vitest test/api.test.ts`
- `pnpm vitest test/playready.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791205462&installation_model_id=424872&pr_number=41&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F41&signature=a108a4d46640878fbf51b8ea966a3bb79fa0a61e0d6f032aa7701b46d8ccee0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->