### PR TITLE
fix(playready): support PRD v2 credentials without group keys

### DIFF
--- a/src/lib/playready/device-credentials.ts
+++ b/src/lib/playready/device-credentials.ts
@@ -1,12 +1,11 @@
-import { equalBytes } from '@noble/curves/utils.js';
 import { EccKey } from '../crypto/ecc-key';
 import { getRandomBytes } from '../utils';
 import { BCertCertType, Certificate, CertificateChain } from './bcert';
 import { InvalidCertificateChain } from './exceptions';
-import { PRD_MAGIC, PRD3 } from './prd';
+import { parsePrd, PRD_MAGIC, PRD2, PRD3 } from './prd';
 
 export class PlayReadyDeviceCredentials {
-  groupKey: EccKey;
+  groupKey: EccKey | null;
   encryptionKey: EccKey;
   signingKey: EccKey;
 
@@ -15,12 +14,12 @@ export class PlayReadyDeviceCredentials {
   securityLevel: number;
 
   constructor(data: {
-    groupKey: Uint8Array;
+    groupKey?: Uint8Array;
     encryptionKey: Uint8Array;
     signingKey: Uint8Array;
     groupCertificate: Uint8Array;
   }) {
-    this.groupKey = EccKey.from(data.groupKey);
+    this.groupKey = data.groupKey ? EccKey.from(data.groupKey) : null;
     this.encryptionKey = EccKey.from(data.encryptionKey);
     this.signingKey = EccKey.from(data.signingKey);
     this.groupCertificate = CertificateChain.from(data.groupCertificate);
@@ -38,7 +37,7 @@ export class PlayReadyDeviceCredentials {
         },
   ) {
     if ('prd' in payload) {
-      const parsed = PRD3.parse(payload.prd);
+      const parsed = parsePrd(payload.prd);
       const groupKey = parsed.group_key;
       const encryptionKey = parsed.encryption_key;
       const signingKey = parsed.signing_key;
@@ -106,18 +105,28 @@ export class PlayReadyDeviceCredentials {
   }
 
   pack() {
-    return PRD3.build({
+    const groupCertificate = this.groupCertificate.dumps();
+    const fields = {
       signature: PRD_MAGIC,
-      version: 3,
-      group_key: this.groupKey.dumps(),
       encryption_key: this.encryptionKey.dumps(),
       signing_key: this.signingKey.dumps(),
-      group_certificate_length: this.groupCertificate.dumps().length,
-      group_certificate: this.groupCertificate.dumps(),
+      group_certificate_length: groupCertificate.length,
+      group_certificate: groupCertificate,
+    };
+    if (!this.groupKey) {
+      return PRD2.build({ ...fields, version: 2 });
+    }
+    return PRD3.build({
+      ...fields,
+      version: 3,
+      group_key: this.groupKey.dumps(),
     });
   }
 
   unpack() {
+    if (!this.groupKey) {
+      throw new Error('Cannot unpack PlayReady group files: PRD v2 credentials have no group key');
+    }
     const groupCertificate = CertificateChain.from(this.groupCertificate.dumps());
     groupCertificate.remove(0);
     return {

--- a/src/lib/playready/prd.ts
+++ b/src/lib/playready/prd.ts
@@ -22,11 +22,19 @@ export const PRD3 = b.object({
   group_certificate: b.bytes((ctx) => ctx.group_certificate_length),
 });
 
-export const PRD = b.object({
+const PRD_HEADER = b.object({
   signature: b.literal('PRD'),
   version: b.uint8(),
-  data: b.discriminatedUnion((ctx) => ctx.version, {
-    2: PRD2,
-    3: PRD3,
-  }),
 });
+
+export const parsePrd = (data: Uint8Array) => {
+  const { version } = PRD_HEADER.parse(data, false);
+  switch (version) {
+    case 2:
+      return { ...PRD2.parse(data), group_key: undefined };
+    case 3:
+      return PRD3.parse(data);
+    default:
+      throw new Error(`Unsupported PRD version: ${version}`);
+  }
+};

--- a/test/playready-client.test.ts
+++ b/test/playready-client.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { expect, test } from 'vitest';
+import { assert, expect, test } from 'vitest';
 import * as common from '../src/lib/crypto/common';
 import { EccKey } from '../src/lib/crypto/ecc-key';
 import { fromBuffer } from '../src/lib';
@@ -54,6 +54,43 @@ test('creates playready device credentials from unpacked fixtures', async () => 
   expect(recreated.pack().length).toBeGreaterThan(0);
 });
 
+test('imports and roundtrips PRD v2 credentials without a group key', async () => {
+  const v3 = await loadPlayReadyClientData();
+  expect(v3[3]).toBe(3);
+  // v2 stores the certificate before the device keys and omits the group key.
+  const prd = new Uint8Array([0x50, 0x52, 0x44, 2, ...v3.subarray(292), ...v3.subarray(100, 292)]);
+  const original = await PlayReadyDeviceCredentials.from({ prd: v3 });
+  const client = await PlayReadyDeviceCredentials.from({ prd });
+
+  expect(client.groupKey).toBeNull();
+  expect(client.encryptionKey.dumps()).toEqual(original.encryptionKey.dumps());
+  expect(client.signingKey.dumps()).toEqual(original.signingKey.dumps());
+  expect(client.groupCertificate.dumps()).toEqual(original.groupCertificate.dumps());
+  expect(client.securityLevel).toBe(original.securityLevel);
+  expect(client.label).toBe(original.label);
+  expect(client.pack()).toEqual(prd);
+  expect(() => client.unpack()).toThrow('PRD v2 credentials have no group key');
+});
+
+test.each([0, 1, 4, 99, 255])('rejects unsupported PRD version %i', async (version) => {
+  const prd = new Uint8Array(await loadPlayReadyClientData());
+  prd[3] = version;
+  await expect(PlayReadyDeviceCredentials.from({ prd })).rejects.toThrow(
+    `Unsupported PRD version: ${version}`,
+  );
+});
+
+test('rejects invalid and truncated PRD headers', async () => {
+  const prd = new Uint8Array(await loadPlayReadyClientData());
+  for (const length of [0, 1, 2, 3]) {
+    await expect(
+      PlayReadyDeviceCredentials.from({ prd: prd.subarray(0, length) }),
+    ).rejects.toThrow();
+  }
+  prd[0] = 0;
+  await expect(PlayReadyDeviceCredentials.from({ prd })).rejects.toThrow();
+});
+
 test('rejects unpacked playready credentials when the group key does not match the certificate', async () => {
   const prd = await loadPlayReadyClientData();
   const original = await PlayReadyDeviceCredentials.from({ prd });
@@ -72,6 +109,7 @@ test('rejects unpacked playready credentials when the group key does not match t
 test('rejects already provisioned playready certificate chains when creating unpacked credentials', async () => {
   const prd = await loadPlayReadyClientData();
   const original = await PlayReadyDeviceCredentials.from({ prd });
+  assert(original.groupKey);
 
   await expect(
     PlayReadyDeviceCredentials.from({
@@ -84,6 +122,7 @@ test('rejects already provisioned playready certificate chains when creating unp
 test('verifies certificate extdata signatures when EXTDATA is present', async () => {
   const prd = await loadPlayReadyClientData();
   const original = await PlayReadyDeviceCredentials.from({ prd });
+  assert(original.groupKey);
   const unpacked = original.unpack();
   const issuerChain = CertificateChain.from(unpacked['bgroupcert.dat']);
   const leafCertificate = await Certificate.newLeafCert({


### PR DESCRIPTION
## Summary

- Parse and roundtrip PRD v2 credentials that omit group keys.
- Preserve PRD v3 handling and reject unsupported or malformed versions.
- Prevent unpacking PRD v2 credentials without a group key.

## Testing

- Added Vitest coverage for PRD v2 roundtrips, unsupported versions, and invalid headers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791205573&installation_model_id=424872&pr_number=42&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F42&signature=0dfe5f9d743b5388939029f42226a241750838a208c85da12fad63a92b20f33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->