### PR TITLE
fix(playready): validate license response structure

### DIFF
--- a/src/lib/playready/session.ts
+++ b/src/lib/playready/session.ts
@@ -1,4 +1,4 @@
-import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { DOMParser, XMLSerializer, type Document, type Element } from '@xmldom/xmldom';
 import * as utils from '@noble/curves/utils.js';
 import { BaseMediaKeysEngineSession } from '../api';
 import {
@@ -41,34 +41,28 @@ import { WrmHeader } from './wrmheader';
 
 const DEFAULT_CLIENT_VERSION = '10.0.16384.10011';
 
-const getLocalName = (node: any) => node.localName ?? node.nodeName?.split(':').pop() ?? '';
+const getLocalName = (node: Element) => node.localName ?? node.nodeName.split(':').pop() ?? '';
 
-const findDirectChildByLocalName = (parent: any, localName: string) => {
-  for (let index = 0; index < parent.childNodes.length; index++) {
-    const child = parent.childNodes[index];
-    if (child.nodeType === child.ELEMENT_NODE && getLocalName(child) === localName) {
-      return child;
-    }
+const findDirectChildByLocalName = (parent: Element, localName: string) =>
+  findDescendantsByLocalName(parent, localName).find((child) => child.parentNode === parent) ??
+  null;
+
+const findDescendantsByLocalName = (parent: Document | Element, localName: string) =>
+  Array.from(parent.getElementsByTagName('*')).filter(
+    (element) => getLocalName(element) === localName,
+  );
+
+const findFirstDescendantByLocalName = (parent: Document | Element, localName: string) =>
+  findDescendantsByLocalName(parent, localName)[0] ?? null;
+
+const requireDirectChild = (parent: Element, localName: string) => {
+  const children = findDescendantsByLocalName(parent, localName).filter(
+    (child) => child.parentNode === parent,
+  );
+  if (children.length !== 1) {
+    throw new InvalidLicense(`Expected one ${localName} in ${getLocalName(parent)}`);
   }
-  return null;
-};
-
-const findDescendantsByLocalName = (parent: any, localName: string) => {
-  const matches: any[] = [];
-  const elements = parent.getElementsByTagName('*');
-
-  for (let index = 0; index < elements.length; index++) {
-    const element = elements[index];
-    if (getLocalName(element) === localName) {
-      matches.push(element);
-    }
-  }
-
-  return matches;
-};
-
-const findFirstDescendantByLocalName = (parent: any, localName: string) => {
-  return findDescendantsByLocalName(parent, localName)[0] ?? null;
+  return children[0]!;
 };
 
 type PlayReadySessionCredentials =
@@ -144,7 +138,11 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
       y: 68827801477692731286297993103001909218341737652466656881935707825713852622178n,
     };
 
-    this.parser = new DOMParser();
+    this.parser = new DOMParser({
+      onError: (_level, message) => {
+        throw new InvalidLicense(message);
+      },
+    });
     this.serializer = new XMLSerializer();
     this.#contentKeys = [];
     this.#dispose = dispose;
@@ -329,12 +327,32 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
 
   async parseLicense(rawLicense: string) {
     this.assertOpen();
-    const xmlDoc = this.parser.parseFromString(rawLicense, 'application/xml');
+    let xmlDoc: Document;
+    try {
+      xmlDoc = this.parser.parseFromString(rawLicense, 'application/xml');
+    } catch {
+      throw new InvalidLicense('Invalid license response XML');
+    }
     this.#throwIfSoapFault(xmlDoc);
-    await this.#verifySignedLicenseResponse(xmlDoc);
+    let root = xmlDoc.documentElement;
+    if (root && getLocalName(root) === 'Envelope') {
+      const body = requireDirectChild(root, 'Body');
+      root = requireDirectChild(body, 'AcquireLicenseResponse');
+    }
+    if (!root || getLocalName(root) !== 'AcquireLicenseResponse') {
+      throw new InvalidLicense('License root must be AcquireLicenseResponse or a SOAP Envelope');
+    }
+    const result = requireDirectChild(root, 'AcquireLicenseResult');
+    const response = requireDirectChild(result, 'Response');
+    const licenseResponse = requireDirectChild(response, 'LicenseResponse');
+    await this.#verifySignedLicenseResponse(response);
     this.assertOpen();
-    this.#mergeRevocationInfo(xmlDoc);
-    const licenseElements = findDescendantsByLocalName(xmlDoc, 'License');
+    const licenses = findDirectChildByLocalName(licenseResponse, 'Licenses');
+    const licenseElements = licenses
+      ? findDescendantsByLocalName(licenses, 'License').filter(
+          (license) => license.parentNode === licenses,
+        )
+      : [];
 
     const keys: Key[] = [];
 
@@ -413,10 +431,11 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
       }
     }
     this.assertOpen();
+    this.#mergeRevocationInfo(licenseResponse);
     return keys;
   }
 
-  #throwIfSoapFault(xmlDoc: any) {
+  #throwIfSoapFault(xmlDoc: Document) {
     const faultElement = findFirstDescendantByLocalName(xmlDoc, 'Fault');
     if (!faultElement) return;
 
@@ -428,10 +447,7 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     throw new ServerException(faultString);
   }
 
-  async #verifySignedLicenseResponse(xmlDoc: any) {
-    const responseElement = findFirstDescendantByLocalName(xmlDoc, 'Response');
-    if (!responseElement) return;
-
+  async #verifySignedLicenseResponse(responseElement: Element) {
     const licenseResponseElement = findDirectChildByLocalName(responseElement, 'LicenseResponse');
     const signatureElement = findDirectChildByLocalName(responseElement, 'Signature');
     if (!licenseResponseElement || !signatureElement) return;
@@ -484,7 +500,7 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     }
   }
 
-  #mergeRevocationInfo(xmlDoc: any) {
+  #mergeRevocationInfo(xmlDoc: Element) {
     const revInfoElement = findFirstDescendantByLocalName(xmlDoc, 'RevInfo');
     if (!revInfoElement) return;
 

--- a/test/playready.test.ts
+++ b/test/playready.test.ts
@@ -50,14 +50,14 @@ const buildRevocationListData = (listId: string, version: number) => {
 };
 
 const buildRevInfoResponse = (entries: Array<{ listId: string; version: number }>) =>
-  '<AcquireLicenseResponse><LicenseResponse><RevInfo>' +
+  '<AcquireLicenseResponse><AcquireLicenseResult><Response><LicenseResponse><RevInfo>' +
   entries
     .map(
       ({ listId, version }) =>
         `<Revocation><ListID>${listId}</ListID><ListData>${buildRevocationListData(listId, version)}</ListData></Revocation>`,
     )
     .join('') +
-  '</RevInfo></LicenseResponse></AcquireLicenseResponse>';
+  '</RevInfo></LicenseResponse></Response></AcquireLicenseResult></AcquireLicenseResponse>';
 
 const buildSignedLicenseResponse = async (
   signingKey: EccKey,
@@ -68,7 +68,7 @@ const buildSignedLicenseResponse = async (
 ) => {
   const xml = [
     '<AcquireLicenseResponse xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols">',
-    '<Response>',
+    '<AcquireLicenseResult><Response>',
     '<LicenseResponse>',
     '<Version>1</Version>',
     '<SigningCertificateChain>AA==</SigningCertificateChain>',
@@ -81,7 +81,7 @@ const buildSignedLicenseResponse = async (
     '</SignedInfo>',
     '<SignatureValue></SignatureValue>',
     '</Signature>',
-    '</Response>',
+    '</Response></AcquireLicenseResult>',
     '</AcquireLicenseResponse>',
   ].join('');
 
@@ -157,6 +157,92 @@ test('playready engine sessions include revocation-list versions and persist mer
   );
 });
 
+const wrapLicenseResponse = (content: string) =>
+  `<AcquireLicenseResponse><AcquireLicenseResult><Response><LicenseResponse>${content}</LicenseResponse></Response></AcquireLicenseResult></AcquireLicenseResponse>`;
+
+test.each([
+  '<html><body>upstream error</body></html>',
+  '<AcquireLicenseResponse/>',
+  '<AcquireLicenseResponse><AcquireLicenseResult/></AcquireLicenseResponse>',
+  '<AcquireLicenseResponse><AcquireLicenseResult><Response/></AcquireLicenseResult></AcquireLicenseResponse>',
+  `<html>${wrapLicenseResponse('')}</html>`,
+  '<Envelope><Body/></Envelope>',
+  wrapLicenseResponse('').replace('</Response>', '<LicenseResponse/></Response>'),
+  wrapLicenseResponse('<RevInfo>').replace('</LicenseResponse>', '</RevInfo>'),
+])('playready rejects invalid responses without changing session state: %s', async (xml) => {
+  const mergeRevocationInfo = vi.fn();
+  const session = new PlayReadySession(
+    'temporary',
+    {
+      certificateChain: new Uint8Array(),
+      encryptionKey: EccKey.generate().dumps(),
+      signingKey: EccKey.generate().dumps(),
+    },
+    undefined,
+    { mergeRevocationInfo },
+  );
+  const parseLicense = vi
+    .spyOn(session, 'parseLicense')
+    .mockResolvedValueOnce([new Key(new Uint8Array(16), 1, 3, new Uint8Array(16).fill(0xaa))]);
+  await session.update(new Uint8Array());
+  parseLicense.mockRestore();
+  const state = session.pause();
+  const keys = new Map(session.keys);
+  const statuses = new Map(session.keyStatuses);
+  const onKeysChange = vi.fn();
+  session.addEventListener('keyschange', onKeysChange);
+  session.addEventListener('keystatuseschange', onKeysChange);
+
+  await expect(session.parseLicense(xml)).rejects.toBeInstanceOf(InvalidLicense);
+  await expect(session.update(new TextEncoder().encode(xml))).rejects.toBeInstanceOf(
+    InvalidLicense,
+  );
+
+  expect(session.pause()).toBe(state);
+  expect(session.keys).toEqual(keys);
+  expect(session.keyStatuses).toEqual(statuses);
+  expect(onKeysChange).not.toHaveBeenCalled();
+  expect(mergeRevocationInfo).not.toHaveBeenCalled();
+});
+
+test.each([
+  wrapLicenseResponse(''),
+  wrapLicenseResponse('<Licenses/>'),
+  wrapLicenseResponse('<Acknowledgement><TransactionID>1</TransactionID></Acknowledgement>'),
+  `<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body>${wrapLicenseResponse('')}</soap:Body></soap:Envelope>`,
+  wrapLicenseResponse('')
+    .replaceAll('<Response>', '<pr:Response>')
+    .replaceAll('</Response>', '</pr:Response>')
+    .replace(
+      '<AcquireLicenseResponse>',
+      '<AcquireLicenseResponse xmlns:pr="http://schemas.microsoft.com/DRM/2007/03/protocols/messages">',
+    ),
+])('playready accepts valid responses without content keys: %s', async (xml) => {
+  const session = createPlayReady().createSession() as PlayReadySession;
+  await expect(session.parseLicense(xml)).resolves.toEqual([]);
+  await expect(session.update(new TextEncoder().encode(xml))).resolves.toBeUndefined();
+});
+
+test('playready does not merge revocation data when a license is invalid', async () => {
+  const mergeRevocationInfo = vi.fn();
+  const session = new PlayReadySession(
+    'temporary',
+    {
+      certificateChain: new Uint8Array(),
+      encryptionKey: EccKey.generate().dumps(),
+      signingKey: EccKey.generate().dumps(),
+    },
+    undefined,
+    { mergeRevocationInfo },
+  );
+  await expect(
+    session.parseLicense(
+      wrapLicenseResponse('<RevInfo/><Licenses><License>AA==</License></Licenses>'),
+    ),
+  ).rejects.toThrow();
+  expect(mergeRevocationInfo).not.toHaveBeenCalled();
+});
+
 test('playready parseLicense rejects unsupported cipher types', async () => {
   const session = new PlayReadySession('temporary', {
     certificateChain: new Uint8Array(),
@@ -192,7 +278,7 @@ test('playready parseLicense rejects unsupported cipher types', async () => {
 
   await expect(
     session.parseLicense(
-      '<AcquireLicenseResponse><LicenseResponse><Licenses><License>AA==</License></Licenses></LicenseResponse></AcquireLicenseResponse>',
+      '<AcquireLicenseResponse><AcquireLicenseResult><Response><LicenseResponse><Licenses><License>AA==</License></Licenses></LicenseResponse></Response></AcquireLicenseResult></AcquireLicenseResponse>',
     ),
   ).rejects.toThrowError(new InvalidLicense('Unsupported cipher type 999'));
 });
@@ -236,7 +322,7 @@ test('playready parseLicense rejects licenses with invalid integrity signatures'
 
   await expect(
     session.parseLicense(
-      '<AcquireLicenseResponse><LicenseResponse><Licenses><License>AA==</License></Licenses></LicenseResponse></AcquireLicenseResponse>',
+      '<AcquireLicenseResponse><AcquireLicenseResult><Response><LicenseResponse><Licenses><License>AA==</License></Licenses></LicenseResponse></Response></AcquireLicenseResult></AcquireLicenseResponse>',
     ),
   ).rejects.toThrowError(new InvalidLicense('License integrity signature does not match'));
   expect(decryptSpy).toHaveBeenCalledTimes(1);
@@ -266,7 +352,7 @@ test('playready parseLicense rejects licenses issued for another device key', as
 
   await expect(
     session.parseLicense(
-      '<AcquireLicenseResponse><LicenseResponse><Licenses><License>AA==</License></Licenses></LicenseResponse></AcquireLicenseResponse>',
+      '<AcquireLicenseResponse><AcquireLicenseResult><Response><LicenseResponse><Licenses><License>AA==</License></Licenses></LicenseResponse></Response></AcquireLicenseResult></AcquireLicenseResponse>',
     ),
   ).rejects.toThrowError(new InvalidLicense('Public encryption key does not match'));
 });


### PR DESCRIPTION
## Summary

- Validate PlayReady license XML structure before processing responses.
- Support direct and SOAP-wrapped license responses with namespaces.
- Prevent invalid responses from mutating session or revocation state.
- Add type-safe XML helpers and regression coverage.

## Testing

- Added coverage for malformed, incomplete, namespaced, SOAP-wrapped, and keyless responses.
- Added checks that invalid licenses preserve session state and do not merge revocation data.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206767&installation_model_id=424872&pr_number=45&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F45&signature=03930fa8c9d0890fe9a5c599eac0a7a19696fbf9a116c7902d9016651f643019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->