### PR TITLE
fix(cli): honor overrides and resolve devices unambiguously

### DIFF
--- a/examples/instance/README.md
+++ b/examples/instance/README.md
@@ -17,3 +17,10 @@ Run server:
 ```shell
 pnpm start
 ```
+
+`--host` and `--port` override the corresponding config values.
+
+Session requests can select a configured client by its exact path, filename, or filename without
+the extension. For `clients/client.wvd`, both `client.wvd` and `client` work. Partial names and
+ambiguous names are rejected. Omit `client` to select the first configured device. User allowlists
+use the same identifiers; use an exact path when filenames or extensionless names collide.

--- a/src/cli/commands/serve/api/session.ts
+++ b/src/cli/commands/serve/api/session.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { basename } from 'node:path';
+import { resolve } from 'node:path';
 import { Hono } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { z } from 'zod';
@@ -15,7 +15,7 @@ import {
 } from '../../../../lib';
 import { WidevineDeviceCredentials } from '../../../../lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '../../../../lib/playready/device-credentials';
-import { clients, config, sessions } from '../state';
+import { clients, config, resolveClient, sessions } from '../state';
 import { WidevineSession } from '../../../../lib/widevine/session';
 
 const app = new Hono();
@@ -47,15 +47,16 @@ app.post(
     }),
   ),
   async (c) => {
-    const clientName = c.req.valid('json').client || config.clients[0];
-    const clientPath = config.clients.find((client: string) =>
-      basename(client).includes(clientName),
-    );
+    const clientName = c.req.valid('json').client;
+    const defaultPath = config.clients[0];
+    const clientPath =
+      clientName === undefined ? defaultPath && resolve(defaultPath) : resolveClient(clientName);
 
     const secretKey = c.req.header('x-secret-key');
     if (secretKey) {
       const user = config.users[secretKey];
-      const clientAllowed = user?.clients.includes(clientName);
+      const clientAllowed =
+        clientPath && user?.clients.some((identifier) => resolveClient(identifier) === clientPath);
       if (!clientAllowed) {
         return c.json({ error: 'Client is not found or you are not authorized to use it.' }, 403);
       }
@@ -65,22 +66,22 @@ app.post(
       return c.json({ error: 'Client not found' }, 400);
     }
 
-    if (!clients.has(clientName)) {
+    if (!clients.has(clientPath)) {
       const clientData = await readFile(clientPath);
       const isWvd = fromBuffer(clientData.subarray(0, 3)).toText() == 'WVD';
       const isPrd = fromBuffer(clientData.subarray(0, 3)).toText() == 'PRD';
       if (isWvd) {
         const client = await WidevineDeviceCredentials.from({ wvd: clientData });
-        clients.set(clientName, client);
+        clients.set(clientPath, client);
       } else if (isPrd) {
         const client = await PlayReadyDeviceCredentials.from({ prd: clientData });
-        clients.set(clientName, client);
+        clients.set(clientPath, client);
       } else {
         return c.json({ error: 'Client is not a valid WVD or PRD file' }, 403);
       }
     }
 
-    const client = clients.get(clientName)!;
+    const client = clients.get(clientPath)!;
 
     const cdm =
       client instanceof WidevineDeviceCredentials

--- a/src/cli/commands/serve/serve.ts
+++ b/src/cli/commands/serve/serve.ts
@@ -1,5 +1,5 @@
 import { readdir } from 'node:fs/promises';
-import { basename, extname } from 'node:path';
+import { resolve } from 'node:path';
 import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import { secureHeaders } from 'hono/secure-headers';
@@ -29,9 +29,8 @@ export const serve = async (options: ServeOptions = {}) => {
   if (options.secret) {
     const anonymousUser = { name: 'anonymous', clients: [] };
     const user = config.users[options.secret] || anonymousUser;
-    const clientFilename = basename(options.client || config.clients.at(-1)!);
-    const clientName = clientFilename.replace(extname(clientFilename), '');
-    if (!user.clients.length) user.clients.push(clientName);
+    const clientPath = options.client ?? config.clients.at(-1);
+    if (!user.clients.length && clientPath) user.clients.push(resolve(clientPath));
     config.users[options.secret] = user;
   }
 
@@ -46,8 +45,8 @@ export const serve = async (options: ServeOptions = {}) => {
 
   const server = nodeServe({
     fetch: app.fetch,
-    port: config.port || 4000,
-    hostname: config.host || '0.0.0.0',
+    port: options.port ?? config.port ?? 4000,
+    hostname: options.host ?? config.host ?? '0.0.0.0',
   });
 
   process.on('SIGINT', () => {

--- a/src/cli/commands/serve/state.ts
+++ b/src/cli/commands/serve/state.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { basename, extname, resolve } from 'node:path';
 import { WidevineDeviceCredentials } from '../../../lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '../../../lib/playready/device-credentials';
 import { Session } from '../../../lib';
@@ -23,6 +24,22 @@ const defaultConfig = {
 };
 
 export const config: Config = defaultConfig;
+
+// Aliases must identify exactly one configured device, regardless of list order.
+export const resolveClient = (identifier: string) => {
+  const paths = new Set(
+    config.clients
+      .filter(
+        (path) =>
+          identifier === path ||
+          identifier === resolve(path) ||
+          identifier === basename(path) ||
+          identifier === basename(path, extname(path)),
+      )
+      .map((path) => resolve(path)),
+  );
+  return paths.size === 1 ? paths.values().next().value : undefined;
+};
 
 export const loadConfig = async (configPath: string) => {
   const data = await readFile(configPath, { encoding: 'utf-8' })

--- a/test/privacy.test.ts
+++ b/test/privacy.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Hono } from 'hono';
 import { fromBase64, Remote, Session, PlayReady, PlayReadyDeviceCredentials } from '../src/lib';
@@ -18,7 +19,7 @@ beforeEach(async () => {
   config.clients = ['test.wvd'];
   config.users = {};
   config.forcePrivacyMode = true;
-  clients.set('test.wvd', await loadWidevineDeviceCredentials());
+  clients.set(resolve('test.wvd'), await loadWidevineDeviceCredentials());
 });
 
 afterEach(() => {
@@ -149,7 +150,7 @@ test('PlayReady rejects server certificates, forced privacy, and CLI encrypt', a
   });
   const engine = new PlayReady({ deviceCredentials });
   await expect(engine.setServerCertificate()).rejects.toThrow('unsupported');
-  clients.set('test.wvd', deviceCredentials);
+  clients.set(resolve('test.wvd'), deviceCredentials);
   const session = await connect().createSession();
   await expect(session.generateRequest(initData)).rejects.toThrow(
     'Forced privacy mode is unsupported',

--- a/test/serve-devices.test.ts
+++ b/test/serve-devices.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import sessionApi from '../src/cli/commands/serve/api/session';
+import { clients, config, sessions } from '../src/cli/commands/serve/state';
+import { loadWidevineClientData } from './utils';
+
+const originalConfig = structuredClone(config);
+let directory: string;
+let clientPath: string;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'okova-devices-'));
+  clientPath = join(directory, 'client.wvd');
+  await writeFile(clientPath, await loadWidevineClientData());
+  config.clients = [relative(process.cwd(), clientPath)];
+  config.users = {};
+});
+
+afterEach(async () => {
+  for (const session of sessions.values()) await session.close();
+  sessions.clear();
+  clients.clear();
+  Object.assign(config, originalConfig);
+  await rm(directory, { recursive: true, force: true });
+});
+
+const open = (client?: string, secret?: string) =>
+  sessionApi.request('/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(secret ? { 'x-secret-key': secret } : {}) },
+    body: JSON.stringify({ client }),
+  });
+
+test('default, name, filename and exact paths share one device cache entry', async () => {
+  for (const identifier of [undefined, 'client', 'client.wvd', config.clients[0], clientPath]) {
+    const response = await open(identifier);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveProperty('id');
+  }
+  expect([...clients.keys()]).toEqual([resolve(clientPath)]);
+});
+
+test('default and filename requests authorize against the resolved device', async () => {
+  config.users = { secret: { name: 'test', clients: ['client'] } };
+  expect((await open(undefined, 'secret')).status).toBe(200);
+  expect((await open('client.wvd', 'secret')).status).toBe(200);
+  expect((await open('client', 'unknown')).status).toBe(403);
+});
+
+test('rejects substrings, empty identifiers and unknown clients', async () => {
+  for (const identifier of ['cli', 'wvd', '', 'missing']) {
+    expect((await open(identifier)).status).toBe(400);
+  }
+  expect(clients.size).toBe(0);
+});
+
+test('overlapping names cannot select or authorize the wrong device', async () => {
+  const otherPath = join(directory, 'client-extra.wvd');
+  await writeFile(otherPath, await loadWidevineClientData());
+  config.clients.unshift(otherPath);
+  config.users = { secret: { name: 'test', clients: ['client'] } };
+  expect((await open('client', 'secret')).status).toBe(200);
+  expect([...clients.keys()]).toEqual([clientPath]);
+  expect((await open(undefined, 'secret')).status).toBe(403);
+});
+
+test('ambiguous aliases fail while exact paths and the default remain usable', async () => {
+  const otherPath = join(directory, 'client.prd');
+  config.clients.push(otherPath);
+  expect((await open('client')).status).toBe(400);
+  expect((await open('client.wvd')).status).toBe(200);
+  expect((await open(clientPath)).status).toBe(200);
+  expect((await open()).status).toBe(200);
+  config.users = { secret: { name: 'test', clients: ['client'] } };
+  expect((await open(clientPath, 'secret')).status).toBe(403);
+  config.users.secret.clients = [clientPath];
+  expect((await open('client.wvd', 'secret')).status).toBe(200);
+});
+
+test('no configured device returns a client error', async () => {
+  config.clients = [];
+  expect((await open()).status).toBe(400);
+});

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -1,0 +1,62 @@
+import { once } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as nodeServer from '@hono/node-server';
+import { expect, test, vi } from 'vitest';
+import { serve } from '../src/cli/commands/serve/serve';
+import { config } from '../src/cli/commands/serve/state';
+
+vi.mock('@hono/node-server', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@hono/node-server')>();
+  return { ...original, serve: vi.fn(original.serve) };
+});
+
+test.each([true, false])('binds using CLI overrides when supplied: %s', async (hasOverrides) => {
+  const directory = await mkdtemp(join(tmpdir(), 'okova-serve-'));
+  const configPath = join(directory, 'config.json');
+  const originalConfig = structuredClone(config);
+  const originalListeners = {
+    SIGINT: process.listeners('SIGINT'),
+    SIGTERM: process.listeners('SIGTERM'),
+  };
+  const startServer = vi.mocked(nodeServer.serve);
+  startServer.mockClear();
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      host: hasOverrides ? '192.0.2.1' : '127.0.0.1',
+      port: hasOverrides ? 1 : 0,
+      clients: ['clients/client.wvd'],
+      users: {},
+    }),
+  );
+
+  try {
+    await serve({
+      config: configPath,
+      ...(hasOverrides ? { host: '127.0.0.1', port: 0 } : {}),
+    });
+    const server = startServer.mock.results[0]?.value;
+    expect(server).toBeDefined();
+    if (!server) return;
+    if (!server.listening) await once(server, 'listening');
+    const address = server.address();
+    expect(address).toMatchObject({ address: '127.0.0.1' });
+    expect(address && typeof address !== 'string' && address.port).toBeGreaterThan(0);
+  } finally {
+    const server = startServer.mock.results[0]?.value;
+    if (server?.listening)
+      await new Promise<void>((resolve, reject) => {
+        server.close((error?: Error) => (error ? reject(error) : resolve()));
+      });
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+      for (const listener of process.listeners(signal)) {
+        if (!originalListeners[signal].includes(listener)) process.removeListener(signal, listener);
+      }
+    }
+    Object.assign(config, originalConfig);
+    vi.restoreAllMocks();
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Honor CLI host and port overrides over config values.
- Resolve configured clients by exact path, filename, or extensionless filename.
- Reject ambiguous or partial client identifiers and align authorization with resolved paths.
- Add coverage for device selection, authorization, and server binding behavior.

## Testing

- `pnpm vitest run test/serve-devices.test.ts test/serve.test.ts test/privacy.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206869&installation_model_id=424872&pr_number=46&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F46&signature=d8b1aaa972d12cc0c278d08cad40406a416317fc60d4ed8949e3f6c666b86105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->