### PR TITLE
fix(extension): serialize key history mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Okova is a set of tools (JavaScript library, command-line utility and browser ex
 
 ### Installation
 
-> Command-line tool installation requires pre-installed JavaScript runtime (e.g. [Node.js](https://nodejs.org/en/download)).
+> Command-line tool installation requires a pre-installed JavaScript runtime, such as [Node.js](https://nodejs.org/en/download) 24.5.0 or later.
 
 ```bash
 npm install -g okova
@@ -84,7 +84,7 @@ oem_crypto_build_information: OEMCrypto Level3 Code 8162 May  9 2018 14:01:12
 
 ## JavaScript library
 
-> Library installation requires pre-installed JavaScript runtime (e.g. [Node.js](https://nodejs.org/en/download)).
+> Library installation requires a pre-installed JavaScript runtime, such as [Node.js](https://nodejs.org/en/download) 24.5.0 or later.
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     }
   },
   "engines": {
-    "node": ">=22.19"
+    "node": ">=24.5.0"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.4",

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -17,7 +17,6 @@ export const Keys = () => {
 
   const clearKeys = async () => {
     await appStorage.allKeys.clear();
-    await appStorage.recentKeys.setValue([]);
     setKeys([]);
   };
 

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -74,15 +74,24 @@ const fromClientToInfo = async (client: Client): Promise<ClientInfo> => {
   return { type, data };
 };
 
+// A shared browser lock serializes background and popup writes, including clears.
+// Call raw setters inside the lock to avoid acquiring the same lock recursively.
+const mutateKeyHistory = (mutation: () => Promise<void>) =>
+  navigator.locks.request('okova:key-history', mutation);
+
+const recentKeys = asJson(storage.defineItem<KeyInfo[]>('local:recent-keys'));
+
 export const appStorage = {
   settings: asJson(storage.defineItem<Settings>('local:settings')),
 
-  recentKeys: asJson(storage.defineItem<KeyInfo[]>('local:recent-keys')),
+  recentKeys: {
+    ...recentKeys,
+    setValue: (keys: KeyInfo[]) => mutateKeyHistory(() => recentKeys.setValue(keys)),
+  },
   recentKeysByDomain: {
     raw: asJson(storage.defineItem<RecentKeysByDomain>('local:recent-keys-by-domain')),
-    setValue: async (keys: RecentKeysByDomain) => {
-      await appStorage.recentKeysByDomain.raw.setValue(keys);
-    },
+    setValue: (keys: RecentKeysByDomain) =>
+      mutateKeyHistory(() => appStorage.recentKeysByDomain.raw.setValue(keys)),
     getValue: async () => {
       return appStorage.recentKeysByDomain.raw.getValue();
     },
@@ -91,50 +100,50 @@ export const appStorage = {
     ) => {
       return appStorage.recentKeysByDomain.raw.watch(callback);
     },
-    clear: async () => {
-      await appStorage.recentKeysByDomain.raw.setValue({});
-    },
+    clear: () => mutateKeyHistory(() => appStorage.recentKeysByDomain.raw.setValue({})),
     setForUrl: async (url: string | undefined, keys: KeyInfo[]) => {
       const domain = getWebsiteDomain(url);
       if (!domain) return;
 
-      const keysByDomain = (await appStorage.recentKeysByDomain.getValue()) || {};
-      await appStorage.recentKeysByDomain.setValue({ ...keysByDomain, [domain]: keys });
+      await mutateKeyHistory(async () => {
+        const keysByDomain = (await appStorage.recentKeysByDomain.getValue()) || {};
+        await appStorage.recentKeysByDomain.raw.setValue({ ...keysByDomain, [domain]: keys });
+      });
     },
   },
   allKeys: {
     raw: asJson(storage.defineItem<KeyInfo[]>('local:all-keys')),
-    setValue: async (keys: KeyInfo[]) => {
-      await appStorage.allKeys.raw.setValue(keys);
-    },
+    setValue: (keys: KeyInfo[]) => mutateKeyHistory(() => appStorage.allKeys.raw.setValue(keys)),
     getValue: async () => {
       return appStorage.allKeys.raw.getValue();
     },
-    clear: async () => {
-      await appStorage.allKeys.raw.setValue([]);
-      await appStorage.recentKeys.setValue([]);
-      await appStorage.recentKeysByDomain.clear();
-    },
-    add: async (...newKeys: KeyInfo[]) => {
-      const keys = (await appStorage.allKeys.getValue()) || [];
-      for (const newKey of newKeys) {
-        const index = keys.findIndex((key) => key.id === newKey.id);
-        if (index === -1) {
-          keys.push(newKey);
-        } else if (!isCapturedKey(keys[index]!) && isCapturedKey(newKey)) {
-          keys[index] = newKey;
+    clear: () =>
+      mutateKeyHistory(async () => {
+        await appStorage.allKeys.raw.setValue([]);
+        await recentKeys.setValue([]);
+        await appStorage.recentKeysByDomain.raw.setValue({});
+      }),
+    add: (...newKeys: KeyInfo[]) =>
+      mutateKeyHistory(async () => {
+        const keys = (await appStorage.allKeys.getValue()) || [];
+        for (const newKey of newKeys) {
+          const index = keys.findIndex((key) => key.id === newKey.id);
+          if (index === -1) {
+            keys.push(newKey);
+          } else if (!isCapturedKey(keys[index]!) && isCapturedKey(newKey)) {
+            keys[index] = newKey;
+          }
         }
-      }
-      await appStorage.allKeys.setValue(keys);
-    },
-    remove: async (key: KeyInfo) => {
-      const keys = (await appStorage.allKeys.getValue()) || [];
-      keys.splice(
-        keys.findIndex((k) => k.id === key.id),
-        1,
-      );
-      await appStorage.allKeys.setValue(keys);
-    },
+        await appStorage.allKeys.raw.setValue(keys);
+      }),
+    remove: (key: KeyInfo) =>
+      mutateKeyHistory(async () => {
+        const keys = (await appStorage.allKeys.getValue()) || [];
+        const index = keys.findIndex((storedKey) => storedKey.id === key.id);
+        if (index === -1) return;
+        keys.splice(index, 1);
+        await appStorage.allKeys.raw.setValue(keys);
+      }),
   },
 
   clients: {

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -56,6 +56,83 @@ test('upgrades a status within the same batch while retaining distinct key IDs',
   expect(await appStorage.allKeys.getValue()).toEqual([key, otherKey]);
 });
 
+test('retains every key from concurrent captures', async () => {
+  const captures = Array.from({ length: 10 }, (_, index) => ({
+    ...key,
+    id: index.toString(16).padStart(32, '0'),
+  }));
+
+  await Promise.all(captures.map((capture) => appStorage.allKeys.add(capture)));
+
+  expect(await appStorage.allKeys.getValue()).toEqual(captures);
+});
+
+test('retains recent keys for different domains during concurrent captures', async () => {
+  const otherKey = { ...key, url: 'https://other.example/video' };
+
+  await Promise.all([
+    appStorage.recentKeysByDomain.setForUrl(key.url, [key]),
+    appStorage.recentKeysByDomain.setForUrl(otherKey.url, [otherKey]),
+  ]);
+
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({
+    'example.com': [key],
+    'other.example': [otherKey],
+  });
+});
+
+test('serializes status upgrades and duplicate captures', async () => {
+  await Promise.all([
+    appStorage.allKeys.add({ ...key, value: 'usable' }),
+    appStorage.allKeys.add(key),
+    appStorage.allKeys.add({ ...key, value: 'expired' }),
+  ]);
+
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+});
+
+test('serializes removals with captures and ignores repeated removals', async () => {
+  const otherKey = { ...key, id: '112233445566778899aabbccddeeff00' };
+  await appStorage.allKeys.add(key);
+
+  await Promise.all([
+    appStorage.allKeys.add(otherKey),
+    appStorage.allKeys.remove(key),
+    appStorage.allKeys.remove(key),
+  ]);
+
+  expect(await appStorage.allKeys.getValue()).toEqual([otherKey]);
+});
+
+test('clears history after pending writes without restoring stale entries', async () => {
+  await Promise.all([
+    appStorage.allKeys.add(key),
+    appStorage.recentKeys.setValue([key]),
+    appStorage.recentKeysByDomain.setForUrl(key.url, [key]),
+    appStorage.allKeys.clear(),
+  ]);
+
+  expect(await appStorage.allKeys.getValue()).toEqual([]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({});
+});
+
+test('releases the lock after a failed write and reports the failure', async () => {
+  const error = new Error('Storage write failed');
+  vi.spyOn(appStorage.allKeys.raw, 'setValue').mockRejectedValueOnce(error);
+
+  const results = await Promise.allSettled([
+    appStorage.allKeys.add(key),
+    appStorage.allKeys.add(key),
+  ]);
+
+  expect(results).toEqual([
+    { status: 'rejected', reason: error },
+    { status: 'fulfilled', value: undefined },
+  ]);
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+});
+
 const startBackground = () => {
   const addListener = vi.spyOn(browser.runtime.onMessage, 'addListener');
   vi.spyOn(browser.tabs, 'query').mockImplementation(async () => []);


### PR DESCRIPTION
## Summary

- Serialize key history writes, removals, clears, and updates with a shared browser lock.
- Prevent concurrent captures from losing keys or restoring stale history after clears.
- Add regression coverage for concurrent mutations and failed writes.

## Testing

- Added tests covering concurrent captures, domain histories, status upgrades, removals, clears, and lock recovery after write failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206923&installation_model_id=424872&pr_number=47&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F47&signature=9146e7896e6a18b0c51126bcfb6442d0117ca35a6e4c543f9d45d03aea07cfb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->