### PR TITLE
fix(cli): preserve colons in license headers

### DIFF
--- a/src/cli/commands/license/license.ts
+++ b/src/cli/commands/license/license.ts
@@ -13,7 +13,11 @@ type LicenseCommandParams = {
 
 export const license = async (params: LicenseCommandParams) => {
   const headers = Object.fromEntries(
-    params.headers?.map((header) => header.split(':').map((s) => s.trim())) || [],
+    params.headers?.map((header) => {
+      const separator = header.indexOf(':');
+      if (separator === -1) return [header.trim()];
+      return [header.slice(0, separator).trim(), header.slice(separator + 1).trim()];
+    }) || [],
   );
   const client = await importClient(params.clientPath || process.cwd());
   const cdm =


### PR DESCRIPTION
## Summary

- Split license header arguments only at the first colon.
- Preserve additional colons in header values.
- Trim header names and values as before.

## Testing

- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791207157&installation_model_id=424872&pr_number=48&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F48&signature=d54fc7406ac986fcd684ee6da577c126111124e088a3d1a86ee3350174543d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->