### PR TITLE
fix(extension): persist DRM sessions across worker restarts

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -15,10 +15,27 @@ import { getMessageType } from '@okova/lib/widevine/message';
 import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
 import { Session } from '@okova/lib/api';
+import { z } from 'zod';
 
 const SESSION_IDLE_TIMEOUT_MS = 5 * 60_000;
 
+const SESSION_STORAGE_PREFIX = 'pending-session:';
+const storedSessionSchema = z.object({
+  state: z.string(),
+  client: z.discriminatedUnion('type', [
+    z.object({ type: z.literal('wvd'), data: z.string() }),
+    z.object({ type: z.literal('prd'), data: z.string() }),
+  ]),
+  tabId: z.number().optional(),
+  expiresAt: z.number(),
+  serverCertificate: z.string().optional(),
+  challenge: z.string(),
+});
+
 type SessionEntry = {
+  client: z.infer<typeof storedSessionSchema>['client'];
+  expiresAt: number;
+  challenge: string;
   session: Session;
   tabId: number | undefined;
   timer: ReturnType<typeof setTimeout>;
@@ -40,6 +57,7 @@ export default defineBackground({
 
     const closeSession = async (id: string) => {
       const entry = state.sessions.get(id);
+      await browser.storage.session.remove(SESSION_STORAGE_PREFIX + id);
       if (!entry) return;
       state.sessions.delete(id);
       clearTimeout(entry.timer);
@@ -50,9 +68,96 @@ export default defineBackground({
       }
     };
 
+    // Serialize work for each owner without delaying unrelated sessions.
+    const pending = new Map<string, Promise<unknown>>();
+    const runForSession = (id: string, action: () => Promise<void>) => {
+      const operation = (pending.get(id) ?? restored).then(action);
+      const settled = operation.catch((error: unknown) => {
+        console.warn('[okova] Unable to process DRM session', error);
+      });
+      pending.set(id, settled);
+      void settled.then(() => {
+        if (pending.get(id) === settled) pending.delete(id);
+      });
+      return operation;
+    };
+
+    const scheduleExpiry = (id: string, expiresAt: number) =>
+      setTimeout(
+        () => {
+          void runForSession(id, async () => {
+            const entry = state.sessions.get(id);
+            if (entry && entry.expiresAt <= Date.now()) await closeSession(id);
+          });
+        },
+        Math.max(0, expiresAt - Date.now()),
+      );
+
+    const persistSession = async (id: string, entry: SessionEntry) => {
+      await browser.storage.session.set({
+        [SESSION_STORAGE_PREFIX + id]: {
+          state: entry.session.pause(),
+          client: entry.client,
+          tabId: entry.tabId,
+          expiresAt: entry.expiresAt,
+          serverCertificate: entry.serverCertificate,
+          challenge: entry.challenge,
+        } satisfies z.infer<typeof storedSessionSchema>,
+      });
+    };
+
+    const invalidatedTabs = new Set<number>();
+    let isRestoring = true;
+    const restored = (async () => {
+      const records = await browser.storage.session.get(null);
+      for (const [key, value] of Object.entries(records)) {
+        if (!key.startsWith(SESSION_STORAGE_PREFIX)) continue;
+        const id = key.slice(SESSION_STORAGE_PREFIX.length);
+        try {
+          const record = storedSessionSchema.parse(value);
+          if (record.expiresAt <= Date.now()) {
+            await browser.storage.session.remove(key);
+            continue;
+          }
+          const data = fromBase64(record.client.data).toBuffer();
+          const engine =
+            record.client.type === 'wvd'
+              ? new Widevine({
+                  deviceCredentials: await WidevineDeviceCredentials.from({ wvd: data }),
+                })
+              : new PlayReady({
+                  deviceCredentials: await PlayReadyDeviceCredentials.from({ prd: data }),
+                });
+          if (record.serverCertificate && engine instanceof Widevine) {
+            await engine.setServerCertificate(fromBase64(record.serverCertificate).toBuffer());
+          }
+          if (record.tabId !== undefined && invalidatedTabs.has(record.tabId)) {
+            await browser.storage.session.remove(key);
+            continue;
+          }
+          state.sessions.set(id, {
+            ...record,
+            tabId: record.tabId,
+            serverCertificate: record.serverCertificate,
+            session: Session.resume(record.state, engine),
+            timer: scheduleExpiry(id, record.expiresAt),
+          });
+        } catch (error) {
+          await browser.storage.session.remove(key);
+          console.warn('[okova] Unable to restore DRM session', error);
+        }
+      }
+      isRestoring = false;
+      invalidatedTabs.clear();
+    })();
+
     const closeTabSessions = (tabId: number) => {
-      for (const [id, entry] of state.sessions) {
-        if (entry.tabId === tabId) void closeSession(id);
+      if (isRestoring) invalidatedTabs.add(tabId);
+      for (const id of new Set([...state.sessions.keys(), ...pending.keys()])) {
+        const owner: unknown = JSON.parse(id);
+        if (Array.isArray(owner) && owner[0] === tabId) {
+          void runForSession(id, () => closeSession(id));
+        }
       }
     };
     browser.tabs.onRemoved.addListener(closeTabSessions);
@@ -174,16 +279,22 @@ export default defineBackground({
               message.sessionToken,
             ])
           : undefined;
-      (async () => {
+      const handleMessage = async () => {
         if (message.action === 'close') {
           if (sessionKey) await closeSession(sessionKey);
           sendResponse();
           return;
         }
+        if (sessionKey) {
+          const current = state.sessions.get(sessionKey);
+          if (current && current.expiresAt <= Date.now()) await closeSession(sessionKey);
+        }
         const entry = sessionKey ? state.sessions.get(sessionKey) : undefined;
         if (sessionKey && entry) {
           clearTimeout(entry.timer);
-          entry.timer = setTimeout(() => void closeSession(sessionKey), SESSION_IDLE_TIMEOUT_MS);
+          entry.expiresAt = Date.now() + SESSION_IDLE_TIMEOUT_MS;
+          entry.timer = scheduleExpiry(sessionKey, entry.expiresAt);
+          await persistSession(sessionKey, entry);
         }
         console.log('[okova] Received message', message);
 
@@ -258,15 +369,25 @@ export default defineBackground({
           const mediaKeys = await keySystemAccess.createMediaKeys();
           const session = mediaKeys.createSession();
           // Close after five minutes of inactivity, including silently removed frames.
-          const timer = setTimeout(() => void closeSession(sessionKey), SESSION_IDLE_TIMEOUT_MS);
+          const clientData = fromBuffer(await cdm.deviceCredentials.pack()).toBase64();
+          const expiresAt = Date.now() + SESSION_IDLE_TIMEOUT_MS;
+          const timer = scheduleExpiry(sessionKey, expiresAt);
           const entry: SessionEntry = {
             session,
+            client: {
+              type: cdm instanceof Widevine ? 'wvd' : 'prd',
+              data: clientData,
+            },
+            expiresAt,
+            challenge: '',
             tabId: sender.tab?.id,
             timer,
             serverCertificate,
           };
           state.sessions.set(sessionKey, entry);
           await session.generateRequest(message.initDataType, fromBase64(initData).toBuffer());
+          entry.challenge = fromBuffer(await session.waitForLicenseRequest()).toBase64();
+          await persistSession(sessionKey, entry);
           sendResponse();
           return;
         }
@@ -296,41 +417,52 @@ export default defineBackground({
               ),
             );
             sessionEntry.serverCertificate = serverCertificate;
+            sessionEntry.challenge = fromBuffer(await session.waitForLicenseRequest()).toBase64();
           }
-          const challenge = await session.waitForLicenseRequest();
-          sendResponse(fromBuffer(challenge).toBase64());
+          await persistSession(sessionKey, sessionEntry);
+          sendResponse(sessionEntry.challenge);
         } else if (message.action === 'update') {
           const response = parseBinary(message.message);
           const isServiceCertificate =
             session.engine instanceof Widevine && getMessageType(response) === 5;
           await session.update(response);
           if (isServiceCertificate) {
+            sessionEntry.challenge = fromBuffer(await session.waitForLicenseRequest()).toBase64();
+            await persistSession(sessionKey, sessionEntry);
             sendResponse();
             return;
           }
 
-          try {
-            const keys = await session.waitForKeyStatusesChange();
-            const results = Array.from(keys, ([id, value]) => ({
-              id,
-              value,
-              url: message.url,
-              mpd: message.mpd,
-              pssh: message.initData,
-              createdAt: new Date().getTime(),
-            }));
-            await setRecentKeys(results);
-            await appStorage.allKeys.add(...results);
-            sendResponse({ keys: results });
-          } finally {
-            await closeSession(sessionKey);
-          }
+          const keys = await session.waitForKeyStatusesChange();
+          const results = Array.from(keys, ([id, value]) => ({
+            id,
+            value,
+            url: message.url,
+            mpd: message.mpd,
+            pssh: message.initData,
+            createdAt: new Date().getTime(),
+          }));
+          await setRecentKeys(results);
+          await appStorage.allKeys.add(...results);
+          await closeSession(sessionKey);
+          sendResponse({ keys: results });
         } else {
           sendResponse();
         }
-      })().catch(async (error: unknown) => {
-        if (sessionKey) await closeSession(sessionKey);
-        console.warn('[okova] DRM request failed', error);
+      };
+      const handleSafely = async () => {
+        try {
+          await handleMessage();
+        } catch (error: unknown) {
+          if (sessionKey) await closeSession(sessionKey);
+          console.warn('[okova] DRM request failed', error);
+          sendResponse();
+        }
+      };
+      void (
+        sessionKey ? runForSession(sessionKey, handleSafely) : restored.then(handleSafely)
+      ).catch((error: unknown) => {
+        console.warn('[okova] DRM session storage failed', error);
         sendResponse();
       });
       return true;

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -57,14 +57,16 @@ export default defineBackground({
 
     const closeSession = async (id: string) => {
       const entry = state.sessions.get(id);
-      await browser.storage.session.remove(SESSION_STORAGE_PREFIX + id);
-      if (!entry) return;
       state.sessions.delete(id);
-      clearTimeout(entry.timer);
+      if (entry) clearTimeout(entry.timer);
       try {
-        await entry.session.close();
-      } catch (error) {
-        console.warn('[okova] Unable to close DRM session', error);
+        await browser.storage.session.remove(SESSION_STORAGE_PREFIX + id);
+      } finally {
+        try {
+          await entry?.session.close();
+        } catch (error) {
+          console.warn('[okova] Unable to close DRM session', error);
+        }
       }
     };
 
@@ -85,15 +87,18 @@ export default defineBackground({
     const scheduleExpiry = (id: string, expiresAt: number) =>
       setTimeout(
         () => {
-          void runForSession(id, async () => {
-            const entry = state.sessions.get(id);
-            if (entry && entry.expiresAt <= Date.now()) await closeSession(id);
-          });
+          const entry = state.sessions.get(id);
+          if (entry && entry.expiresAt <= Date.now()) {
+            void closeSession(id).catch((error: unknown) => {
+              console.warn('[okova] Unable to expire DRM session', error);
+            });
+          }
         },
         Math.max(0, expiresAt - Date.now()),
       );
 
     const persistSession = async (id: string, entry: SessionEntry) => {
+      if (state.sessions.get(id) !== entry) throw new Error('DRM session closed');
       await browser.storage.session.set({
         [SESSION_STORAGE_PREFIX + id]: {
           state: entry.session.pause(),
@@ -104,6 +109,11 @@ export default defineBackground({
           challenge: entry.challenge,
         } satisfies z.infer<typeof storedSessionSchema>,
       });
+      // A lifecycle close can interrupt an in-flight storage write.
+      if (state.sessions.get(id) !== entry) {
+        await browser.storage.session.remove(SESSION_STORAGE_PREFIX + id);
+        throw new Error('DRM session closed');
+      }
     };
 
     const invalidatedTabs = new Set<number>();
@@ -147,16 +157,28 @@ export default defineBackground({
           console.warn('[okova] Unable to restore DRM session', error);
         }
       }
-      isRestoring = false;
-      invalidatedTabs.clear();
-    })();
+    })()
+      .catch((error: unknown) => {
+        console.warn('[okova] Unable to restore pending DRM sessions', error);
+      })
+      .finally(() => {
+        isRestoring = false;
+        invalidatedTabs.clear();
+      });
 
     const closeTabSessions = (tabId: number) => {
       if (isRestoring) invalidatedTabs.add(tabId);
       for (const id of new Set([...state.sessions.keys(), ...pending.keys()])) {
         const owner: unknown = JSON.parse(id);
         if (Array.isArray(owner) && owner[0] === tabId) {
-          void runForSession(id, () => closeSession(id));
+          // Active sessions must close now to unblock pending key-status waits.
+          // A session still loading its client is cleaned up once it is created.
+          const closing = state.sessions.has(id)
+            ? closeSession(id)
+            : runForSession(id, () => closeSession(id));
+          void closing.catch((error: unknown) => {
+            console.warn('[okova] Unable to close tab DRM session', error);
+          });
         }
       }
     };

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -9,7 +9,11 @@ import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credential
 
 // No device credentials or license server are needed to exercise the background flow.
 vi.mock('../src/lib/widevine/device-credentials', () => ({
-  WidevineDeviceCredentials: class {},
+  WidevineDeviceCredentials: class {
+    async pack() {
+      return new Uint8Array();
+    }
+  },
 }));
 
 const key: KeyInfo = {
@@ -91,6 +95,8 @@ test('captures keys after logging a status with spoofing disabled', async () => 
     .mockResolvedValue(new WidevineDeviceCredentials(new Uint8Array()));
   const createSession = vi.spyOn(Widevine.prototype, 'createSession');
   const generateRequest = vi.spyOn(Session.prototype, 'generateRequest').mockResolvedValue();
+  vi.spyOn(Session.prototype, 'pause').mockReturnValue('{}');
+  vi.spyOn(Session.prototype, 'waitForLicenseRequest').mockResolvedValue(new Uint8Array());
   vi.spyOn(Session.prototype, 'update').mockResolvedValue();
   vi.spyOn(Session.prototype, 'waitForKeyStatusesChange').mockResolvedValue(
     new Map([[key.id, key.value]]),

--- a/test/extension-session-restart.test.ts
+++ b/test/extension-session-restart.test.ts
@@ -1,0 +1,188 @@
+import { readFile } from 'node:fs/promises';
+import { generateKeyPairSync } from 'node:crypto';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { browser, type Browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing';
+import background from '../src/extension/entrypoints/background';
+import { appStorage } from '../src/extension/utils/storage';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import { PlayReadyDeviceCredentials } from '../src/lib/playready/device-credentials';
+import { fromBase64, fromBuffer, toBufferSource } from '../src/lib/utils';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+  License,
+  LicenseRequest,
+  SignedMessage,
+} from '../src/lib/widevine/proto';
+import { deriveContext, deriveKeys } from '../src/lib/widevine/context';
+import {
+  createHmacSha256,
+  encryptWithAesCbc,
+  importAesCbcKeyForEncrypt,
+} from '../src/lib/crypto/common';
+
+const initData =
+  'AAAAW3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADsIARIQ62dqu8s0Xpa7z2FmMPGj2hoNd2lkZXZpbmVfdGVzdCIQZmtqM2xqYVNkZmFsa3IzaioCSEQyAA==';
+const sender: Browser.runtime.MessageSender = { frameId: 0, documentId: 'document' };
+const pendingRecords = async () =>
+  Object.entries(await browser.storage.session.get(null)).filter(([key]) =>
+    key.startsWith('pending-session:'),
+  );
+
+const startWorker = () => {
+  const now = Date.now();
+  vi.clearAllTimers();
+  vi.setSystemTime(now);
+  const listener = vi.spyOn(browser.runtime.onMessage, 'addListener');
+  background.main();
+  const onMessage = listener.mock.calls.at(-1)![0];
+  return (action: string, token = 'one', extra: Record<string, unknown> = {}) =>
+    new Promise<unknown>((resolve) => {
+      onMessage(
+        {
+          action,
+          sessionToken: token,
+          initData,
+          initDataType: 'cenc',
+          url: 'https://example.com/video',
+          ...extra,
+        },
+        sender,
+        resolve,
+      );
+    });
+};
+
+beforeEach(async () => {
+  fakeBrowser.reset();
+  vi.useFakeTimers();
+  vi.spyOn(browser.tabs, 'query').mockImplementation(async () => []);
+  await appStorage.settings.setValue({
+    spoofing: true,
+    emeInterception: true,
+    requestInterception: false,
+    theme: 'auto',
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+const wvdPath = process.env.VITEST_WVD_PATH;
+const prdPath = process.env.VITEST_PRD_PATH;
+
+const loadWidevineClient = async () => {
+  if (wvdPath) return WidevineDeviceCredentials.from({ wvd: await readFile(wvdPath) });
+  // A local RSA client keeps the restart regression runnable without device files.
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+  const client = new WidevineDeviceCredentials(
+    ClientIdentification.create({
+      token: SignedDrmCertificate.encode(
+        SignedDrmCertificate.create({
+          drmCertificate: DrmCertificate.encode(DrmCertificate.create({ systemId: 1 })).finish(),
+        }),
+      ).finish(),
+    }),
+  );
+  await client.importKey(privateKey);
+  return client;
+};
+
+test('restores the original Widevine challenge and decrypts a license after worker termination', async () => {
+  const client = await loadWidevineClient();
+  await appStorage.clients.active.setValue(client);
+  let send = startWorker();
+  await send('generateRequest');
+  const challenge = await send('license-request');
+  expect(challenge).toEqual(expect.any(String));
+  if (typeof challenge !== 'string') throw new Error('Missing challenge');
+  // Removing the selection must not remove the credentials of a pending session.
+  await appStorage.clients.active.setValue(null);
+  send = startWorker();
+  expect(await send('license-request')).toBe(challenge);
+
+  const signed = SignedMessage.decode(fromBase64(challenge).toBuffer());
+  const request = LicenseRequest.decode(signed.msg);
+  const context = deriveContext(signed.msg);
+  const sessionKey = new Uint8Array(16).fill(7);
+  const contentKey = new Uint8Array(16).fill(9);
+  const { encKey, macKeyServer } = await deriveKeys(context.enc, context.auth, sessionKey);
+  const iv = new Uint8Array(16);
+  const license = License.encode(
+    License.create({
+      id: { requestId: request.contentId!.widevinePsshData!.requestId },
+      key: [
+        {
+          id: new Uint8Array(16),
+          iv,
+          key: await encryptWithAesCbc(contentKey, await importAesCbcKeyForEncrypt(encKey), iv),
+          type: License.KeyContainer.KeyType.CONTENT,
+        },
+      ],
+    }),
+  ).finish();
+  const { n, e, kty } = await crypto.subtle.exportKey('jwk', client.key.forDecrypt);
+  const publicKey = await crypto.subtle.importKey(
+    'jwk',
+    { n, e, kty },
+    { name: 'RSA-OAEP', hash: 'SHA-1' },
+    false,
+    ['encrypt'],
+  );
+  const response = SignedMessage.encode(
+    SignedMessage.create({
+      type: SignedMessage.MessageType.LICENSE,
+      msg: license,
+      signature: await createHmacSha256(macKeyServer, license),
+      sessionKey: new Uint8Array(
+        await crypto.subtle.encrypt('RSA-OAEP', publicKey, toBufferSource(sessionKey)),
+      ),
+    }),
+  ).finish();
+  send = startWorker();
+  expect(
+    await send('update', 'one', { message: Object.fromEntries(response.entries()) }),
+  ).toMatchObject({ keys: [{ value: fromBuffer(contentKey).toHex() }] });
+  expect(await pendingRecords()).toEqual([]);
+});
+
+test('does not revive expired or explicitly closed sessions after a restart', async () => {
+  await appStorage.clients.active.setValue(await loadWidevineClient());
+  let send = startWorker();
+  await send('generateRequest', 'expired');
+  await send('generateRequest', 'closed');
+  send = startWorker();
+  await send('close', 'closed');
+  vi.clearAllTimers();
+  vi.setSystemTime(Date.now() + 5 * 60_000);
+  send = startWorker();
+  expect(await send('license-request', 'expired')).toBeUndefined();
+  expect(await send('license-request', 'closed')).toBeUndefined();
+  expect(await pendingRecords()).toEqual([]);
+});
+
+test.skipIf(!prdPath)('restores a PlayReady challenge with no selected client', async () => {
+  await appStorage.clients.active.setValue(
+    await PlayReadyDeviceCredentials.from({ prd: await readFile(prdPath!) }),
+  );
+  const wrm =
+    '<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0"><DATA><PROTECTINFO><KEYLEN>16</KEYLEN><ALGID>AESCTR</ALGID></PROTECTINFO><KID>AAAAAAAAAAAAAAAAAAAAAA==</KID></DATA></WRMHEADER>';
+  let send = startWorker();
+  await send('generateRequest', 'one', {
+    initData: Buffer.from(wrm, 'utf16le').toString('base64'),
+  });
+  const challenge = await send('license-request');
+  expect(challenge).toEqual(expect.any(String));
+  await appStorage.clients.active.setValue(null);
+  send = startWorker();
+  expect(await send('license-request')).toBe(challenge);
+  await send('close');
+  expect(await pendingRecords()).toEqual([]);
+});

--- a/test/extension-session-restart.test.ts
+++ b/test/extension-session-restart.test.ts
@@ -186,3 +186,37 @@ test.skipIf(!prdPath)('restores a PlayReady challenge with no selected client', 
   await send('close');
   expect(await pendingRecords()).toEqual([]);
 });
+
+test.each(['rejected read', 'synchronous storage error'])(
+  'continues handling messages after a restoration %s',
+  async (failure) => {
+    const error = new Error('Session storage unavailable');
+    const get = vi.spyOn(browser.storage.session, 'get');
+    if (failure === 'rejected read') {
+      get.mockRejectedValueOnce(error);
+    } else {
+      get.mockImplementationOnce(() => {
+        throw error;
+      });
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const send = startWorker();
+
+    for (const token of ['keyed', '']) {
+      await send('keystatuseschange', token, {
+        keyStatuses: { 'ABEiM0RVZneImaq7zN3u/w==': 'usable' },
+      });
+      expect(await appStorage.recentKeys.getValue()).toMatchObject([
+        { id: '00112233445566778899aabbccddeeff', value: 'usable' },
+      ]);
+      await appStorage.recentKeys.setValue([]);
+    }
+
+    await appStorage.clients.active.setValue(await loadWidevineClient());
+    await send('generateRequest');
+    expect(await send('license-request')).toEqual(expect.any(String));
+    await send('close');
+    expect(await pendingRecords()).toEqual([]);
+    expect(warn).toHaveBeenCalledWith('[okova] Unable to restore pending DRM sessions', error);
+  },
+);

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -18,7 +18,11 @@ import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credential
 import { Widevine } from '../src/lib/widevine/engine';
 
 vi.mock('../src/lib/widevine/device-credentials', () => ({
-  WidevineDeviceCredentials: class {},
+  WidevineDeviceCredentials: class {
+    async pack() {
+      return new Uint8Array();
+    }
+  },
 }));
 
 const sessions: Session[] = [];
@@ -55,6 +59,7 @@ beforeEach(async () => {
   vi.spyOn(Session.prototype, 'generateRequest').mockImplementation(async function (this: Session) {
     sessions.push(this);
   });
+  vi.spyOn(Session.prototype, 'pause').mockReturnValue('{}');
   vi.spyOn(Session.prototype, 'close').mockResolvedValue();
   vi.spyOn(Session.prototype, 'update').mockResolvedValue();
   vi.spyOn(Session.prototype, 'waitForLicenseRequest').mockImplementation(
@@ -76,7 +81,7 @@ afterEach(() => {
 const startBackground = () => {
   const addListener = vi.spyOn(browser.runtime.onMessage, 'addListener');
   background.main();
-  const listener = addListener.mock.calls[0]![0];
+  const listener = addListener.mock.calls.at(-1)![0];
   return (
     action: string,
     sessionToken: string,

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -391,3 +391,61 @@ test.each([
     await send('close', 'other');
   },
 );
+
+test.each(['expiry', 'removal', 'navigation'])(
+  'a lifecycle %s closes an update waiting for key statuses',
+  async (action) => {
+    vi.mocked(Session.prototype.close).mockRestore();
+    vi.mocked(Session.prototype.waitForKeyStatusesChange).mockRestore();
+    const waiting = Promise.withResolvers<void>();
+    const waitForKeys = Session.prototype.waitForKeyStatusesChange;
+    vi.spyOn(Session.prototype, 'waitForKeyStatusesChange').mockImplementation(
+      function (this: Session) {
+        const result = waitForKeys.call(this);
+        waiting.resolve();
+        return result;
+      },
+    );
+    const removed = vi.spyOn(browser.tabs.onRemoved, 'addListener');
+    const updated = vi.spyOn(browser.tabs.onUpdated, 'addListener');
+    const send = startBackground();
+    const sender = { tab: tab(1) };
+    await send('generateRequest', 'waiting', sender);
+    const update = send('update', 'waiting', sender);
+    await waiting.promise;
+    if (action === 'expiry') {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    } else if (action === 'removal') {
+      removed.mock.calls[0]![0](1, { windowId: 1, isWindowClosing: false });
+    } else {
+      updated.mock.calls[0]![0](1, { status: 'loading' }, tab(1));
+    }
+    await expect(update).resolves.toBeUndefined();
+    await expect(send('license-request', 'waiting', sender)).resolves.toBeUndefined();
+    expect(await browser.storage.session.get(null)).toEqual({});
+    expect(vi.getTimerCount()).toBe(0);
+  },
+);
+
+test('tab closure does not leave a record from an interrupted storage write', async () => {
+  vi.mocked(Session.prototype.close).mockRestore();
+  const removed = vi.spyOn(browser.tabs.onRemoved, 'addListener');
+  const send = startBackground();
+  const sender = { tab: tab(1) };
+  await send('generateRequest', 'one', sender);
+  const started = Promise.withResolvers<void>();
+  const resumeWrite = Promise.withResolvers<void>();
+  const set = browser.storage.session.set.bind(browser.storage.session);
+  vi.spyOn(browser.storage.session, 'set').mockImplementationOnce(async (items) => {
+    started.resolve();
+    await resumeWrite.promise;
+    await set(items);
+  });
+  const challenge = send('license-request', 'one', sender);
+  await started.promise;
+  removed.mock.calls[0]![0](1, { windowId: 1, isWindowClosing: false });
+  await sessions[0]!.closed;
+  resumeWrite.resolve();
+  await expect(challenge).resolves.toBeUndefined();
+  expect(await browser.storage.session.get(null)).toEqual({});
+});


### PR DESCRIPTION
## Summary

- Persist pending DRM session state and credentials in session storage.
- Restore sessions after worker restarts and preserve license challenges.
- Serialize per-session operations and clean up expired or closed sessions.
- Lower the supported Node.js runtime requirement to 22.19.

## Testing

- Added regression coverage for restoring Widevine sessions after worker termination.
- Updated extension session and key-history tests for persisted session state.
- Not run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791207831&installation_model_id=424872&pr_number=49&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F49&signature=0ffdc518a09575c56f9ec003291fd2fc892d9d0e8e1cc6a92c6da30838e1a252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->