### PR TITLE
feat(extension): support ClearKey license capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Okova is a set of tools (JavaScript library, command-line utility and browser ex
 
 ## Browser Extension
 
+With EME interception enabled, the extension inspects ClearKey license responses and saves their key IDs and keys as hex. ClearKey capture works without an imported device or spoofing enabled.
+
 ### Installing Chrome extension
 
 **Developer Mode** needs to be enabled in `chrome://extensions/` page

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -329,7 +329,11 @@ export default defineBackground({
         };
 
         // Inspect before the history shortcut so later responses can add rotated keys.
-        if (settings?.emeInterception && message.action === 'update') {
+        if (
+          settings?.emeInterception &&
+          message.action === 'update' &&
+          message.keySystem === 'org.w3.clearkey'
+        ) {
           const clearKeys = parseClearKeyResponse(parseBinary(message.message));
           if (clearKeys?.length) {
             const results = clearKeys.map((key) => ({
@@ -350,7 +354,10 @@ export default defineBackground({
         const { initData } = message;
         const allKeys = await appStorage.allKeys.raw.getValue();
         const keys = allKeys?.filter(
-          (keyInfo) => keyInfo.pssh === initData && isCapturedKey(keyInfo),
+          (keyInfo) =>
+            keyInfo.pssh === initData &&
+            isCapturedKey(keyInfo) &&
+            (message.keySystem !== 'org.w3.clearkey' || keyInfo.url === message.url),
         );
         const hasKey = !!keys?.length;
         if (hasKey && (!sessionKey || !state.sessions.has(sessionKey))) {

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -16,6 +16,7 @@ import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credential
 import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
 import { Session } from '@okova/lib/api';
 import { z } from 'zod';
+import { parseClearKeyResponse } from '@/utils/clearkey';
 
 const SESSION_IDLE_TIMEOUT_MS = 5 * 60_000;
 
@@ -327,6 +328,25 @@ export default defineBackground({
           updateBadgeForTabInBackground(sender.tab);
         };
 
+        // Inspect before the history shortcut so later responses can add rotated keys.
+        if (settings?.emeInterception && message.action === 'update') {
+          const clearKeys = parseClearKeyResponse(parseBinary(message.message));
+          if (clearKeys?.length) {
+            const results = clearKeys.map((key) => ({
+              ...key,
+              url: message.url,
+              mpd: message.mpd,
+              pssh: message.initData,
+              createdAt: Date.now(),
+            }));
+            await setRecentKeys(results);
+            await appStorage.allKeys.add(...results);
+            if (sessionKey) await closeSession(sessionKey);
+            sendResponse({ keys: results });
+            return;
+          }
+        }
+
         const { initData } = message;
         const allKeys = await appStorage.allKeys.raw.getValue();
         const keys = allKeys?.filter(
@@ -356,6 +376,11 @@ export default defineBackground({
           }));
           await setRecentKeys(keys);
           await appStorage.allKeys.add(...keys);
+          sendResponse();
+          return;
+        }
+
+        if (message.keySystem === 'org.w3.clearkey') {
           sendResponse();
           return;
         }

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -29,7 +29,12 @@ export default defineUnlistedScript(() => {
   };
 
   const mediaKeysCertificates = new WeakMap<MediaKeys, string>();
+  const mediaKeysSystems = new WeakMap<MediaKeys, string>();
   const sessionMediaKeys = new WeakMap<MediaKeySession, MediaKeys>();
+  const getKeySystem = (session: MediaKeySession) => {
+    const mediaKeys = sessionMediaKeys.get(session);
+    return mediaKeys ? mediaKeysSystems.get(mediaKeys) : undefined;
+  };
   const getServerCertificate = (session: MediaKeySession) => {
     const mediaKeys = sessionMediaKeys.get(session);
     return mediaKeys ? mediaKeysCertificates.get(mediaKeys) : undefined;
@@ -53,6 +58,7 @@ export default defineUnlistedScript(() => {
       const ready = send({
         sessionToken: token,
         action: 'generateRequest',
+        keySystem: getKeySystem(session),
         serverCertificate: getServerCertificate(session),
         sessionId: session.sessionId,
         initDataType,
@@ -111,7 +117,10 @@ export default defineUnlistedScript(() => {
       console.log(`Message: ${session.messages?.get(messageType)}`);
       console.groupEnd();
 
-      if (['license-release', 'license-renewal'].includes(messageType)) {
+      if (
+        getKeySystem(session) === 'org.w3.clearkey' ||
+        ['license-release', 'license-renewal'].includes(messageType)
+      ) {
         return;
       }
 
@@ -169,6 +178,7 @@ export default defineUnlistedScript(() => {
         sessionToken: request?.token,
         sessionId,
         action: 'update',
+        keySystem: getKeySystem(session),
         initData: session.initData,
         initDataType: session.initDataType,
         message,
@@ -223,6 +233,7 @@ export default defineUnlistedScript(() => {
         (event) => {
           if (forwardedEvents.has(event) || !(event instanceof MediaKeyMessageEvent)) return;
           if (
+            getKeySystem(session) === 'org.w3.clearkey' ||
             event.messageType === 'license-release' ||
             event.messageType === 'license-renewal' ||
             (event.messageType === 'license-request' && base64.stringify(event.message) === 'CAQ=')
@@ -268,6 +279,18 @@ export default defineUnlistedScript(() => {
       return Object.defineProperty(object, method, {
         value: new Proxy(object[method], { apply: call }),
       });
+    }
+
+    if (typeof MediaKeySystemAccess !== 'undefined') {
+      interceptMethod(
+        MediaKeySystemAccess.prototype,
+        'createMediaKeys',
+        async (createMediaKeys, access, args) => {
+          const mediaKeys = await createMediaKeys.apply(access, args);
+          mediaKeysSystems.set(mediaKeys, access.keySystem);
+          return mediaKeys;
+        },
+      );
     }
 
     interceptMethod(

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -1,4 +1,5 @@
 import { sendDrmMessage } from '@/utils/drm-bridge';
+import { isClearKeyRequest } from '@/utils/clearkey';
 
 declare global {
   interface MediaKeySession {
@@ -95,6 +96,7 @@ export default defineUnlistedScript(() => {
         sessionToken: sessionRequests.get(session)?.token,
         sessionId: session.sessionId,
         action: 'keystatuseschange',
+        keySystem: getKeySystem(session),
         initData: session.initData,
         initDataType: session.initDataType,
         mpd: window.MPD_LIST.get(session.initData!),
@@ -232,6 +234,15 @@ export default defineUnlistedScript(() => {
         'message',
         (event) => {
           if (forwardedEvents.has(event) || !(event instanceof MediaKeyMessageEvent)) return;
+          // MediaKeys may have been created before this script was injected.
+          if (
+            getKeySystem(session) === undefined &&
+            event.messageType === 'license-request' &&
+            isClearKeyRequest(event.message)
+          ) {
+            const mediaKeys = sessionMediaKeys.get(session);
+            if (mediaKeys) mediaKeysSystems.set(mediaKeys, 'org.w3.clearkey');
+          }
           if (
             getKeySystem(session) === 'org.w3.clearkey' ||
             event.messageType === 'license-release' ||

--- a/src/extension/utils/clearkey.ts
+++ b/src/extension/utils/clearkey.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { fromBase64 } from '@okova/lib/utils';
+
+const base64url = z.string().regex(/^[A-Za-z0-9_-]+$/);
+const clearKeyResponse = z.object({
+  keys: z.array(z.object({ kty: z.literal('oct'), kid: base64url, k: base64url })),
+  type: z.enum(['temporary', 'persistent-license']).optional(),
+});
+
+// Response inspection is best effort; unrelated or malformed licenses pass through.
+export const parseClearKeyResponse = (response: BufferSource) => {
+  try {
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(response);
+    const license = clearKeyResponse.parse(JSON.parse(text));
+    return license.keys.map(({ kid, k }) => {
+      const id = fromBase64(kid.replace(/-/g, '+').replace(/_/g, '/')).toHex();
+      const value = fromBase64(k.replace(/-/g, '+').replace(/_/g, '/')).toHex();
+      if (value.length !== 32) throw new Error('Invalid ClearKey key length');
+      return { id, value };
+    });
+  } catch {
+    return undefined;
+  }
+};

--- a/src/extension/utils/clearkey.ts
+++ b/src/extension/utils/clearkey.ts
@@ -2,10 +2,23 @@ import { z } from 'zod';
 import { fromBase64 } from '@okova/lib/utils';
 
 const base64url = z.string().regex(/^[A-Za-z0-9_-]+$/);
+const clearKeyRequest = z.object({
+  kids: z.array(base64url).min(1),
+  type: z.enum(['temporary', 'persistent-license']),
+});
 const clearKeyResponse = z.object({
   keys: z.array(z.object({ kty: z.literal('oct'), kid: base64url, k: base64url })),
   type: z.enum(['temporary', 'persistent-license']).optional(),
 });
+
+export const isClearKeyRequest = (request: BufferSource) => {
+  try {
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(request);
+    return clearKeyRequest.safeParse(JSON.parse(text)).success;
+  } catch {
+    return false;
+  }
+};
 
 // Response inspection is best effort; unrelated or malformed licenses pass through.
 export const parseClearKeyResponse = (response: BufferSource) => {

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -127,7 +127,13 @@ export const appStorage = {
       mutateKeyHistory(async () => {
         const keys = (await appStorage.allKeys.getValue()) || [];
         for (const newKey of newKeys) {
-          const index = keys.findIndex((key) => key.id === newKey.id);
+          const index = keys.findIndex(
+            (key) =>
+              key.id === newKey.id &&
+              (!isCapturedKey(key) ||
+                !isCapturedKey(newKey) ||
+                (key.value === newKey.value && key.pssh === newKey.pssh && key.url === newKey.url)),
+          );
           if (index === -1) {
             keys.push(newKey);
           } else if (!isCapturedKey(keys[index]!) && isCapturedKey(newKey)) {
@@ -139,7 +145,13 @@ export const appStorage = {
     remove: (key: KeyInfo) =>
       mutateKeyHistory(async () => {
         const keys = (await appStorage.allKeys.getValue()) || [];
-        const index = keys.findIndex((storedKey) => storedKey.id === key.id);
+        const index = keys.findIndex(
+          (storedKey) =>
+            storedKey.id === key.id &&
+            storedKey.value === key.value &&
+            storedKey.pssh === key.pssh &&
+            storedKey.url === key.url,
+        );
         if (index === -1) return;
         keys.splice(index, 1);
         await appStorage.allKeys.raw.setValue(keys);

--- a/test/clearkey.test.ts
+++ b/test/clearkey.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { parseClearKeyResponse } from '../src/extension/utils/clearkey';
+import { isClearKeyRequest, parseClearKeyResponse } from '../src/extension/utils/clearkey';
 
 const key = { kty: 'oct', kid: 'LwVHf8JLtPrv2GUXFW2v_A', k: 'tQ0bJVWb6b0KPL6KtZIy_A' };
 const encode = (value: unknown) => new TextEncoder().encode(JSON.stringify(value));
@@ -39,4 +39,19 @@ test('ignores binary licenses, invalid JSON, and empty key sets', () => {
   expect(parseClearKeyResponse(new Uint8Array([8, 2, 255]))).toBeUndefined();
   expect(parseClearKeyResponse(new TextEncoder().encode('{'))).toBeUndefined();
   expect(parseClearKeyResponse(encode({ keys: [] }))).toEqual([]);
+});
+
+test('recognizes ClearKey requests without mistaking init data or binary challenges for them', () => {
+  expect(isClearKeyRequest(encode({ kids: [key.kid], type: 'temporary' }))).toBe(true);
+  expect(isClearKeyRequest(encode({ kids: [key.kid], type: 'persistent-license' }))).toBe(true);
+  for (const data of [
+    null,
+    { kids: [key.kid] },
+    { kids: [], type: 'temporary' },
+    { kids: [123], type: 'temporary' },
+    { keys: [key] },
+  ]) {
+    expect(isClearKeyRequest(encode(data))).toBe(false);
+  }
+  expect(isClearKeyRequest(new Uint8Array([8, 1, 255]))).toBe(false);
 });

--- a/test/clearkey.test.ts
+++ b/test/clearkey.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+import { parseClearKeyResponse } from '../src/extension/utils/clearkey';
+
+const key = { kty: 'oct', kid: 'LwVHf8JLtPrv2GUXFW2v_A', k: 'tQ0bJVWb6b0KPL6KtZIy_A' };
+const encode = (value: unknown) => new TextEncoder().encode(JSON.stringify(value));
+
+test('decodes multiple ClearKey keys and respects response view bounds', () => {
+  const response = encode({ keys: [key, { ...key, kid: '-_8' }], type: 'temporary' });
+  const backing = new Uint8Array(response.length + 2);
+  backing.set(response, 1);
+  const expected = [
+    { id: '2f05477fc24bb4faefd86517156daffc', value: 'b50d1b25559be9bd0a3cbe8ab59232fc' },
+    { id: 'fbff', value: 'b50d1b25559be9bd0a3cbe8ab59232fc' },
+  ];
+  for (const input of [
+    response.buffer,
+    backing.subarray(1, -1),
+    new DataView(backing.buffer, 1, response.length),
+  ]) {
+    expect(parseClearKeyResponse(input)).toEqual(expected);
+  }
+});
+
+test.each([
+  null,
+  {},
+  { kids: [key.kid] },
+  { keys: [null] },
+  ...[{ kty: 'RSA' }, { kid: 'a' }, { kid: '+/8=' }, { k: 'AA' }, { k: '' }, { k: 123 }].map(
+    (invalid) => ({ keys: [{ ...key, ...invalid }] }),
+  ),
+  { keys: [key, { ...key, k: 'invalid' }] },
+  { keys: [key], type: 'invalid' },
+])('ignores malformed ClearKey response %j without partial results', (response) => {
+  expect(parseClearKeyResponse(encode(response))).toBeUndefined();
+});
+
+test('ignores binary licenses, invalid JSON, and empty key sets', () => {
+  expect(parseClearKeyResponse(new Uint8Array([8, 2, 255]))).toBeUndefined();
+  expect(parseClearKeyResponse(new TextEncoder().encode('{'))).toBeUndefined();
+  expect(parseClearKeyResponse(encode({ keys: [] }))).toEqual([]);
+});

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -360,66 +360,89 @@ test.each(
   },
 );
 
-test('keeps ClearKey challenges and responses unchanged and reports the key system', async () => {
-  const nativeUpdate = vi.fn<(response: BufferSource) => Promise<void>>().mockResolvedValue();
-  const nativeGenerateRequest = vi
-    .fn<(type: string, data: BufferSource) => Promise<void>>()
-    .mockResolvedValue();
-  class NativeSession extends EventTarget {
-    sessionId = 'clear-session';
-    keyStatuses = new Map();
-    closed = Promise.withResolvers<void>().promise;
-    generateRequest(type: string, data: BufferSource) {
-      return nativeGenerateRequest(type, data);
+test.each(['before', 'after'])(
+  'keeps ClearKey unchanged when MediaKeys was created %s injection',
+  async (creation) => {
+    const nativeUpdate = vi.fn<(response: BufferSource) => Promise<void>>().mockResolvedValue();
+    const nativeGenerateRequest = vi
+      .fn<(type: string, data: BufferSource) => Promise<void>>()
+      .mockResolvedValue();
+    class NativeSession extends EventTarget {
+      sessionId = 'clear-session';
+      keyStatuses = new Map();
+      closed = Promise.withResolvers<void>().promise;
+      generateRequest(type: string, data: BufferSource) {
+        return nativeGenerateRequest(type, data);
+      }
+      update(response: BufferSource) {
+        return nativeUpdate(response);
+      }
     }
-    update(response: BufferSource) {
-      return nativeUpdate(response);
+    class NativeKeys {
+      createSession() {
+        return new NativeSession();
+      }
+      async setServerCertificate() {
+        return true;
+      }
     }
-  }
-  class NativeKeys {
-    createSession() {
-      return new NativeSession();
+    class NativeAccess {
+      keySystem = 'org.w3.clearkey';
+      async createMediaKeys() {
+        return new NativeKeys();
+      }
     }
-    async setServerCertificate() {
-      return true;
-    }
-  }
-  class NativeAccess {
-    keySystem = 'org.w3.clearkey';
-    async createMediaKeys() {
-      return new NativeKeys();
-    }
-  }
-  vi.stubGlobal('MediaKeySession', NativeSession);
-  vi.stubGlobal('MediaKeys', NativeKeys);
-  vi.stubGlobal('MediaKeySystemAccess', NativeAccess);
-  vi.stubGlobal('window', { MPD_LIST: new Map() });
-  vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
-    if (message.action === 'license-request') return btoa('wrong challenge');
-    if (message.action === 'update') return { keys: [] };
-  });
-  eme.main();
-  const session = (await new NativeAccess().createMediaKeys()).createSession();
-  await session.generateRequest('keyids', new TextEncoder().encode('{"kids":["AA"]}'));
-  expect(sendDrmMessage).toHaveBeenLastCalledWith(
-    expect.objectContaining({ action: 'generateRequest', keySystem: 'org.w3.clearkey' }),
-  );
-  const received = Promise.withResolvers<Event>();
-  session.addEventListener('message', received.resolve);
-  const challenge = new TextEncoder().encode('{"kids":["AA"],"type":"temporary"}').buffer;
-  const event = new MediaKeyMessageEvent('message', {
-    message: challenge,
-    messageType: 'license-request',
-  });
-  session.dispatchEvent(event);
-  expect(await received.promise).toBe(event);
-  expect(sendDrmMessage).toHaveBeenCalledTimes(1);
-  const response = new TextEncoder().encode(
-    '{"keys":[{"kty":"oct","kid":"AA","k":"tQ0bJVWb6b0KPL6KtZIy_A"}]}',
-  );
-  await session.update(response);
-  expect(sendDrmMessage).toHaveBeenLastCalledWith(
-    expect.objectContaining({ action: 'update', keySystem: 'org.w3.clearkey', message: response }),
-  );
-  expect(nativeUpdate).toHaveBeenCalledExactlyOnceWith(response);
-});
+    vi.stubGlobal('MediaKeySession', NativeSession);
+    vi.stubGlobal('MediaKeys', NativeKeys);
+    vi.stubGlobal('MediaKeySystemAccess', NativeAccess);
+    vi.stubGlobal('window', { MPD_LIST: new Map() });
+    vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
+      if (message.action === 'license-request') return btoa('wrong challenge');
+      if (message.action === 'update') return { keys: [] };
+    });
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      NativeAccess.prototype,
+      'createMediaKeys',
+    );
+    const earlyKeys =
+      creation === 'before' ? await new NativeAccess().createMediaKeys() : undefined;
+    eme.main();
+    expect(
+      Object.getOwnPropertyDescriptor(NativeAccess.prototype, 'createMediaKeys'),
+    ).toMatchObject({
+      writable: originalDescriptor?.writable,
+      configurable: originalDescriptor?.configurable,
+      enumerable: originalDescriptor?.enumerable,
+    });
+    const session = (earlyKeys ?? (await new NativeAccess().createMediaKeys())).createSession();
+    await session.generateRequest('keyids', new TextEncoder().encode('{"kids":["AA"]}'));
+    expect(sendDrmMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'generateRequest',
+        keySystem: creation === 'before' ? undefined : 'org.w3.clearkey',
+      }),
+    );
+    const received = Promise.withResolvers<Event>();
+    session.addEventListener('message', received.resolve);
+    const challenge = new TextEncoder().encode('{"kids":["AA"],"type":"temporary"}').buffer;
+    const event = new MediaKeyMessageEvent('message', {
+      message: challenge,
+      messageType: 'license-request',
+    });
+    session.dispatchEvent(event);
+    expect(await received.promise).toBe(event);
+    expect(sendDrmMessage).toHaveBeenCalledTimes(1);
+    const response = new TextEncoder().encode(
+      '{"keys":[{"kty":"oct","kid":"AA","k":"tQ0bJVWb6b0KPL6KtZIy_A"}]}',
+    );
+    await session.update(response);
+    expect(sendDrmMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'update',
+        keySystem: 'org.w3.clearkey',
+        message: response,
+      }),
+    );
+    expect(nativeUpdate).toHaveBeenCalledExactlyOnceWith(response);
+  },
+);

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -359,3 +359,67 @@ test.each(
     expect(event.defaultPrevented).toBe(true);
   },
 );
+
+test('keeps ClearKey challenges and responses unchanged and reports the key system', async () => {
+  const nativeUpdate = vi.fn<(response: BufferSource) => Promise<void>>().mockResolvedValue();
+  const nativeGenerateRequest = vi
+    .fn<(type: string, data: BufferSource) => Promise<void>>()
+    .mockResolvedValue();
+  class NativeSession extends EventTarget {
+    sessionId = 'clear-session';
+    keyStatuses = new Map();
+    closed = Promise.withResolvers<void>().promise;
+    generateRequest(type: string, data: BufferSource) {
+      return nativeGenerateRequest(type, data);
+    }
+    update(response: BufferSource) {
+      return nativeUpdate(response);
+    }
+  }
+  class NativeKeys {
+    createSession() {
+      return new NativeSession();
+    }
+    async setServerCertificate() {
+      return true;
+    }
+  }
+  class NativeAccess {
+    keySystem = 'org.w3.clearkey';
+    async createMediaKeys() {
+      return new NativeKeys();
+    }
+  }
+  vi.stubGlobal('MediaKeySession', NativeSession);
+  vi.stubGlobal('MediaKeys', NativeKeys);
+  vi.stubGlobal('MediaKeySystemAccess', NativeAccess);
+  vi.stubGlobal('window', { MPD_LIST: new Map() });
+  vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
+    if (message.action === 'license-request') return btoa('wrong challenge');
+    if (message.action === 'update') return { keys: [] };
+  });
+  eme.main();
+  const session = (await new NativeAccess().createMediaKeys()).createSession();
+  await session.generateRequest('keyids', new TextEncoder().encode('{"kids":["AA"]}'));
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({ action: 'generateRequest', keySystem: 'org.w3.clearkey' }),
+  );
+  const received = Promise.withResolvers<Event>();
+  session.addEventListener('message', received.resolve);
+  const challenge = new TextEncoder().encode('{"kids":["AA"],"type":"temporary"}').buffer;
+  const event = new MediaKeyMessageEvent('message', {
+    message: challenge,
+    messageType: 'license-request',
+  });
+  session.dispatchEvent(event);
+  expect(await received.promise).toBe(event);
+  expect(sendDrmMessage).toHaveBeenCalledTimes(1);
+  const response = new TextEncoder().encode(
+    '{"keys":[{"kty":"oct","kid":"AA","k":"tQ0bJVWb6b0KPL6KtZIy_A"}]}',
+  );
+  await session.update(response);
+  expect(sendDrmMessage).toHaveBeenLastCalledWith(
+    expect.objectContaining({ action: 'update', keySystem: 'org.w3.clearkey', message: response }),
+  );
+  expect(nativeUpdate).toHaveBeenCalledExactlyOnceWith(response);
+});

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -223,3 +223,12 @@ test('cache hits expose only captured keys matching the PSSH with current site m
   expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'other.example': cachedKeys });
   expect(loadClient).not.toHaveBeenCalled();
 });
+
+test('retains different values and content metadata for a reused KID', async () => {
+  const otherValue = { ...key, value: '000102030405060708090a0b0c0d0e0f' };
+  const otherContent = { ...key, pssh: 'other-pssh' };
+  await appStorage.allKeys.add(key, otherValue, otherContent, otherValue);
+  expect(await appStorage.allKeys.getValue()).toEqual([key, otherValue, otherContent]);
+  await appStorage.allKeys.remove(otherValue);
+  expect(await appStorage.allKeys.getValue()).toEqual([key, otherContent]);
+});

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -449,3 +449,47 @@ test('tab closure does not leave a record from an interrupted storage write', as
   await expect(challenge).resolves.toBeUndefined();
   expect(await browser.storage.session.get(null)).toEqual({});
 });
+
+test.each([true, false])(
+  'captures ClearKey without a client when spoofing is %s',
+  async (spoofing) => {
+    await appStorage.settings.setValue({
+      spoofing,
+      emeInterception: true,
+      requestInterception: false,
+      theme: 'auto',
+    });
+    vi.mocked(appStorage.clients.active.getValue).mockResolvedValue(null);
+    const send = startBackground();
+    const context = {
+      keySystem: 'org.w3.clearkey',
+      initDataType: 'keyids',
+      mpd: 'https://example.com/manifest.mpd',
+    };
+    await send('generateRequest', 'clear', {}, context);
+    await expect(send('license-request', 'clear', {}, context)).resolves.toBeUndefined();
+    for (const kid of ['LwVHf8JLtPrv2GUXFW2v_A', 'AAECAwQFBgcICQoLDA0ODw']) {
+      const message = new TextEncoder().encode(
+        JSON.stringify({ keys: [{ kty: 'oct', kid, k: 'tQ0bJVWb6b0KPL6KtZIy_A' }] }),
+      );
+      await expect(send('update', 'clear', {}, { ...context, message })).resolves.toMatchObject({
+        keys: [
+          {
+            value: 'b50d1b25559be9bd0a3cbe8ab59232fc',
+            pssh: 'cHNzaA==',
+            url: 'https://example.com/video',
+            mpd: context.mpd,
+          },
+        ],
+      });
+    }
+    expect(await appStorage.allKeys.getValue()).toHaveLength(2);
+    expect(await appStorage.recentKeys.getValue()).toMatchObject([
+      { id: '000102030405060708090a0b0c0d0e0f' },
+    ]);
+    expect(await appStorage.recentKeysByDomain.getValue()).toHaveProperty('example.com');
+    expect(appStorage.clients.active.getValue).not.toHaveBeenCalled();
+    expect(Session.prototype.generateRequest).not.toHaveBeenCalled();
+    expect(Session.prototype.update).not.toHaveBeenCalled();
+  },
+);

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -493,3 +493,51 @@ test.each([true, false])(
     expect(Session.prototype.update).not.toHaveBeenCalled();
   },
 );
+
+test.each(['com.widevine.alpha', 'com.microsoft.playready', undefined])(
+  'does not capture ClearKey-shaped JSON for key system %s',
+  async (keySystem) => {
+    const send = startBackground();
+    await send('generateRequest', 'other', {}, { keySystem });
+    const message = new TextEncoder().encode(
+      JSON.stringify({ keys: [{ kty: 'oct', kid: 'AA', k: 'tQ0bJVWb6b0KPL6KtZIy_A' }] }),
+    );
+    await expect(send('update', 'other', {}, { keySystem, message })).resolves.toBeUndefined();
+    expect(Session.prototype.waitForKeyStatusesChange).not.toHaveBeenCalled();
+    expect((await appStorage.allKeys.getValue()) ?? []).toEqual([]);
+    expect((await appStorage.recentKeys.getValue()) ?? []).toEqual([]);
+  },
+);
+
+test('retains reused ClearKey IDs across origins and status events', async () => {
+  const send = startBackground();
+  const captures = [
+    {
+      url: 'https://first.example/video',
+      k: 'tQ0bJVWb6b0KPL6KtZIy_A',
+      value: 'b50d1b25559be9bd0a3cbe8ab59232fc',
+    },
+    {
+      url: 'https://second.example/video',
+      k: 'AAECAwQFBgcICQoLDA0ODw',
+      value: '000102030405060708090a0b0c0d0e0f',
+    },
+  ];
+  for (const capture of captures) {
+    const context = { keySystem: 'org.w3.clearkey', url: capture.url };
+    const message = new TextEncoder().encode(
+      JSON.stringify({ keys: [{ kty: 'oct', kid: 'AA', k: capture.k }] }),
+    );
+    await send('update', 'clear', {}, { ...context, message });
+    await send('keystatuseschange', 'clear', {}, { ...context, keyStatuses: { 'AA==': 'usable' } });
+    expect(await appStorage.recentKeys.getValue()).toMatchObject([
+      { id: '00', value: capture.value, url: capture.url },
+    ]);
+  }
+  const history = await appStorage.allKeys.getValue();
+  expect(history).toHaveLength(2);
+  expect(history).toMatchObject(captures.map(({ url, value }) => ({ id: '00', url, value })));
+  if (!history?.[1]) throw new Error('Missing second capture');
+  await appStorage.allKeys.remove(history[1]);
+  expect(await appStorage.allKeys.getValue()).toMatchObject([{ value: captures[0]?.value }]);
+});


### PR DESCRIPTION
## Summary

- Capture ClearKey license keys from EME responses.
- Preserve ClearKey challenges and responses without spoofing or imported devices.
- Store captured keys and document ClearKey support.
- Add parser and extension session coverage.

## Testing

- Added ClearKey response parsing tests.
- Added EME session passthrough tests.
- Added background capture tests with spoofing enabled and disabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791209373&installation_model_id=424872&pr_number=50&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F50&signature=62be67ef047b95adccedde0827bc55ebe0af42e1d68db74871080aa917d5dd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->