### PR TITLE
feat(pssh): add PSSH inspection, editing, and conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,56 @@ async function main() {
 }
 ```
 
+### Inspect, edit, and convert PSSH boxes
+
+```ts
+import {
+  PSSH_SYSTEM_IDS,
+  createPsshBox,
+  parsePsshBoxes,
+  getPsshKeyIds,
+  setPsshKeyIds,
+  convertPsshBox,
+  psshBoxToBase64,
+} from 'okova';
+
+const widevine = setPsshKeyIds(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine }), [
+  '00112233-4455-6677-8899-aabbccddeeff',
+]);
+const playready = convertPsshBox(widevine, 'playready', {
+  laUrl: 'https://example.com/license',
+});
+const [box] = parsePsshBoxes(psshBoxToBase64(playready));
+console.log(box.systemId, box.version, getPsshKeyIds(box));
+const restored = convertPsshBox(box, 'widevine');
+```
+
+`parsePsshBoxes` accepts bytes or base64 containing one or more full PSSH boxes. It
+rejects malformed boxes, raw DRM headers, and other MP4 box types. The returned
+`ParsedPsshBox` exposes `systemId`, `version`, `flags`, `keyIds`, and raw payload
+`data`. Unknown system IDs and opaque payloads can be parsed and serialized.
+`serializePsshBox` returns full box bytes; `psshBoxToBase64` returns base64. Both
+write a normal 32-bit size field, including for inputs parsed with extended sizes.
+
+IDs accept 16-byte arrays, UUID strings, or 32 hex digits. Inspection returns
+lowercase hex in UUID byte order, accounting for PlayReady's GUID byte order.
+`getPsshKeyIds` prefers nonempty version 1 box KIDs, then reads Widevine protobuf
+or PlayReady Object headers, versions 4.0 through 4.3. `createPsshBox` wraps raw
+payload bytes or base64; its `keyIds` option is only available with `version: 1`
+and sets box KIDs. Use `setPsshKeyIds` to populate or replace Widevine payload KIDs.
+It also updates version 1 box KIDs and preserves other protobuf fields. Editing
+and conversion return new boxes without changing their inputs. PlayReady KID
+replacement is not supported.
+
+Conversion carries KIDs, box version, flags, and `cenc`/`cbcs` encryption signaling.
+Widevine data without an explicit scheme defaults to AES-CTR. Unsupported or mixed
+PlayReady algorithms are rejected. Conversion discards other source metadata,
+including license URLs, provider data, custom attributes, and checksums. Supply
+`laUrl` when converting to PlayReady if needed. Generated PlayReady 4.3 headers
+omit checksums because computing them requires content keys. Converted headers
+may not meet a particular license server's requirements. See Microsoft's
+[PlayReady header specification](https://learn.microsoft.com/en-us/playready/specifications/playready-header-specification).
+
 ## Disclaimer
 
 1. This project does not condone piracy or any action against the terms of the DRM systems.

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -85,6 +85,7 @@ export { fetchDecryptionKeys };
 export * from './utils';
 export * from './api';
 export * from './decrypt';
+export * from './pssh';
 export * from './widevine/engine';
 export * from './widevine/device-credentials';
 export * from './playready/engine';

--- a/src/lib/pssh.ts
+++ b/src/lib/pssh.ts
@@ -1,0 +1,299 @@
+import { WrmHeader } from './playready/wrmheader';
+import { fromBase64, fromBuffer, fromHex } from './utils';
+import { WidevinePsshData } from './widevine/proto';
+import { decodeExactly } from './widevine/protobuf';
+
+export const PSSH_SYSTEM_IDS = {
+  widevine: 'edef8ba979d64acea3c827dcd51d21ed',
+  playready: '9a04f07998404286ab92e65be0885f95',
+} as const;
+
+/** IDs use UUID byte order, represented as 32 lowercase hex digits. */
+export type ParsedPsshBox = {
+  systemId: string;
+  flags: number;
+  data: Uint8Array;
+} & ({ version: 0; keyIds: [] } | { version: 1; keyIds: string[] });
+
+type PsshId = string | Uint8Array;
+
+const normalizeId = (value: PsshId) => {
+  const hex = typeof value === 'string' ? value : fromBuffer(value).toHex();
+  if (!/^(?:[\da-f]{32}|[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})$/i.test(hex)) {
+    throw new Error('PSSH IDs must be 16 bytes, 32 hex digits, or a UUID');
+  }
+  return hex.replaceAll('-', '').toLowerCase();
+};
+
+const inputBytes = (value: Uint8Array | string) =>
+  typeof value === 'string' ? fromBase64(value).toBuffer() : value;
+
+/** Construct a box around an opaque payload. keyIds here are the version 1 box IDs. */
+export const createPsshBox = (
+  options: {
+    systemId: PsshId;
+    data?: Uint8Array | string;
+    flags?: number;
+  } & ({ version?: 0; keyIds?: never } | { version: 1; keyIds?: readonly PsshId[] }),
+): ParsedPsshBox => {
+  const flags = options.flags ?? 0;
+  if (!Number.isInteger(flags) || flags < 0 || flags > 0xffffff) {
+    throw new Error('PSSH flags must be an unsigned 24-bit integer');
+  }
+  const common = {
+    systemId: normalizeId(options.systemId),
+    flags,
+    data: new Uint8Array(inputBytes(options.data ?? new Uint8Array())),
+  };
+  if (options.version === 1) {
+    return { ...common, version: 1, keyIds: (options.keyIds ?? []).map(normalizeId) };
+  }
+  if (options.version !== undefined && options.version !== 0) {
+    throw new Error('Unsupported PSSH version');
+  }
+  if (options.keyIds !== undefined) throw new Error('Version 0 boxes cannot contain box key IDs');
+  return { ...common, version: 0, keyIds: [] };
+};
+
+/** Parse a sequence of full PSSH boxes. Raw DRM headers and other MP4 boxes are rejected. */
+export const parsePsshBoxes = (input: Uint8Array | string): ParsedPsshBox[] => {
+  const bytes = inputBytes(input);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const boxes: ParsedPsshBox[] = [];
+  let offset = 0;
+  const requireBytes = (cursor: number, count: number, end: number) => {
+    if (cursor + count > end) throw new Error('Truncated PSSH box');
+  };
+  while (offset < bytes.length) {
+    requireBytes(offset, 8, bytes.length);
+    const size = view.getUint32(offset);
+    if (view.getUint32(offset + 4) !== 0x70737368) throw new Error('Expected a PSSH box');
+    let cursor = offset + 8;
+    let length = size || bytes.length - offset;
+    if (size === 1) {
+      requireBytes(cursor, 8, bytes.length);
+      const extendedSize = view.getBigUint64(cursor);
+      if (extendedSize > BigInt(bytes.length - offset)) throw new Error('Truncated PSSH box');
+      length = Number(extendedSize);
+      cursor += 8;
+    }
+    const end = offset + length;
+    if (end > bytes.length) throw new Error('Truncated PSSH box');
+    requireBytes(cursor, 24, end);
+    const version = bytes[cursor];
+    if (version !== 0 && version !== 1) throw new Error(`Unsupported PSSH version ${version}`);
+    const flags = view.getUint32(cursor) & 0xffffff;
+    const systemId = bytes.slice(cursor + 4, cursor + 20);
+    cursor += 20;
+    const keyIds: Uint8Array[] = [];
+    if (version === 1) {
+      const count = view.getUint32(cursor);
+      cursor += 4;
+      requireBytes(cursor, count * 16 + 4, end);
+      for (let index = 0; index < count; index++, cursor += 16) {
+        keyIds.push(bytes.slice(cursor, cursor + 16));
+      }
+    }
+    const dataLength = view.getUint32(cursor);
+    cursor += 4;
+    if (cursor + dataLength !== end) throw new Error('Invalid PSSH data length');
+    const common = { systemId, flags, data: bytes.subarray(cursor, end) };
+    boxes.push(
+      createPsshBox(version === 1 ? { ...common, version, keyIds } : { ...common, version }),
+    );
+    offset = end;
+  }
+  if (!boxes.length) throw new Error('PSSH data must not be empty');
+  return boxes;
+};
+
+/** Serialize one full box using a normal 32-bit size field. */
+export const serializePsshBox = (box: ParsedPsshBox): Uint8Array => {
+  const checked = createPsshBox(
+    box.version === 1
+      ? box
+      : {
+          systemId: box.systemId,
+          flags: box.flags,
+          data: box.data,
+          version: box.version,
+        },
+  );
+  if (box.version === 0 && box.keyIds.length)
+    throw new Error('Version 0 boxes cannot contain box key IDs');
+  const size =
+    32 + (checked.version === 1 ? 4 + checked.keyIds.length * 16 : 0) + checked.data.length;
+  if (size > 0xffffffff) throw new Error('PSSH box exceeds the 32-bit size limit');
+  const bytes = new Uint8Array(size);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, size);
+  view.setUint32(4, 0x70737368);
+  view.setUint32(8, checked.version * 0x1000000 + checked.flags);
+  bytes.set(fromHex(checked.systemId).toBuffer(), 12);
+  let cursor = 28;
+  if (checked.version === 1) {
+    view.setUint32(cursor, checked.keyIds.length);
+    cursor += 4;
+    for (const keyId of checked.keyIds) {
+      bytes.set(fromHex(keyId).toBuffer(), cursor);
+      cursor += 16;
+    }
+  }
+  view.setUint32(cursor, checked.data.length);
+  bytes.set(checked.data, cursor + 4);
+  return bytes;
+};
+
+export const psshBoxToBase64 = (box: ParsedPsshBox) => fromBuffer(serializePsshBox(box)).toBase64();
+
+// PlayReady stores the first three GUID fields in little endian order.
+const swapGuidByteOrder = (bytes: Uint8Array) => {
+  normalizeId(bytes);
+  const result = new Uint8Array(bytes);
+  result.subarray(0, 4).reverse();
+  result.subarray(4, 6).reverse();
+  result.subarray(6, 8).reverse();
+  return result;
+};
+
+const readPlayreadyHeaders = (data: Uint8Array) => {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  if (data.length < 6 || view.getUint32(0, true) !== data.length) {
+    throw new Error('Invalid PlayReady Object length');
+  }
+  const headers: WrmHeader[] = [];
+  let cursor = 6;
+  const count = view.getUint16(4, true);
+  for (let index = 0; index < count; index++) {
+    if (cursor + 4 > data.length) throw new Error('Truncated PlayReady record');
+    const type = view.getUint16(cursor, true);
+    const length = view.getUint16(cursor + 2, true);
+    cursor += 4;
+    if (cursor + length > data.length) throw new Error('Truncated PlayReady record');
+    if (type === 1) {
+      if (length % 2) throw new Error('Invalid UTF-16LE PlayReady header');
+      const xml = new TextDecoder('utf-16le', { fatal: true }).decode(
+        data.subarray(cursor, cursor + length),
+      );
+      const header = new WrmHeader(xml);
+      if (header.version === 'UNKNOWN') throw new Error('Unsupported PlayReady header version');
+      headers.push(header);
+    }
+    cursor += length;
+  }
+  if (cursor !== data.length || !headers.length)
+    throw new Error('Invalid PlayReady Object records');
+  return headers;
+};
+
+/** Inspect box KIDs first, falling back to Widevine protobuf or PlayReady Object KIDs. */
+export const getPsshKeyIds = (box: ParsedPsshBox): string[] => {
+  if (box.version === 1 && box.keyIds.length) return box.keyIds.map(normalizeId);
+  switch (normalizeId(box.systemId)) {
+    case PSSH_SYSTEM_IDS.widevine:
+      return decodeExactly(box.data, WidevinePsshData, 'Widevine PSSH data').keyIds.map((keyId) =>
+        normalizeId(keyId.length === 32 ? new TextDecoder().decode(keyId) : keyId),
+      );
+    case PSSH_SYSTEM_IDS.playready:
+      return readPlayreadyHeaders(box.data).flatMap((header) =>
+        header.keyIds.map((keyId) => normalizeId(swapGuidByteOrder(keyId.value))),
+      );
+    default:
+      throw new Error('Cannot inspect payload KIDs for this PSSH system');
+  }
+};
+
+/** Replace Widevine payload KIDs and synchronize version 1 box KIDs, without mutating the input. */
+export const setPsshKeyIds = (box: ParsedPsshBox, keyIds: readonly PsshId[]): ParsedPsshBox => {
+  if (normalizeId(box.systemId) !== PSSH_SYSTEM_IDS.widevine) {
+    throw new Error('KID replacement is supported only for Widevine PSSH boxes');
+  }
+  const ids = keyIds.map(normalizeId);
+  const payload = decodeExactly(box.data, WidevinePsshData, 'Widevine PSSH data');
+  payload.keyIds = ids.map((id) => fromHex(id).toBuffer());
+  const data = WidevinePsshData.encode(payload).finish();
+  return box.version === 1 ? { ...box, data, keyIds: ids } : { ...box, data, keyIds: [] };
+};
+
+const CENC = 0x63656e63;
+const CBCS = 0x63626373;
+
+const createPlayreadyData = (keyIds: string[], algorithm: 'AESCTR' | 'AESCBC', laUrl?: string) => {
+  if (laUrl !== undefined) new URL(laUrl);
+  const escapeXml = (value: string) =>
+    value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replace(/[^\x20-\x7e]/gu, (character) => `&#${character.codePointAt(0)};`);
+  const kids = keyIds
+    .map(
+      (id) =>
+        `<KID ALGID="${algorithm}" VALUE="${fromBuffer(swapGuidByteOrder(fromHex(id).toBuffer())).toBase64()}"></KID>`,
+    )
+    .join('');
+  const xml = `<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.3.0.0"><DATA><PROTECTINFO><KIDS>${kids}</KIDS></PROTECTINFO>${laUrl === undefined ? '' : `<LA_URL>${escapeXml(laUrl)}</LA_URL>`}</DATA></WRMHEADER>`;
+  const length = xml.length * 2;
+  if (length > 0xffff) throw new Error('PlayReady header exceeds the 16-bit record size limit');
+  const data = new Uint8Array(10 + length);
+  const view = new DataView(data.buffer);
+  view.setUint32(0, data.length, true);
+  view.setUint16(4, 1, true);
+  view.setUint16(6, 1, true);
+  view.setUint16(8, length, true);
+  for (let index = 0; index < xml.length; index++)
+    view.setUint16(10 + index * 2, xml.charCodeAt(index), true);
+  return data;
+};
+
+/** Convert KIDs and cenc/cbcs signaling. Other DRM metadata is discarded; no checksums are generated. */
+export const convertPsshBox = (
+  box: ParsedPsshBox,
+  target: 'widevine' | 'playready',
+  options: { laUrl?: string } = {},
+): ParsedPsshBox => {
+  const source = normalizeId(box.systemId);
+  if (target !== 'widevine' && target !== 'playready')
+    throw new Error('Unsupported target PSSH system');
+  if (source === PSSH_SYSTEM_IDS[target]) throw new Error(`PSSH is already ${target}`);
+  if (source !== PSSH_SYSTEM_IDS.widevine && source !== PSSH_SYSTEM_IDS.playready)
+    throw new Error('Unsupported source PSSH system');
+  const keyIds = getPsshKeyIds(box);
+  if (!keyIds.length) throw new Error('PSSH conversion requires at least one KID');
+  let data: Uint8Array;
+  if (target === 'playready') {
+    const payload = decodeExactly(box.data, WidevinePsshData, 'Widevine PSSH data');
+    if (
+      payload.protectionScheme !== 0 &&
+      payload.protectionScheme !== CENC &&
+      payload.protectionScheme !== CBCS
+    )
+      throw new Error('Unsupported Widevine protection scheme');
+    if (
+      Object.hasOwn(payload, 'algorithm') &&
+      payload.algorithm !== WidevinePsshData.Algorithm.AESCTR
+    )
+      throw new Error('Unsupported Widevine algorithm');
+    data = createPlayreadyData(
+      keyIds,
+      payload.protectionScheme === CBCS ? 'AESCBC' : 'AESCTR',
+      options.laUrl,
+    );
+  } else {
+    const keys = readPlayreadyHeaders(box.data).flatMap((header) => header.keyIds);
+    const algorithm = keys[0]?.algId;
+    if (
+      (algorithm !== 'AESCTR' && algorithm !== 'AESCBC') ||
+      keys.some((key) => key.algId !== algorithm)
+    )
+      throw new Error('Unsupported or mixed PlayReady algorithms');
+    data = WidevinePsshData.encode(
+      WidevinePsshData.create({
+        keyIds: keyIds.map((id) => fromHex(id).toBuffer()),
+        protectionScheme: algorithm === 'AESCBC' ? CBCS : CENC,
+      }),
+    ).finish();
+  }
+  const common = { systemId: PSSH_SYSTEM_IDS[target], flags: box.flags, data };
+  return createPsshBox(box.version === 1 ? { ...common, version: 1, keyIds } : common);
+};

--- a/test/pssh-box.test.ts
+++ b/test/pssh-box.test.ts
@@ -1,0 +1,189 @@
+import { expect, test } from 'vitest';
+import {
+  PSSH_SYSTEM_IDS,
+  createPsshBox,
+  parsePsshBoxes,
+  serializePsshBox,
+  psshBoxToBase64,
+  getPsshKeyIds,
+  setPsshKeyIds,
+  convertPsshBox,
+} from '../src/lib/main';
+import { WidevinePsshData } from '../src/lib/widevine/proto';
+import { createPssh } from '../src/lib/widevine/pssh';
+import { Pssh } from '../src/lib/playready/pssh';
+import { WrmHeader } from '../src/lib/playready/wrmheader';
+
+const KID = '00112233445566778899aabbccddeeff';
+const OTHER_KID = 'ffeeddccbbaa99887766554433221100';
+const widevine = () => setPsshKeyIds(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine }), [KID]);
+
+test('construction and parsing own their payload bytes, including Node Buffers', () => {
+  const input = Buffer.from([1, 2, 3]);
+  const box = createPsshBox({ systemId: KID, data: input });
+  input.fill(0);
+  expect(box.data).toEqual(new Uint8Array([1, 2, 3]));
+  const encoded = Buffer.from(serializePsshBox(box));
+  const parsed = parsePsshBoxes(encoded)[0];
+  encoded.fill(0);
+  expect(parsed).toEqual(box);
+});
+
+test('conversion rejects mixed PlayReady algorithms and oversized generated records', () => {
+  const source = setPsshKeyIds(widevine(), [KID, OTHER_KID]);
+  const box = convertPsshBox(source, 'playready');
+  const xml = Buffer.from(box.data.subarray(10)).toString('utf16le');
+  const mixed = new Uint8Array(box.data);
+  mixed.set(Buffer.from(xml.replace('AESCTR', 'AESCBC'), 'utf16le'), 10);
+  expect(() => convertPsshBox({ ...box, data: mixed }, 'widevine')).toThrow('mixed');
+  expect(() =>
+    convertPsshBox(source, 'playready', { laUrl: `https://example.com/${'a'.repeat(33000)}` }),
+  ).toThrow('size limit');
+});
+
+test('serializes known version 0 bytes and parses concatenated boxes from a buffer slice', () => {
+  const empty = createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine });
+  expect(Buffer.from(serializePsshBox(empty)).toString('hex')).toBe(
+    '000000207073736800000000edef8ba979d64acea3c827dcd51d21ed00000000',
+  );
+  const v1 = createPsshBox({
+    systemId: '00000000-0000-0000-0000-000000000000',
+    version: 1,
+    keyIds: [KID],
+    flags: 0xffffff,
+    data: new Uint8Array([1, 2]),
+  });
+  const joined = Buffer.concat([Buffer.from([255]), serializePsshBox(empty), serializePsshBox(v1)]);
+  expect(parsePsshBoxes(joined.subarray(1))).toEqual([empty, v1]);
+  expect(parsePsshBoxes(psshBoxToBase64(v1))).toEqual([v1]);
+  expect(getPsshKeyIds(v1)).toEqual([KID]);
+});
+
+test('accepts extended sizes and size-to-end boxes, serializing with a normal size', () => {
+  const normal = serializePsshBox(widevine());
+  const extended = Buffer.concat([normal.subarray(0, 8), Buffer.alloc(8), normal.subarray(8)]);
+  extended.writeUInt32BE(1, 0);
+  extended.writeBigUInt64BE(BigInt(extended.length), 8);
+  expect(serializePsshBox(parsePsshBoxes(extended)[0])).toEqual(normal);
+  const toEnd = normal.slice();
+  new DataView(toEnd.buffer).setUint32(0, 0);
+  expect(serializePsshBox(parsePsshBoxes(toEnd)[0])).toEqual(normal);
+});
+
+test('rejects truncation, invalid versions, overflowing KID counts and mismatched lengths', () => {
+  const bytes = serializePsshBox(
+    createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine, version: 1, keyIds: [KID] }),
+  );
+  for (let length = 0; length < bytes.length; length++) {
+    expect(() => parsePsshBoxes(bytes.subarray(0, length))).toThrow();
+  }
+  for (const [offset, value] of [
+    [0, 12],
+    [4, 0],
+    [8, 0x02000000],
+    [28, 0xffffffff],
+    [48, 1],
+  ]) {
+    const corrupt = bytes.slice();
+    new DataView(corrupt.buffer).setUint32(offset, value);
+    expect(() => parsePsshBoxes(corrupt)).toThrow();
+  }
+  expect(() => parsePsshBoxes('%%%')).toThrow();
+  expect(() => createPsshBox({ systemId: 'bad' })).toThrow();
+  expect(() => createPsshBox({ systemId: KID, flags: 0x1000000 })).toThrow();
+  expect(() =>
+    createPsshBox({ systemId: KID, version: 1, keyIds: [new Uint8Array(15)] }),
+  ).toThrow();
+});
+
+test.each([0, 1] as const)(
+  'editing Widevine v%i preserves metadata and unknown protobuf fields',
+  (version) => {
+    const payload = WidevinePsshData.encode(
+      WidevinePsshData.create({ provider: 'test-provider', contentId: new Uint8Array([1, 2, 3]) }),
+    ).finish();
+    const data = new Uint8Array([...payload, 0xf8, 0x07, 0x01]);
+    const box = createPsshBox(
+      version === 1
+        ? { systemId: PSSH_SYSTEM_IDS.widevine, data, version, keyIds: [OTHER_KID] }
+        : { systemId: PSSH_SYSTEM_IDS.widevine, data },
+    );
+    const before = serializePsshBox(box);
+    const edited = setPsshKeyIds(box, [KID, OTHER_KID]);
+    expect(serializePsshBox(box)).toEqual(before);
+    expect(getPsshKeyIds(edited)).toEqual([KID, OTHER_KID]);
+    expect(edited.keyIds).toEqual(version === 1 ? [KID, OTHER_KID] : []);
+    const parsed = createPssh(serializePsshBox(edited));
+    expect(parsed.data.provider).toBe('test-provider');
+    expect(parsed.data.contentId).toEqual(new Uint8Array([1, 2, 3]));
+    expect(Array.from(edited.data.slice(-3))).toEqual([0xf8, 0x07, 0x01]);
+    expect(getPsshKeyIds(setPsshKeyIds(edited, []))).toEqual([]);
+  },
+);
+
+test.each([0x63656e63, 0x63626373])(
+  'converts scheme %i both ways using PlayReady GUID byte order',
+  (protectionScheme) => {
+    const source = setPsshKeyIds(
+      createPsshBox({
+        systemId: PSSH_SYSTEM_IDS.widevine,
+        version: 1,
+        flags: 7,
+        data: WidevinePsshData.encode(WidevinePsshData.create({ protectionScheme })).finish(),
+      }),
+      [KID, OTHER_KID],
+    );
+    const converted = convertPsshBox(source, 'playready', {
+      laUrl: 'https://example.com/许可?a=1&b=2',
+    });
+    const header = new WrmHeader(new Pssh(serializePsshBox(converted)).wrmHeaders[0]);
+    expect(Buffer.from(header.keyIds[0].value).toString('hex')).toBe(
+      '33221100554477668899aabbccddeeff',
+    );
+    expect(header.keyIds[0].algId).toBe(protectionScheme === 0x63656e63 ? 'AESCTR' : 'AESCBC');
+    expect(header.keyIds[0].checksum).toBeNull();
+    expect(header.laUrl).toBe('https://example.com/许可?a=1&b=2');
+    expect(getPsshKeyIds({ ...converted, version: 0, keyIds: [] })).toEqual([KID, OTHER_KID]);
+    const restored = convertPsshBox(converted, 'widevine');
+    expect(getPsshKeyIds(restored)).toEqual([KID, OTHER_KID]);
+    expect(restored.flags).toBe(7);
+    expect(restored.version).toBe(1);
+    expect(WidevinePsshData.decode(restored.data).protectionScheme).toBe(protectionScheme);
+  },
+);
+
+test('reads legacy PlayReady versions and rejects corrupt objects or unsupported algorithms', () => {
+  const kid = 'MyIRAFVEd2aImaq7zN3u/w==';
+  for (const version of ['4.0.0.0', '4.1.0.0', '4.2.0.0', '4.3.0.0']) {
+    let info = `<KID ALGID="AESCTR" VALUE="${kid}"></KID>`;
+    if (version === '4.2.0.0' || version === '4.3.0.0') info = `<KIDS>${info}</KIDS>`;
+    let content = `<PROTECTINFO>${info}</PROTECTINFO>`;
+    if (version === '4.0.0.0')
+      content = `<PROTECTINFO><KEYLEN>16</KEYLEN><ALGID>AESCTR</ALGID></PROTECTINFO><KID>${kid}</KID>`;
+    const xml = Buffer.from(
+      `<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="${version}"><DATA>${content}</DATA></WRMHEADER>`,
+      'utf16le',
+    );
+    const pro = Buffer.alloc(10 + xml.length);
+    pro.writeUInt32LE(pro.length, 0);
+    pro.writeUInt16LE(1, 4);
+    pro.writeUInt16LE(1, 6);
+    pro.writeUInt16LE(xml.length, 8);
+    pro.set(xml, 10);
+    const box = createPsshBox({ systemId: PSSH_SYSTEM_IDS.playready, data: pro });
+    expect(getPsshKeyIds(box)).toEqual([KID]);
+    expect(getPsshKeyIds(convertPsshBox(box, 'widevine'))).toEqual([KID]);
+    const corrupt = { ...box, data: box.data.slice(0, -1) };
+    expect(() => getPsshKeyIds(corrupt)).toThrow();
+  }
+  const unsupported = createPsshBox({
+    systemId: PSSH_SYSTEM_IDS.widevine,
+    data: WidevinePsshData.encode(WidevinePsshData.create({ protectionScheme: 123 })).finish(),
+  });
+  expect(() => convertPsshBox(setPsshKeyIds(unsupported, [KID]), 'playready')).toThrow('scheme');
+  expect(() => convertPsshBox(widevine(), 'widevine')).toThrow('already');
+  expect(() => setPsshKeyIds(convertPsshBox(widevine(), 'playready'), [KID])).toThrow('only');
+  expect(() =>
+    convertPsshBox(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine }), 'playready'),
+  ).toThrow('at least one');
+});


### PR DESCRIPTION
## Summary

- Add APIs to parse, create, serialize, inspect, and edit PSSH boxes.
- Support Widevine and PlayReady KID extraction and conversion.
- Document the new PSSH functionality and add comprehensive tests.

## Testing

- Added Vitest coverage for parsing, serialization, validation, editing, GUID byte order, and DRM conversion.
- Not run: full test suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791209838&installation_model_id=424872&pr_number=51&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F51&signature=3384a9d1e4f9b6ebf6396d4530708c03767d6d509d981635d3739f02ae083fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->