### PR TITLE
fix(extension): remove unsafe worker response interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Okova is a set of tools (JavaScript library, command-line utility and browser ex
 
 With EME interception enabled, the extension inspects ClearKey license responses and saves their key IDs and keys as hex. ClearKey capture works without an imported device or spoofing enabled.
 
+Experimental request interception detects streaming manifests in page fetch and XMLHttpRequest responses. Requests made inside workers are not inspected.
+
 ### Installing Chrome extension
 
 **Developer Mode** needs to be enabled in `chrome://extensions/` page

--- a/src/extension/entrypoints/network.tsx
+++ b/src/extension/entrypoints/network.tsx
@@ -29,23 +29,6 @@ export default defineUnlistedScript(() => {
     window.postMessage(message, '*');
   };
 
-  const isResponseMessage = (event: MessageEvent) => {
-    return event.data && event.data.jsonrpc === '2.0' && event.data.method === 'response';
-  };
-
-  const originalWorker = window.Worker;
-  // @ts-ignore
-  window.Worker = function (scriptUrl: string | URL, options: WorkerOptions) {
-    const worker = new originalWorker(scriptUrl, options);
-    worker.addEventListener('message', (event) => {
-      if (isResponseMessage(event)) {
-        const { url, headers, text } = event.data.params;
-        postMessage(url, headers, text);
-      }
-    });
-    return worker;
-  };
-
   const inspectFetchResponse = async (response: Response) => {
     const url = response.url;
     const headers = Object.fromEntries(response.headers.entries());
@@ -134,74 +117,8 @@ export default defineUnlistedScript(() => {
     window.XMLHttpRequest = PatchedXHR;
   };
 
-  const patchBlobFetch = () => {
-    const originalCreateObjectURL = URL.createObjectURL;
-    URL.createObjectURL = function (blob) {
-      if (
-        blob instanceof Blob &&
-        (blob.type.includes('javascript') ||
-          blob.type.includes('application/x-javascript') ||
-          blob.type === 'text/javascript' ||
-          blob.type === '')
-      ) {
-        // Convert blob to text synchronously
-        const xhr = new XMLHttpRequest();
-        const url = originalCreateObjectURL(blob);
-        xhr.overrideMimeType('text/plain; charset=x-user-defined');
-        xhr.open('GET', url, false);
-        xhr.send();
-        const blobDataBuffer = Uint8Array.from(xhr.response as string, (c) => c.charCodeAt(0));
-        const sourceCode = new TextDecoder().decode(blobDataBuffer);
-        const injectionCode = `
-          const originalFetch = fetch;
-          fetch = async function(...args) {
-            const response = await originalFetch.apply(this, args);
-
-            const inspectResponse = async () => {
-              const size = response.headers.get('content-length');
-              const MAX_SIZE = 1024 * 1024 * 1; // 1 MB
-              const isSizeOk = Number(size) < MAX_SIZE;
-              if (size && !isSizeOk) return;
-
-              const type = response.headers.get('content-type');
-              const isTypeOk = type?.includes('xml') || type?.includes('dash') || type?.includes('octet-stream');
-              if (!isTypeOk) return;
-
-              const clone = response.clone();
-              const text = await clone.text();
-              const message = {
-                jsonrpc: '2.0',
-                method: 'response',
-                params: {
-                  url: response.url,
-                  text,
-                  headers: Object.fromEntries(response.headers.entries())
-                },
-                id: Date.now()
-              };
-              if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
-                self.postMessage(message);
-              } else {
-                window.postMessage(message, '*');
-              }
-            };
-            void inspectResponse().catch(error => {
-              console.warn('[okova] Fetch response inspection failed', error);
-            });
-            return response;
-          };
-        `;
-        const modifiedCode = injectionCode + '\n' + sourceCode;
-        const modifiedBlob = new Blob([modifiedCode], { type: blob.type });
-        return originalCreateObjectURL.call(URL, modifiedBlob);
-      }
-      return originalCreateObjectURL.call(URL, blob);
-    };
-  };
-
   patchFetch();
   patchXmlHttpRequest();
-  patchBlobFetch();
 
   console.log('[okova] Response interception added');
 });

--- a/src/extension/entrypoints/popup/routes/settings.tsx
+++ b/src/extension/entrypoints/popup/routes/settings.tsx
@@ -86,7 +86,10 @@ export const Settings = () => {
             Spoofing
           </Cell>
         </Section>
-        <Section header="Network" footer="Experimental feature.">
+        <Section
+          header="Network"
+          footer="Experimental feature. Requests inside workers are not inspected."
+        >
           {[
             <Cell
               subtitle="Streaming manifest URL detection"

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -1,4 +1,3 @@
-import { runInNewContext } from 'node:vm';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import network from '../src/extension/entrypoints/network';
@@ -7,7 +6,6 @@ const manifest = '<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"/>';
 const url = 'https://example.com/manifest.mpd';
 const postMessage = vi.fn();
 const nativeFetch = vi.fn<typeof fetch>();
-const nativeCreateObjectURL = vi.fn<typeof URL.createObjectURL>();
 
 // Node lacks XMLHttpRequest. Model its response getters and load events.
 class NativeXHR extends EventTarget {
@@ -41,8 +39,6 @@ beforeEach(() => {
   vi.stubGlobal('fetch', nativeFetch);
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'warn').mockImplementation(() => {});
-  // Restore the object URL patch after each test.
-  vi.spyOn(URL, 'createObjectURL').mockImplementation(nativeCreateObjectURL);
   network.main();
 });
 
@@ -154,26 +150,7 @@ test('contains XHR body inspection failures while delivering load events', async
 const makeResponse = () =>
   new Response(manifest, { headers: { 'content-type': 'application/dash+xml' } });
 
-// Execute the actual generated blob worker script with Node's real fetch body types.
-const useWorkerFetch = async () => {
-  let workerBlob: Blob | undefined;
-  const patchedCreateObjectURL = URL.createObjectURL;
-  nativeCreateObjectURL.mockImplementation((blob) => {
-    if (blob instanceof Blob) workerBlob = blob;
-    return 'blob:test';
-  });
-  patchedCreateObjectURL(new Blob([''], { type: 'text/javascript' }));
-  if (!workerBlob) throw new Error('Worker script was not generated');
-  class WorkerGlobalScope {
-    postMessage = postMessage;
-  }
-  const context = { fetch: nativeFetch, console, WorkerGlobalScope, self: new WorkerGlobalScope() };
-  runInNewContext(await workerBlob.text(), context);
-  vi.stubGlobal('fetch', context.fetch);
-};
-
-test.each(['page', 'worker'])('%s fetch returns before inspection finishes', async (context) => {
-  if (context === 'worker') await useWorkerFetch();
+test('page fetch returns before inspection finishes', async () => {
   const response = makeResponse();
   const inspection = Promise.withResolvers<string>();
   const clone = response.clone();
@@ -189,38 +166,32 @@ test.each(['page', 'worker'])('%s fetch returns before inspection finishes', asy
   await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce());
 });
 
-test.each([
-  ['page', 'clone'],
-  ['page', 'body'],
-  ['page', 'message'],
-  ['worker', 'clone'],
-  ['worker', 'body'],
-  ['worker', 'message'],
-])('%s fetch contains %s inspection failures', async (context, failure) => {
-  if (context === 'worker') await useWorkerFetch();
-  const response = makeResponse();
-  const error = new Error('Inspection failed');
-  if (failure === 'clone') {
-    vi.spyOn(response, 'clone').mockImplementation(() => {
-      throw error;
-    });
-  } else if (failure === 'body') {
-    const clone = response.clone();
-    vi.spyOn(clone, 'text').mockRejectedValue(error);
-    vi.spyOn(response, 'clone').mockReturnValue(clone);
-  } else {
-    postMessage.mockImplementation(() => {
-      throw error;
-    });
-  }
-  nativeFetch.mockResolvedValue(response);
-  expect(await fetch(url)).toBe(response);
-  expect(await response.text()).toBe(manifest);
-  await vi.waitFor(() => expect(console.warn).toHaveBeenCalledWith(expect.any(String), error));
-});
+test.each(['clone', 'body', 'message'])(
+  'page fetch contains %s inspection failures',
+  async (failure) => {
+    const response = makeResponse();
+    const error = new Error('Inspection failed');
+    if (failure === 'clone') {
+      vi.spyOn(response, 'clone').mockImplementation(() => {
+        throw error;
+      });
+    } else if (failure === 'body') {
+      const clone = response.clone();
+      vi.spyOn(clone, 'text').mockRejectedValue(error);
+      vi.spyOn(response, 'clone').mockReturnValue(clone);
+    } else {
+      postMessage.mockImplementation(() => {
+        throw error;
+      });
+    }
+    nativeFetch.mockResolvedValue(response);
+    expect(await fetch(url)).toBe(response);
+    expect(await response.text()).toBe(manifest);
+    await vi.waitFor(() => expect(console.warn).toHaveBeenCalledWith(expect.any(String), error));
+  },
+);
 
-test.each(['page', 'worker'])('%s fetch preserves network failures', async (context) => {
-  if (context === 'worker') await useWorkerFetch();
+test('page fetch preserves network failures', async () => {
   const error = new TypeError('Network failure');
   nativeFetch.mockRejectedValue(error);
   await expect(fetch(url)).rejects.toBe(error);


### PR DESCRIPTION
## Summary

- Remove worker and Blob URL response interception that modified page behavior.
- Keep manifest inspection for page-level fetch and XMLHttpRequest responses.
- Document that requests inside workers are not inspected.
- Update network interception tests to cover page-level behavior only.

## Testing

- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219007&installation_model_id=424872&pr_number=54&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F54&signature=845d7d3ed1a80af816863e390e7300ca08871eb9dfab7e18aa4c2edcef74a208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->