### PR TITLE
fix(extension): reacquire keys for previously captured PSSH

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { appStorage, getRecentKeysForUrl } from '@/utils/storage';
+import { appStorage, getRecentKeysForUrl, isCapturedKey } from '@/utils/storage';
 import { getDrmFailureStorage } from '@/utils/storage';
 import type { DrmStage, KeyInfo } from '@/utils/storage';
 import {
@@ -390,7 +390,17 @@ export default defineBackground({
             createdAt: new Date().getTime(),
           }));
           stage = 'history';
-          await setRecentKeys(keys);
+          const recentKeys = getRecentKeysForUrl(
+            message.url,
+            await appStorage.recentKeysByDomain.getValue(),
+            await appStorage.recentKeys.getValue(),
+          );
+          // Status events must not replace extracted keys or borrow another capture's metadata.
+          const capturedKeys = recentKeys.filter(
+            (key) => isCapturedKey(key) && key.url === message.url && key.pssh === initData,
+          );
+          const capturedIds = new Set(capturedKeys.map((key) => key.id));
+          await setRecentKeys([...capturedKeys, ...keys.filter((key) => !capturedIds.has(key.id))]);
           await appStorage.allKeys.add(...keys);
           await clearFailure();
           sendResponse();

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { appStorage, getRecentKeysForUrl, isCapturedKey } from '@/utils/storage';
+import { appStorage, getRecentKeysForUrl } from '@/utils/storage';
 import { getDrmFailureStorage } from '@/utils/storage';
 import type { DrmStage, KeyInfo } from '@/utils/storage';
 import {
@@ -350,7 +350,7 @@ export default defineBackground({
           updateBadgeForTabInBackground(sender.tab);
         };
 
-        // Inspect before the history shortcut so later responses can add rotated keys.
+        // Inspect each response so repeated initialization data can yield new keys.
         if (
           settings?.emeInterception &&
           message.action === 'update' &&
@@ -378,26 +378,6 @@ export default defineBackground({
         }
 
         const { initData } = message;
-        const allKeys = await appStorage.allKeys.raw.getValue();
-        const keys = allKeys?.filter(
-          (keyInfo) =>
-            keyInfo.pssh === initData &&
-            isCapturedKey(keyInfo) &&
-            (message.keySystem !== 'org.w3.clearkey' || keyInfo.url === message.url),
-        );
-        const hasKey = !!keys?.length;
-        if (hasKey && (!sessionKey || !state.sessions.has(sessionKey))) {
-          const currentSiteKeys = keys.map((keyInfo: KeyInfo) => ({
-            ...keyInfo,
-            url: message.url ?? keyInfo.url,
-            mpd: message.mpd ?? keyInfo.mpd,
-          }));
-          stage = 'history';
-          await setRecentKeys(currentSiteKeys);
-          await clearFailure();
-          sendResponse();
-          return;
-        }
 
         if (settings?.emeInterception && message.action === 'keystatuseschange') {
           const keyStatuses = message.keyStatuses as Record<string, string>;

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -202,25 +202,25 @@ test('captures keys after logging a status with spoofing disabled', async () => 
   expect(await appStorage.recentKeys.getValue()).toEqual(capturedKeys);
 
   await sendMessage({ action: 'generateRequest', initDataType: 'cenc' });
-  expect(createSession).toHaveBeenCalledOnce();
+  expect(createSession).toHaveBeenCalledTimes(2);
+  await sendMessage({ action: 'close' });
 });
 
-test('cache hits expose only captured keys matching the PSSH with current site metadata', async () => {
-  await appStorage.allKeys.setValue([
-    { ...key, value: 'usable' },
-    { ...key, id: '112233445566778899aabbccddeeff00' },
-    { ...key, id: '2233445566778899aabbccddeeff0011', pssh: 'other-pssh' },
-  ]);
+test('stored captures are not relabeled as current-site results', async () => {
+  await appStorage.allKeys.setValue([key]);
   const loadClient = vi.spyOn(appStorage.clients.active, 'getValue');
   const sendMessage = startBackground();
-  const url = 'https://other.example/video';
-  const mpd = 'https://other.example/manifest.mpd';
 
-  await sendMessage({ action: 'generateRequest', initDataType: 'cenc', url, mpd });
+  await sendMessage({
+    action: 'license-request',
+    keySystem: 'com.widevine.alpha',
+    url: 'https://other.example/video',
+    mpd: 'https://other.example/manifest.mpd',
+  });
 
-  const cachedKeys = [{ ...key, id: '112233445566778899aabbccddeeff00', url, mpd }];
-  expect(await appStorage.recentKeys.getValue()).toEqual(cachedKeys);
-  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'other.example': cachedKeys });
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+  expect((await appStorage.recentKeys.getValue()) ?? []).toEqual([]);
+  expect((await appStorage.recentKeysByDomain.getValue()) ?? {}).toEqual({});
   expect(loadClient).not.toHaveBeenCalled();
 });
 

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -232,3 +232,43 @@ test('retains different values and content metadata for a reused KID', async () 
   await appStorage.allKeys.remove(otherValue);
   expect(await appStorage.allKeys.getValue()).toEqual([key, otherContent]);
 });
+
+test.each([
+  { url: key.url, pssh: key.pssh, preservesCapture: true },
+  { url: 'https://example.com/another-video', pssh: key.pssh, preservesCapture: false },
+  { url: key.url, pssh: 'another-pssh', preservesCapture: false },
+])('scopes captured recent keys to the status event context: $url, $pssh', async (context) => {
+  await appStorage.settings.setValue({
+    spoofing: false,
+    emeInterception: true,
+    requestInterception: false,
+    theme: 'auto',
+  });
+  await appStorage.recentKeys.setValue([key]);
+  await appStorage.recentKeysByDomain.setForUrl(key.url, [key]);
+  const sendMessage = startBackground();
+  const otherId = '112233445566778899aabbccddeeff00';
+  await sendMessage({
+    action: 'keystatuseschange',
+    url: context.url,
+    initData: context.pssh,
+    keyStatuses: {
+      [fromHex(key.id).toBase64()]: 'usable',
+      [fromHex(otherId).toBase64()]: 'expired',
+    },
+  });
+  const status = (id: string, value: string) => ({
+    ...key,
+    id,
+    value,
+    url: context.url,
+    pssh: context.pssh,
+    createdAt: expect.any(Number),
+  });
+  const expected = [
+    context.preservesCapture ? key : status(key.id, 'usable'),
+    status(otherId, 'expired'),
+  ];
+  expect(await appStorage.recentKeys.getValue()).toEqual(expected);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': expected });
+});

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -662,7 +662,7 @@ test('retains reused ClearKey IDs across origins and status events', async () =>
     await send('update', 'clear', {}, { ...context, message });
     await send('keystatuseschange', 'clear', {}, { ...context, keyStatuses: { 'AA==': 'usable' } });
     expect(await appStorage.recentKeys.getValue()).toMatchObject([
-      { id: '00', value: 'usable', url: capture.url },
+      { id: '00', value: capture.value, url: capture.url },
     ]);
   }
   const history = await appStorage.allKeys.getValue();
@@ -724,6 +724,19 @@ test.each(['https://example.com/video', 'https://other.example/video'])(
     };
     await expect(send('update', 'fresh', {}, context)).resolves.toEqual({ keys: [captured] });
     expect(await appStorage.recentKeys.getValue()).toEqual([captured]);
+    await send(
+      'keystatuseschange',
+      'fresh',
+      {},
+      {
+        ...context,
+        keyStatuses: { [fromBuffer(Buffer.from(captured.id, 'hex')).toBase64()]: 'usable' },
+      },
+    );
+    expect(await appStorage.recentKeys.getValue()).toEqual([captured]);
+    expect(await appStorage.recentKeysByDomain.getValue()).toEqual({
+      [new URL(url).hostname]: [captured],
+    });
     expect(await appStorage.allKeys.getValue()).toEqual([oldKey, captured]);
     expect(Session.prototype.close).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -515,15 +515,6 @@ test('cleanup failures preserve the original diagnostic and still respond', asyn
 });
 
 test('an old document cannot clear a new document failure after navigation', async () => {
-  const key = {
-    id: '00112233445566778899aabbccddeeff',
-    value: 'ffeeddccbbaa99887766554433221100',
-    url: 'https://example.com/video',
-    mpd: '',
-    pssh: 'cHNzaA==',
-    createdAt: Date.now(),
-  };
-  await appStorage.allKeys.setValue([key]);
   const updated = vi.spyOn(browser.tabs.onUpdated, 'addListener');
   const send = startBackground();
   const started = Promise.withResolvers<void>();
@@ -534,7 +525,14 @@ test('an old document cannot clear a new document failure after navigation', asy
     await resumeWrite.promise;
     await setRecentKeys(keys);
   });
-  const oldRequest = send('generateRequest', 'old', { tab: tab(1), documentId: 'old' });
+  const oldRequest = send(
+    'keystatuseschange',
+    'old',
+    { tab: tab(1), documentId: 'old' },
+    {
+      keyStatuses: { 'AAECAw==': 'usable' },
+    },
+  );
   await started.promise;
   updated.mock.calls[0]![0](1, { status: 'loading' }, tab(1));
   vi.mocked(appStorage.clients.active.getValue).mockResolvedValue(null);
@@ -664,7 +662,7 @@ test('retains reused ClearKey IDs across origins and status events', async () =>
     await send('update', 'clear', {}, { ...context, message });
     await send('keystatuseschange', 'clear', {}, { ...context, keyStatuses: { 'AA==': 'usable' } });
     expect(await appStorage.recentKeys.getValue()).toMatchObject([
-      { id: '00', value: capture.value, url: capture.url },
+      { id: '00', value: 'usable', url: capture.url },
     ]);
   }
   const history = await appStorage.allKeys.getValue();
@@ -695,3 +693,39 @@ test('a recovered ClearKey history write clears its diagnostic', async () => {
   });
   expect(await getDrmFailureStorage(1).getValue()).toBeNull();
 });
+
+test.each(['https://example.com/video', 'https://other.example/video'])(
+  'acquires fresh keys for a previously captured PSSH at %s',
+  async (url) => {
+    const oldKey = {
+      id: '00112233445566778899aabbccddeeff',
+      value: '000102030405060708090a0b0c0d0e0f',
+      url: 'https://example.com/video',
+      mpd: 'https://example.com/old.mpd',
+      pssh: 'cHNzaA==',
+      createdAt: 1,
+    };
+    await appStorage.allKeys.setValue([oldKey]);
+    const readHistory = vi.spyOn(appStorage.allKeys.raw, 'getValue');
+    const send = startBackground();
+    const context = { keySystem: 'com.widevine.alpha', url, mpd: `${url}/new.mpd` };
+    await send('generateRequest', 'fresh', {}, context);
+    expect(Session.prototype.generateRequest).toHaveBeenCalledOnce();
+    await expect(send('license-request', 'fresh', {}, context)).resolves.toBe(
+      btoa(sessions[0]!.sessionId),
+    );
+    expect(readHistory).not.toHaveBeenCalled();
+    const captured = {
+      ...oldKey,
+      value: 'ffeeddccbbaa99887766554433221100',
+      url,
+      mpd: context.mpd,
+      createdAt: Date.now(),
+    };
+    await expect(send('update', 'fresh', {}, context)).resolves.toEqual({ keys: [captured] });
+    expect(await appStorage.recentKeys.getValue()).toEqual([captured]);
+    expect(await appStorage.allKeys.getValue()).toEqual([oldKey, captured]);
+    expect(Session.prototype.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  },
+);


### PR DESCRIPTION
## Summary

- Reacquire fresh DRM keys when previously captured PSSH data is encountered.
- Stop relabeling historical captures as current-site results.
- Remove obsolete remote session mutation locking and concurrency tests.

## Testing

- Not run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791220189&installation_model_id=424872&pr_number=56&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F56&signature=62c64e5a868dd853f01a5923f8efd97f045b46169d1dbc71b781aea3a2bad809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->