### PR TITLE
fix(serve): enforce session and request limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,31 @@ certificate changes, updates, close, or delete requests return HTTP 409. Wait fo
 the active request to finish before retrying. Requests for different sessions
 can run concurrently; key retrieval remains available during mutations.
 
+The server limits sessions and concurrent requests across all users and devices.
+In `okova.config.json`, optional `sessionLimits` fields override these defaults:
+
+```json
+{
+  "sessionLimits": {
+    "maxSessions": 64,
+    "maxConcurrentRequests": 64,
+    "idleTimeoutMs": 300000,
+    "keyWaitTimeoutMs": 30000
+  }
+}
+```
+
+Limits must be positive integers. Excess session opens or concurrent requests
+return HTTP 503; clients can retry after existing work finishes or sessions close.
+Session capacity includes opens still loading a device. Each request for an
+existing session refreshes its idle timer. Idle expiry closes the native session,
+clears its keys, and releases waiting requests. Keep sessions active while using
+them and create a new one after expiry. Server shutdown also closes sessions.
+
+`GET /sessions/:id/keys` returns HTTP 504 if no key-status event arrives before
+`keyWaitTimeoutMs`. Disconnecting cancels that request's wait without closing the
+session. Each session keeps its own certificates and custom PlayReady data.
+
 ### Inspect, edit, and convert PSSH boxes
 
 ```ts

--- a/src/cli/commands/serve/api/session.ts
+++ b/src/cli/commands/serve/api/session.ts
@@ -5,15 +5,7 @@ import { createMiddleware } from 'hono/factory';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 
-import {
-  fromBuffer,
-  MediaKeyMessageEvent,
-  PlayReady,
-  requestMediaKeySystemAccess,
-  setSupportedEngines,
-  Widevine,
-  type Session,
-} from '../../../../lib';
+import { fromBuffer, MediaKeyMessageEvent, PlayReady, Widevine, Session } from '../../../../lib';
 import { WidevineDeviceCredentials } from '../../../../lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '../../../../lib/playready/device-credentials';
 import { clients, config, resolveClient, sessions } from '../state';
@@ -37,6 +29,25 @@ const secretKeyMiddleware = createMiddleware(async (c, next) => {
 });
 
 app.use(secretKeyMiddleware);
+app.use(async (c, next) => {
+  const release = sessions.beginRequest();
+  if (!release) return c.json({ error: 'Concurrent request limit reached' }, 503);
+  try {
+    await next();
+  } finally {
+    release();
+  }
+});
+
+const reserveSession = createMiddleware(async (c, next) => {
+  const release = sessions.reserve();
+  if (!release) return c.json({ error: 'Session capacity reached' }, 503);
+  try {
+    await next();
+  } finally {
+    release();
+  }
+});
 
 const busySessions = new WeakSet<Session>();
 
@@ -58,6 +69,7 @@ const exclusiveSessionMutation = createMiddleware(async (c, next) => {
 
 app.post(
   '/',
+  reserveSession,
   zValidator(
     'json',
     z.object({
@@ -108,12 +120,8 @@ app.post(
         ? new Widevine({ deviceCredentials: client })
         : new PlayReady({ deviceCredentials: client, customData: c.req.valid('json').customData });
 
-    setSupportedEngines([cdm]);
-    const keySystemAccess = requestMediaKeySystemAccess(cdm.keySystem, []);
-    const mediaKeys = await keySystemAccess.createMediaKeys();
-
     const sessionType = c.req.valid('json').sessionType as MediaKeySessionType | undefined;
-    const session = mediaKeys.createSession(sessionType);
+    const session = new Session(sessionType, cdm);
 
     const sessionKey = `${secretKey ?? ''}:${session.sessionId}`;
     sessions.set(sessionKey, session);
@@ -294,8 +302,20 @@ app.get('/:id/keys', zValidator('param', z.object({ id: z.string() })), async (c
   if (!session) {
     return c.json({ error: 'Session not found. Unable to get keys.' }, 400);
   }
-  const keys = await session.waitForKeyStatusesChange();
-  return c.json(Object.fromEntries(keys));
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.sessionLimits.keyWaitTimeoutMs);
+  try {
+    const keys = await session.waitForKeyStatusesChange({
+      signal: AbortSignal.any([c.req.raw.signal, controller.signal]),
+    });
+    return c.json(Object.fromEntries(keys));
+  } catch (error) {
+    if (c.req.raw.signal.aborted) return c.json({ error: 'Request aborted' }, 408);
+    if (controller.signal.aborted) return c.json({ error: 'Timed out waiting for keys' }, 504);
+    return c.json({ error: error instanceof Error ? error.message : 'Session closed' }, 400);
+  } finally {
+    clearTimeout(timeout);
+  }
 });
 
 app.post(

--- a/src/cli/commands/serve/serve.ts
+++ b/src/cli/commands/serve/serve.ts
@@ -35,6 +35,20 @@ export const serve = async (options: ServeOptions = {}) => {
   }
 
   const app = new Hono();
+  const pendingRequests = new Set<Promise<void>>();
+  let isShuttingDown = false;
+
+  app.use(async (c, next) => {
+    if (isShuttingDown) return c.json({ error: 'Server is shutting down' }, 503);
+    const completed = Promise.withResolvers<void>();
+    pendingRequests.add(completed.promise);
+    try {
+      await next();
+    } finally {
+      pendingRequests.delete(completed.promise);
+      completed.resolve();
+    }
+  });
 
   app.use(logger());
   app.use(secureHeaders());
@@ -50,16 +64,22 @@ export const serve = async (options: ServeOptions = {}) => {
   });
 
   const shutdown = () => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
     const disconnected = new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
-    void Promise.all([disconnected, sessions.clear()]).then(
-      () => process.exit(0),
-      (error: unknown) => {
-        console.error('Failed to shut down server', error);
-        process.exit(1);
-      },
-    );
+    // Release key waiters first, then close sessions created by requests still draining.
+    // Track handlers too: a pending device load can outlive its disconnected socket.
+    void Promise.all([disconnected, sessions.clear(), ...pendingRequests])
+      .then(() => sessions.clear())
+      .then(
+        () => process.exit(0),
+        (error: unknown) => {
+          console.error('Failed to shut down server', error);
+          process.exit(1);
+        },
+      );
   };
   process.once('SIGINT', shutdown);
   process.once('SIGTERM', shutdown);

--- a/src/cli/commands/serve/serve.ts
+++ b/src/cli/commands/serve/serve.ts
@@ -6,7 +6,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { showRoutes } from 'hono/dev';
 import { serve as nodeServe } from '@hono/node-server';
 import { help } from './help';
-import { config, loadConfig } from './state';
+import { config, loadConfig, sessions } from './state';
 import session from './api/session';
 
 type ServeOptions = {
@@ -49,20 +49,20 @@ export const serve = async (options: ServeOptions = {}) => {
     hostname: options.host ?? config.host ?? '0.0.0.0',
   });
 
-  process.on('SIGINT', () => {
-    server.close();
-    process.exit(0);
-  });
-
-  process.on('SIGTERM', () => {
-    server.close((err) => {
-      if (err) {
-        console.error(err);
-        process.exit(1);
-      }
-      process.exit(0);
+  const shutdown = () => {
+    const disconnected = new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
     });
-  });
+    void Promise.all([disconnected, sessions.clear()]).then(
+      () => process.exit(0),
+      (error: unknown) => {
+        console.error('Failed to shut down server', error);
+        process.exit(1);
+      },
+    );
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
 };
 
 serve.help = help;

--- a/src/cli/commands/serve/session-registry.ts
+++ b/src/cli/commands/serve/session-registry.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import type { Session } from '../../../lib/api';
+
+const timeoutMs = z.number().int().positive().max(2_147_483_647);
+export const sessionLimitsSchema = z.object({
+  maxSessions: z.number().int().positive().default(64),
+  maxConcurrentRequests: z.number().int().positive().default(64),
+  idleTimeoutMs: timeoutMs.default(300_000),
+  keyWaitTimeoutMs: timeoutMs.default(30_000),
+});
+
+type Entry = {
+  session: Session;
+  timer: ReturnType<typeof setTimeout>;
+  handleClosed: () => void;
+};
+
+export class SessionRegistry {
+  #entries = new Map<string, Entry>();
+  #pendingSessions = 0;
+  #activeRequests = 0;
+
+  constructor(readonly getLimits: () => z.infer<typeof sessionLimitsSchema>) {}
+
+  get size() {
+    return this.#entries.size;
+  }
+
+  // Reserve before asynchronous device loading so simultaneous opens cannot exceed capacity.
+  reserve() {
+    if (this.size + this.#pendingSessions >= this.getLimits().maxSessions) return;
+    this.#pendingSessions++;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.#pendingSessions--;
+    };
+  }
+
+  beginRequest() {
+    if (this.#activeRequests >= this.getLimits().maxConcurrentRequests) return;
+    this.#activeRequests++;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.#activeRequests--;
+    };
+  }
+
+  set(key: string, session: Session) {
+    if (this.#entries.has(key)) throw new Error('Session already registered');
+    if (this.size >= this.getLimits().maxSessions) throw new Error('Session capacity reached');
+    const handleClosed = () => this.delete(key);
+    const timer = setTimeout(() => {
+      void this.#close(key).catch((error: unknown) => {
+        console.error('Failed to close expired session', error);
+      });
+    }, this.getLimits().idleTimeoutMs);
+    timer.unref();
+    this.#entries.set(key, { session, timer, handleClosed });
+    session.addEventListener('closed', handleClosed, { once: true });
+  }
+
+  get(key: string) {
+    const entry = this.#entries.get(key);
+    entry?.timer.refresh();
+    return entry?.session;
+  }
+
+  has(key: string) {
+    return this.#entries.has(key);
+  }
+
+  *values() {
+    for (const entry of this.#entries.values()) yield entry.session;
+  }
+
+  delete(key: string) {
+    const entry = this.#entries.get(key);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    entry.session.removeEventListener('closed', entry.handleClosed);
+    this.#entries.delete(key);
+  }
+
+  async #close(key: string) {
+    const entry = this.#entries.get(key);
+    if (!entry) return;
+    try {
+      await entry.session.close();
+    } finally {
+      this.delete(key);
+    }
+  }
+
+  async clear() {
+    await Promise.all([...this.#entries.keys()].map((key) => this.#close(key)));
+  }
+}

--- a/src/cli/commands/serve/state.ts
+++ b/src/cli/commands/serve/state.ts
@@ -2,9 +2,8 @@ import { readFile } from 'node:fs/promises';
 import { basename, extname, resolve } from 'node:path';
 import { WidevineDeviceCredentials } from '../../../lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '../../../lib/playready/device-credentials';
-import { Session } from '../../../lib';
+import { SessionRegistry, sessionLimitsSchema } from './session-registry';
 
-export const sessions = new Map<string, Session>();
 export const clients = new Map<string, WidevineDeviceCredentials | PlayReadyDeviceCredentials>();
 
 type Config = {
@@ -13,6 +12,7 @@ type Config = {
   clients: string[];
   users: { [secretKey: string]: { name: string; clients: string[] } };
   forcePrivacyMode: boolean;
+  sessionLimits: ReturnType<typeof sessionLimitsSchema.parse>;
 };
 
 const defaultConfig = {
@@ -21,9 +21,11 @@ const defaultConfig = {
   clients: [],
   users: {},
   forcePrivacyMode: true,
+  sessionLimits: sessionLimitsSchema.parse({}),
 };
 
-export const config: Config = defaultConfig;
+export const config: Config = structuredClone(defaultConfig);
+export const sessions = new SessionRegistry(() => config.sessionLimits);
 
 // Aliases must identify exactly one configured device, regardless of list order.
 export const resolveClient = (identifier: string) => {
@@ -45,5 +47,6 @@ export const loadConfig = async (configPath: string) => {
   const data = await readFile(configPath, { encoding: 'utf-8' })
     .then((data) => JSON.parse(data))
     .catch(() => defaultConfig);
-  Object.assign(config, data);
+  const sessionLimits = sessionLimitsSchema.parse(data.sessionLimits ?? {});
+  Object.assign(config, data, { sessionLimits });
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -432,14 +432,20 @@ export class Session extends EventTarget implements MediaKeySession {
     });
   }
 
-  async waitForKeyStatusesChange() {
+  async waitForKeyStatusesChange(options: Pick<WaitForKeysOptions, 'signal'> = {}) {
     if (this.#closed) throw new Error('Session closed');
+    options.signal?.throwIfAborted();
     if (this.keys.size) return new Map(this.keys);
 
     return new Promise<MediaKeysMap>((resolve, reject) => {
       const cleanup = () => {
         this.removeEventListener('keystatuseschange', handler);
         this.removeEventListener('closed', handleClosed);
+        options.signal?.removeEventListener('abort', handleAbort);
+      };
+      const handleAbort = () => {
+        cleanup();
+        reject(options.signal?.reason ?? new Error('Aborted while waiting for keys'));
       };
       const handleClosed = () => {
         cleanup();
@@ -452,6 +458,7 @@ export class Session extends EventTarget implements MediaKeySession {
 
       this.addEventListener('keystatuseschange', handler);
       this.addEventListener('closed', handleClosed);
+      options.signal?.addEventListener('abort', handleAbort, { once: true });
     });
   }
 

--- a/test/playready-custom-data.test.ts
+++ b/test/playready-custom-data.test.ts
@@ -29,8 +29,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
-  for (const session of sessions.values()) await session.close();
-  sessions.clear();
+  await sessions.clear();
   clients.clear();
   Object.assign(config, originalConfig);
   vi.unstubAllGlobals();
@@ -156,4 +155,23 @@ test.each([
   } finally {
     await session.close();
   }
+});
+
+test('remote capacity applies across separate PlayReady engines', async () => {
+  config.clients = ['capacity.prd'];
+  config.users = {};
+  config.sessionLimits = { ...originalConfig.sessionLimits, maxSessions: 16 };
+  clients.set(resolve('capacity.prd'), deviceCredentials);
+  const responses = await Promise.all(
+    Array.from({ length: 17 }, () =>
+      sessionApi.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      }),
+    ),
+  );
+  expect(responses.filter((response) => response.status === 200)).toHaveLength(16);
+  expect(responses.filter((response) => response.status === 503)).toHaveLength(1);
+  expect(sessions.size).toBe(16);
 });

--- a/test/privacy.test.ts
+++ b/test/privacy.test.ts
@@ -22,10 +22,10 @@ beforeEach(async () => {
   clients.set(resolve('test.wvd'), await loadWidevineDeviceCredentials());
 });
 
-afterEach(() => {
+afterEach(async () => {
   Object.assign(config, originalConfig);
   clients.clear();
-  sessions.clear();
+  await sessions.clear();
   vi.unstubAllGlobals();
 });
 

--- a/test/serve-devices.test.ts
+++ b/test/serve-devices.test.ts
@@ -19,8 +19,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  for (const session of sessions.values()) await session.close();
-  sessions.clear();
+  await sessions.clear();
   clients.clear();
   Object.assign(config, originalConfig);
   await rm(directory, { recursive: true, force: true });

--- a/test/serve-session-concurrency.test.ts
+++ b/test/serve-session-concurrency.test.ts
@@ -42,8 +42,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  for (const session of sessions.values()) await session.close();
-  sessions.clear();
+  await sessions.clear();
   Object.assign(config, originalConfig);
 });
 

--- a/test/serve-session-limits.test.ts
+++ b/test/serve-session-limits.test.ts
@@ -1,0 +1,213 @@
+import { getEventListeners, once } from 'node:events';
+import { request as httpRequest } from 'node:http';
+import { resolve } from 'node:path';
+import { serve } from '@hono/node-server';
+import { afterEach, assert, beforeEach, expect, test, vi } from 'vitest';
+import sessionApi from '../src/cli/commands/serve/api/session';
+import { clients, config, sessions } from '../src/cli/commands/serve/state';
+import { SessionRegistry, sessionLimitsSchema } from '../src/cli/commands/serve/session-registry';
+import { Session } from '../src/lib/api';
+import { Widevine } from '../src/lib/widevine/engine';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+} from '../src/lib/widevine/proto';
+
+const originalConfig = structuredClone(config);
+const credentials = new WidevineDeviceCredentials(
+  ClientIdentification.create({
+    token: SignedDrmCertificate.encode(
+      SignedDrmCertificate.create({
+        drmCertificate: DrmCertificate.encode(DrmCertificate.create({ systemId: 1 })).finish(),
+      }),
+    ).finish(),
+  }),
+);
+
+beforeEach(() => {
+  config.clients = ['test.wvd'];
+  config.users = {};
+  config.forcePrivacyMode = false;
+  config.sessionLimits = sessionLimitsSchema.parse({ maxSessions: 2, idleTimeoutMs: 1000 });
+  clients.set(resolve('test.wvd'), credentials);
+});
+
+afterEach(async () => {
+  await sessions.clear();
+  clients.clear();
+  Object.assign(config, structuredClone(originalConfig));
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const open = (client?: string) =>
+  sessionApi.request('/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client }),
+  });
+
+const registeredSession = () => {
+  const engine = new Widevine({ deviceCredentials: credentials });
+  const session = new Session('temporary', engine);
+  sessions.set(`:${session.sessionId}`, session);
+  return { session, engine, path: `/${session.sessionId}` };
+};
+
+test('simultaneous opens respect capacity before creating engines and close releases a slot', async () => {
+  const create = vi.spyOn(Widevine.prototype, 'createSession');
+  const responses = await Promise.all(Array.from({ length: 10 }, () => open()));
+  expect(responses.filter((response) => response.status === 200)).toHaveLength(2);
+  expect(responses.filter((response) => response.status === 503)).toHaveLength(8);
+  expect(create).toHaveBeenCalledTimes(2);
+  expect(sessions.size).toBe(2);
+  const session = sessions.values().next().value;
+  assert(session);
+  expect((await sessionApi.request(`/${session.sessionId}/close`, { method: 'POST' })).status).toBe(
+    200,
+  );
+  expect((await open()).status).toBe(200);
+});
+
+test('failed creation releases its reservation', async () => {
+  for (let index = 0; index < 3; index++) expect((await open('missing')).status).toBe(400);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(Widevine.prototype, 'createSession').mockImplementationOnce(() => {
+    throw new Error('Failed to create native session');
+  });
+  expect((await open()).status).toBe(500);
+  expect((await open()).status).toBe(200);
+  expect((await open()).status).toBe(200);
+});
+
+test('capacity counts pending creation across owners and devices', async () => {
+  const registry = new SessionRegistry(() => config.sessionLimits);
+  const releaseFirst = registry.reserve();
+  const releaseSecond = registry.reserve();
+  expect(releaseFirst).toBeTypeOf('function');
+  expect(releaseSecond).toBeTypeOf('function');
+  expect(registry.reserve()).toBeUndefined();
+  releaseFirst?.();
+  releaseFirst?.();
+  const releaseThird = registry.reserve();
+  expect(releaseThird).toBeTypeOf('function');
+  expect(registry.reserve()).toBeUndefined();
+  releaseSecond?.();
+  releaseThird?.();
+});
+
+test('requests refresh idle expiry, which closes the native session and pending key wait', async () => {
+  vi.useFakeTimers();
+  const { session, engine, path } = registeredSession();
+  await vi.advanceTimersByTimeAsync(900);
+  const pending = sessionApi.request(`${path}/keys`);
+  await vi.advanceTimersByTimeAsync(900);
+  expect(sessions.size).toBe(1);
+  await vi.advanceTimersByTimeAsync(100);
+  expect((await pending).status).toBe(400);
+  expect(sessions.size).toBe(0);
+  expect(engine.sessions.size).toBe(0);
+  expect(getEventListeners(session, 'keystatuseschange')).toHaveLength(0);
+  await expect(session.update(new Uint8Array())).rejects.toThrow('Session closed');
+  expect((await open()).status).toBe(200);
+});
+
+test('key wait deadline removes listeners and releases concurrent request capacity', async () => {
+  vi.useFakeTimers();
+  config.sessionLimits.maxConcurrentRequests = 1;
+  config.sessionLimits.keyWaitTimeoutMs = 100;
+  const { session, path } = registeredSession();
+  const pending = sessionApi.request(`${path}/keys`);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(getEventListeners(session, 'keystatuseschange')).toHaveLength(1);
+  expect((await open()).status).toBe(503);
+  await vi.advanceTimersByTimeAsync(100);
+  const response = await pending;
+  expect(response.status).toBe(504);
+  expect(await response.json()).toEqual({ error: 'Timed out waiting for keys' });
+  expect(getEventListeners(session, 'keystatuseschange')).toHaveLength(0);
+  expect((await open()).status).toBe(200);
+});
+
+test.each([false, true])(
+  'aborted key requests clean up, already aborted: %s',
+  async (alreadyAborted) => {
+    const { session, path } = registeredSession();
+    const controller = new AbortController();
+    const listening = Promise.withResolvers<void>();
+    const addListener = session.addEventListener.bind(session);
+    vi.spyOn(session, 'addEventListener').mockImplementation((...args) => {
+      addListener(...args);
+      if (args[0] === 'keystatuseschange') listening.resolve();
+    });
+    if (alreadyAborted) controller.abort();
+    const pending = sessionApi.request(`${path}/keys`, { signal: controller.signal });
+    if (!alreadyAborted) {
+      await listening.promise;
+      controller.abort();
+    }
+    expect((await pending).status).toBe(408);
+    expect(getEventListeners(session, 'keystatuseschange')).toHaveLength(0);
+    expect(sessions.size).toBe(1);
+  },
+);
+
+test('a real client disconnect cancels its key wait', async () => {
+  const { session, path } = registeredSession();
+  const listening = Promise.withResolvers<void>();
+  const finished = Promise.withResolvers<void>();
+  const addListener = session.addEventListener.bind(session);
+  vi.spyOn(session, 'addEventListener').mockImplementation((...args) => {
+    addListener(...args);
+    if (args[0] === 'keystatuseschange') listening.resolve();
+  });
+  const server = serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch: async (request) => {
+      try {
+        return await sessionApi.fetch(request);
+      } finally {
+        finished.resolve();
+      }
+    },
+  });
+  let request: ReturnType<typeof httpRequest> | undefined;
+  try {
+    if (!server.listening) await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP address');
+    request = httpRequest(`http://127.0.0.1:${address.port}${path}/keys`);
+    request.on('error', () => {});
+    request.end();
+    await listening.promise;
+    request.destroy();
+    await finished.promise;
+    expect(getEventListeners(session, 'keystatuseschange')).toHaveLength(0);
+    expect(sessions.size).toBe(1);
+  } finally {
+    request?.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test('clearing the registry closes every engine and key waiter', async () => {
+  const first = registeredSession();
+  const second = registeredSession();
+  const waiting = expect(first.session.waitForKeyStatusesChange()).rejects.toThrow(
+    'Session closed',
+  );
+  await sessions.clear();
+  await waiting;
+  expect(sessions.size).toBe(0);
+  expect(first.engine.sessions.size).toBe(0);
+  expect(second.engine.sessions.size).toBe(0);
+});
+
+test.each([0, -1, 1.5, Infinity, '64', null])('rejects invalid limits: %s', (value) => {
+  for (const field of Object.keys(config.sessionLimits)) {
+    expect(sessionLimitsSchema.safeParse({ [field]: value }).success).toBe(false);
+  }
+});

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -28,6 +28,7 @@ test.each([true, false])('binds using CLI overrides when supplied: %s', async (h
       host: hasOverrides ? '192.0.2.1' : '127.0.0.1',
       port: hasOverrides ? 1 : 0,
       clients: ['clients/client.wvd'],
+      sessionLimits: { maxSessions: 3 },
       users: {},
     }),
   );
@@ -37,6 +38,7 @@ test.each([true, false])('binds using CLI overrides when supplied: %s', async (h
       config: configPath,
       ...(hasOverrides ? { host: '127.0.0.1', port: 0 } : {}),
     });
+    expect(config.sessionLimits).toMatchObject({ maxSessions: 3, keyWaitTimeoutMs: 30_000 });
     const server = startServer.mock.results[0]?.value;
     expect(server).toBeDefined();
     if (!server) return;

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -3,9 +3,17 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as nodeServer from '@hono/node-server';
-import { expect, test, vi } from 'vitest';
+import { assert, expect, test, vi } from 'vitest';
 import { serve } from '../src/cli/commands/serve/serve';
-import { config } from '../src/cli/commands/serve/state';
+import { clients, config, sessions } from '../src/cli/commands/serve/state';
+import { Session } from '../src/lib/api';
+import { Widevine } from '../src/lib/widevine/engine';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+} from '../src/lib/widevine/proto';
 
 vi.mock('@hono/node-server', async (importOriginal) => {
   const original = await importOriginal<typeof import('@hono/node-server')>();
@@ -62,3 +70,122 @@ test.each([true, false])('binds using CLI overrides when supplied: %s', async (h
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test.each([false, true])(
+  'shutdown closes sessions from pending device loads, disconnected: %s',
+  async (disconnect) => {
+    const directory = await mkdtemp(join(tmpdir(), 'okova-shutdown-'));
+    const configPath = join(directory, 'config.json');
+    const clientPath = join(directory, 'client.wvd');
+    const originalConfig = structuredClone(config);
+    const originalListeners = {
+      SIGINT: process.listeners('SIGINT'),
+      SIGTERM: process.listeners('SIGTERM'),
+    };
+    const credentials = new WidevineDeviceCredentials(
+      ClientIdentification.create({
+        token: SignedDrmCertificate.encode(
+          SignedDrmCertificate.create({
+            drmCertificate: DrmCertificate.encode(DrmCertificate.create({ systemId: 1 })).finish(),
+          }),
+        ).finish(),
+      }),
+    );
+    const parsing = Promise.withResolvers<void>();
+    const resumeParsing = Promise.withResolvers<void>();
+    const exited = Promise.withResolvers<void>();
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      exited.resolve();
+      return undefined as never;
+    });
+    vi.spyOn(WidevineDeviceCredentials, 'from').mockImplementation(async () => {
+      parsing.resolve();
+      await resumeParsing.promise;
+      return credentials;
+    });
+    const createSession = vi.spyOn(Widevine.prototype, 'createSession');
+    const startServer = vi.mocked(nodeServer.serve);
+    startServer.mockClear();
+    const controller = new AbortController();
+    let pendingResponse: Promise<number | undefined> | undefined;
+
+    try {
+      await writeFile(clientPath, 'WVD');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          host: '127.0.0.1',
+          port: 0,
+          clients: [clientPath],
+          users: {},
+        }),
+      );
+      await serve({ config: configPath });
+      const server = startServer.mock.results[0]?.value;
+      assert(server);
+      if (!server.listening) await once(server, 'listening');
+      const address = server.address();
+      assert(address && typeof address !== 'string');
+
+      const existing = new Session('temporary', new Widevine({ deviceCredentials: credentials }));
+      sessions.set(`:${existing.sessionId}`, existing);
+      const keyWait = expect(existing.waitForKeyStatusesChange()).rejects.toThrow('Session closed');
+      createSession.mockClear();
+      pendingResponse = fetch(`http://127.0.0.1:${address.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Connection: 'close' },
+        body: '{}',
+        signal: controller.signal,
+      }).then(
+        async (response) => {
+          await response.json();
+          return response.status;
+        },
+        (error: unknown) => {
+          if (!controller.signal.aborted) throw error;
+          return undefined;
+        },
+      );
+      await parsing.promise;
+      const shutdown = process
+        .listeners('SIGTERM')
+        .find((listener) => !originalListeners.SIGTERM.includes(listener));
+      assert(shutdown);
+      const disconnected = once(server, 'close');
+      if (disconnect) controller.abort();
+      shutdown('SIGTERM');
+      await keyWait;
+      if (disconnect) await disconnected;
+      expect(exit).not.toHaveBeenCalled();
+
+      resumeParsing.resolve();
+      expect(await pendingResponse).toBe(disconnect ? undefined : 200);
+      await exited.promise;
+      expect(exit).toHaveBeenCalledExactlyOnceWith(0);
+      expect(createSession).toHaveBeenCalledOnce();
+      const native = createSession.mock.results[0]?.value;
+      assert(native);
+      await expect(native.update(new Uint8Array())).rejects.toThrow('Session closed');
+      expect(sessions.size).toBe(0);
+    } finally {
+      resumeParsing.resolve();
+      controller.abort();
+      await pendingResponse;
+      const server = startServer.mock.results[0]?.value;
+      if (server?.listening) {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+      await sessions.clear();
+      clients.clear();
+      Object.assign(config, originalConfig);
+      for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+        for (const listener of process.listeners(signal)) {
+          if (!originalListeners[signal].includes(listener))
+            process.removeListener(signal, listener);
+        }
+      }
+      vi.restoreAllMocks();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/session-close.test.ts
+++ b/test/session-close.test.ts
@@ -65,8 +65,8 @@ const createSession = (kind: string) => {
   return { native, engine, session: new Session('temporary', engine, native) };
 };
 
-afterEach(() => {
-  sessions.clear();
+afterEach(async () => {
+  await sessions.clear();
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

- Add configurable global session and concurrent-request limits.
- Enforce capacity during asynchronous session creation.
- Expire idle sessions and clean up native resources on shutdown.
- Add key-wait timeouts and request-abort handling.
- Reuse captured extension keys safely and update related tests.

## Testing

- Added coverage for session capacity, request limits, idle expiry, timeouts, aborts, cleanup, and invalid configuration.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791221082&installation_model_id=424872&pr_number=57&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F57&signature=307297a813fd4f9996fda5a61e0e3d08d893b1ecebf12b930ead9d7c5c51cd01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->