### PR TITLE
fix(cli): prevent credential export overwrites

### DIFF
--- a/src/cli/commands/client/export-files.ts
+++ b/src/cli/commands/client/export-files.ts
@@ -1,4 +1,4 @@
-import { link, lstat, mkdir, mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
+import { link, lstat, mkdir, mkdtemp, open, rm, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // Stage complete files beside their destinations, then publish without replacing existing paths.
@@ -15,19 +15,54 @@ export const exportFiles = async (directory: string, files: Record<string, Uint8
   }
 
   const stagingDirectory = await mkdtemp(join(directory, '.okova-export-'));
-  const published: string[] = [];
+  const published: { destination: string; dev: bigint; ino: bigint }[] = [];
   try {
     for (const [filename, data] of Object.entries(files)) {
       await writeFile(join(stagingDirectory, filename), data, { flag: 'wx', mode: 0o600 });
     }
     for (const filename of filenames) {
       const destination = join(directory, filename);
+      const stagedPath = join(stagingDirectory, filename);
+      const staged = await lstat(stagedPath, { bigint: true });
       // Unlike rename, link fails if a destination appeared after preflight.
-      await link(join(stagingDirectory, filename), destination);
-      published.push(destination);
+      try {
+        await link(stagedPath, destination);
+        published.push({ destination, dev: staged.dev, ino: staged.ino });
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          !('code' in error) ||
+          !['EPERM', 'ENOTSUP', 'EOPNOTSUPP', 'ENOSYS', 'EXDEV'].includes(String(error.code))
+        ) {
+          throw error;
+        }
+        // Filesystems without hard links still support exclusive creation.
+        const output = await open(destination, 'wx', 0o600);
+        try {
+          const created = await output.stat({ bigint: true });
+          published.push({ destination, dev: created.dev, ino: created.ino });
+          await output.writeFile(files[filename]);
+        } finally {
+          await output.close();
+        }
+      }
     }
   } catch (error) {
-    const rollback = await Promise.allSettled(published.map((path) => unlink(path)));
+    const rollback = await Promise.allSettled(
+      published.map(async ({ destination, dev, ino }) => {
+        try {
+          const current = await lstat(destination, { bigint: true });
+          // Leave paths now owned by another writer alone.
+          // This is best-effort: filesystem APIs cannot atomically compare and unlink an inode.
+          if (current.dev === dev && current.ino === ino) {
+            await unlink(destination);
+          }
+        } catch (error) {
+          if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return;
+          throw error;
+        }
+      }),
+    );
     const failures = rollback.filter((result) => result.status === 'rejected');
     if (failures.length) {
       throw new AggregateError(

--- a/src/cli/commands/client/export-files.ts
+++ b/src/cli/commands/client/export-files.ts
@@ -1,0 +1,42 @@
+import { link, lstat, mkdir, mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Stage complete files beside their destinations, then publish without replacing existing paths.
+export const exportFiles = async (directory: string, files: Record<string, Uint8Array>) => {
+  await mkdir(directory, { recursive: true });
+  const filenames = Object.keys(files);
+  for (const filename of filenames) {
+    const destination = join(directory, filename);
+    const existing = await lstat(destination).catch((error: unknown) => {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return null;
+      throw error;
+    });
+    if (existing) throw new Error(`Refusing to overwrite existing path: ${destination}`);
+  }
+
+  const stagingDirectory = await mkdtemp(join(directory, '.okova-export-'));
+  const published: string[] = [];
+  try {
+    for (const [filename, data] of Object.entries(files)) {
+      await writeFile(join(stagingDirectory, filename), data, { flag: 'wx', mode: 0o600 });
+    }
+    for (const filename of filenames) {
+      const destination = join(directory, filename);
+      // Unlike rename, link fails if a destination appeared after preflight.
+      await link(join(stagingDirectory, filename), destination);
+      published.push(destination);
+    }
+  } catch (error) {
+    const rollback = await Promise.allSettled(published.map((path) => unlink(path)));
+    const failures = rollback.filter((result) => result.status === 'rejected');
+    if (failures.length) {
+      throw new AggregateError(
+        [error, ...failures.map((result) => result.reason)],
+        'Export failed and some newly created files could not be removed',
+      );
+    }
+    throw error;
+  } finally {
+    await rm(stagingDirectory, { recursive: true, force: true });
+  }
+};

--- a/src/cli/commands/client/help.ts
+++ b/src/cli/commands/client/help.ts
@@ -17,6 +17,8 @@ export const help = () => {
       'unpack from <input> path to separate client id and private key placed in <output> directory',
   );
   console.log('');
+  console.log('Exports create output directories and refuse to overwrite existing paths.');
+  console.log('');
   console.log(`Flags:`);
   console.log(col(`-f, --format`) + 'Specify format for pack command (wvd/okova)');
   console.log(col(`-h, --help`) + 'Display this menu and exit');

--- a/src/cli/commands/client/pack.ts
+++ b/src/cli/commands/client/pack.ts
@@ -1,6 +1,6 @@
-import { writeFile } from 'node:fs/promises';
-import { extname, join } from 'node:path';
+import { basename, dirname, extname, join } from 'node:path';
 import { importClient } from '../../utils';
+import { exportFiles } from './export-files';
 
 export const pack = async (input = process.cwd(), format?: string, output?: string) => {
   const client = await importClient(input, output);
@@ -8,7 +8,7 @@ export const pack = async (input = process.cwd(), format?: string, output?: stri
   const data = await client.pack();
   const filename = `${client.getName()}`.replaceAll(' ', '-').toLowerCase();
   const outputPath = output || join(process.cwd(), `${filename}.${ext}`);
-  await writeFile(outputPath, data);
+  await exportFiles(dirname(outputPath), { [basename(outputPath)]: data });
   console.log(`Client packed: ${outputPath}`);
   // Convert to Base64: `base64 -i /Users/.../client.wvd | tr -d '\n' | pbcopy`
 };

--- a/src/cli/commands/client/unpack.ts
+++ b/src/cli/commands/client/unpack.ts
@@ -1,16 +1,13 @@
-import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { importClient } from '../../utils';
+import { exportFiles } from './export-files';
 
 export const unpack = async (input = process.cwd(), output?: string) => {
   const client = await importClient(input, output);
   if (!('unpack' in client)) return;
   const unpacked = await client.unpack();
-  const outputs: string[] = [];
-  for (const [filename, data] of Object.entries(unpacked)) {
-    const outputPath = join(output || process.cwd(), filename);
-    await writeFile(outputPath, data);
-    outputs.push(outputPath);
-  }
+  const directory = output || process.cwd();
+  await exportFiles(directory, unpacked);
+  const outputs = Object.keys(unpacked).map((filename) => join(directory, filename));
   console.log(`Client unpacked: ${outputs.join(', ')}`);
 };

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -72,10 +72,10 @@ const help = () => {
       const [input, output] = positionals;
       switch (subcommand) {
         case 'pack':
-          client.pack(input, args.values.format as string | undefined, output);
+          await client.pack(input, args.values.format as string | undefined, output);
           break;
         case 'unpack':
-          client.unpack(input, output);
+          await client.unpack(input, output);
           break;
         case 'info':
           client.info(input);
@@ -121,4 +121,7 @@ const help = () => {
       }
     }
   }
-})();
+})().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/test/client-export.test.ts
+++ b/test/client-export.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, expect, test, vi } from 'vitest';
-import { link, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+  link,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { exportFiles } from '../src/cli/commands/client/export-files';
@@ -71,6 +81,71 @@ test('preserves a destination created after preflight and rolls back earlier out
     .mockImplementationOnce(async (source, destination) => {
       await writeFile(destination, 'concurrent export');
       await fs.link(source, destination);
+    });
+  await expect(exportFiles(directory, files)).rejects.toMatchObject({ code: 'EEXIST' });
+  expect(await readdir(directory)).toEqual(['device_private_key']);
+  expect(await readFile(join(directory, 'device_private_key'), 'utf8')).toBe('concurrent export');
+});
+
+test.each(['link', 'exclusive create'])(
+  'preserves an atomically replaced %s output when a later publication fails',
+  async (method) => {
+    const directory = await temporaryDirectory();
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    if (method === 'link') {
+      vi.mocked(link).mockImplementationOnce(fs.link);
+    } else {
+      vi.mocked(link).mockRejectedValueOnce(
+        Object.assign(new Error('Hard links unavailable'), { code: 'ENOTSUP' }),
+      );
+    }
+    vi.mocked(link).mockImplementationOnce(async () => {
+      const replacement = join(directory, 'replacement');
+      await writeFile(replacement, 'another writer');
+      await rename(replacement, join(directory, 'device_client_id_blob'));
+      throw new Error('Disk failure');
+    });
+    await expect(exportFiles(directory, files)).rejects.toThrow('Disk failure');
+    expect(await readdir(directory)).toEqual(['device_client_id_blob']);
+    expect(await readFile(join(directory, 'device_client_id_blob'), 'utf8')).toBe('another writer');
+  },
+);
+
+test('preserves the publication error when another writer already removed an output', async () => {
+  const directory = await temporaryDirectory();
+  const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  vi.mocked(link)
+    .mockImplementationOnce(fs.link)
+    .mockImplementationOnce(async () => {
+      await unlink(join(directory, 'device_client_id_blob'));
+      throw new Error('Disk failure');
+    });
+  await expect(exportFiles(directory, files)).rejects.toThrow('Disk failure');
+  expect(await readdir(directory)).toEqual([]);
+});
+
+test.each(['EPERM', 'ENOTSUP', 'EOPNOTSUPP', 'ENOSYS', 'EXDEV'])(
+  'exports using exclusive creation when links fail with %s',
+  async (code) => {
+    const directory = await temporaryDirectory();
+    const error = Object.assign(new Error('Hard links unavailable'), { code });
+    vi.mocked(link).mockRejectedValueOnce(error).mockRejectedValueOnce(error);
+    await exportFiles(directory, files);
+    expect((await readdir(directory)).sort()).toEqual(Object.keys(files).sort());
+    for (const [filename, data] of Object.entries(files)) {
+      expect(new Uint8Array(await readFile(join(directory, filename)))).toEqual(data);
+    }
+  },
+);
+
+test('exclusive creation preserves a concurrent output and rolls back a previous fallback output', async () => {
+  const directory = await temporaryDirectory();
+  const error = Object.assign(new Error('Hard links unavailable'), { code: 'ENOTSUP' });
+  vi.mocked(link)
+    .mockRejectedValueOnce(error)
+    .mockImplementationOnce(async (_source, destination) => {
+      await writeFile(destination, 'concurrent export');
+      throw error;
     });
   await expect(exportFiles(directory, files)).rejects.toMatchObject({ code: 'EEXIST' });
   expect(await readdir(directory)).toEqual(['device_private_key']);

--- a/test/client-export.test.ts
+++ b/test/client-export.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { link, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { exportFiles } from '../src/cli/commands/client/export-files';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...fs, link: vi.fn(fs.link) };
+});
+
+const directories: string[] = [];
+const temporaryDirectory = async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'okova-export-test-'));
+  directories.push(directory);
+  return directory;
+};
+const files = {
+  device_client_id_blob: new Uint8Array([1, 2, 3]),
+  device_private_key: new Uint8Array([4, 5, 6]),
+};
+
+afterEach(async () => {
+  vi.mocked(link).mockClear();
+  await Promise.all(
+    directories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+test('creates nested output directories and publishes complete files without staging leftovers', async () => {
+  const directory = join(await temporaryDirectory(), 'nested', 'client');
+  await exportFiles(directory, files);
+  expect((await readdir(directory)).sort()).toEqual(Object.keys(files).sort());
+  for (const [filename, data] of Object.entries(files)) {
+    expect(new Uint8Array(await readFile(join(directory, filename)))).toEqual(data);
+  }
+});
+
+test.each(Object.keys(files))(
+  'refuses existing %s before publishing any file',
+  async (filename) => {
+    const directory = await temporaryDirectory();
+    await writeFile(join(directory, filename), 'sentinel');
+    await expect(exportFiles(directory, files)).rejects.toThrow('Refusing to overwrite');
+    expect(await readFile(join(directory, filename), 'utf8')).toBe('sentinel');
+    expect(await readdir(directory)).toEqual([filename]);
+    expect(link).not.toHaveBeenCalled();
+  },
+);
+
+test('refuses dangling symlinks', async () => {
+  const directory = await temporaryDirectory();
+  await symlink(join(directory, 'missing'), join(directory, 'device_private_key'));
+  await expect(exportFiles(directory, files)).rejects.toThrow('Refusing to overwrite');
+  expect(await readdir(directory)).toEqual(['device_private_key']);
+});
+
+test('rolls back the first output if the second publication fails', async () => {
+  const directory = await temporaryDirectory();
+  const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  vi.mocked(link).mockImplementationOnce(fs.link).mockRejectedValueOnce(new Error('Disk failure'));
+  await expect(exportFiles(directory, files)).rejects.toThrow('Disk failure');
+  expect(await readdir(directory)).toEqual([]);
+});
+
+test('preserves a destination created after preflight and rolls back earlier outputs', async () => {
+  const directory = await temporaryDirectory();
+  const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  vi.mocked(link)
+    .mockImplementationOnce(fs.link)
+    .mockImplementationOnce(async (source, destination) => {
+      await writeFile(destination, 'concurrent export');
+      await fs.link(source, destination);
+    });
+  await expect(exportFiles(directory, files)).rejects.toMatchObject({ code: 'EEXIST' });
+  expect(await readdir(directory)).toEqual(['device_private_key']);
+  expect(await readFile(join(directory, 'device_private_key'), 'utf8')).toBe('concurrent export');
+});


### PR DESCRIPTION
## Summary

- Add atomic, non-overwriting file exports for client pack and unpack commands.
- Create missing output directories and roll back partial exports on failure.
- Surface async export errors through the CLI and document overwrite behavior.

## Testing

- Added tests for nested directory creation and complete file publication.
- Added coverage for existing files, dangling symlinks, publication failures, and concurrent destination creation.
- Not run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791221996&installation_model_id=424872&pr_number=58&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F58&signature=53c45bfd6a40f1ed247d51e44813bf559ce190eb056609bf2f4b2b6427f678b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->