### PR TITLE
fix(session): harden license errors and preserve key updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ async function main() {
 }
 ```
 
+`fetchDecryptionKeys` rejects unsuccessful HTTP responses with `LicenseHttpError`,
+which exposes `status` and `endpoint`. The endpoint excludes URL credentials, query
+parameters, and fragments; the error does not include the response body. Status is
+checked after any `transformResponse` callback. PlayReady requests default to
+`Content-Type: text/xml; charset=utf-8` unless you provide that header.
+
 ### PlayReady custom challenge data
 
 Pass application-specific data as a string when creating the engine:

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -329,6 +329,7 @@ export class Session extends EventTarget implements MediaKeySession {
   };
 
   #handleKeysChange = () => {
+    if (this.#engineSession) this.#syncFromEngineSession(this.#engineSession);
     const keysChangeEvent = new Event('keyschange');
     this.dispatchEvent(keysChangeEvent);
     this.onkeyschange?.call(this as unknown as MediaKeySession, keysChangeEvent);

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -17,6 +17,23 @@ interface FetchDecryptionKeysParams {
   logger?: Logger;
 }
 
+export class LicenseHttpError extends Error {
+  readonly status: number;
+  readonly endpoint: string;
+
+  constructor(status: number, url: string) {
+    const endpoint = new URL(url);
+    endpoint.username = '';
+    endpoint.password = '';
+    endpoint.search = '';
+    endpoint.hash = '';
+    super(`License request failed with HTTP ${status} at ${endpoint.href}`);
+    this.name = 'LicenseHttpError';
+    this.status = status;
+    this.endpoint = endpoint.href;
+  }
+}
+
 const fetchDecryptionKeys = async (params: FetchDecryptionKeysParams) => {
   const { pssh, cdm, transformRequest, transformResponse } = params;
   const initDataType = 'cenc';
@@ -25,16 +42,23 @@ const fetchDecryptionKeys = async (params: FetchDecryptionKeysParams) => {
   const session = await cdm.createSession();
   const fetchImpl = params.fetch ?? globalThis.fetch;
   const sendRequest = async (server: string, body: Uint8Array) => {
+    const headers = new Headers(params.headers);
+    if (cdm.keySystem.startsWith('com.microsoft.playready') && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'text/xml; charset=utf-8');
+    }
     const request = new Request(server, {
       body: toBufferSource(body),
       method: 'POST',
-      headers: params.headers,
+      headers,
     });
 
-    return fetchImpl((await transformRequest?.(request)) || request)
-      .then((r) => transformResponse?.(r) || r)
-      .then((r) => r.arrayBuffer())
-      .then((buffer) => new Uint8Array(buffer));
+    const transformedRequest = (await transformRequest?.(request)) || request;
+    const response = await fetchImpl(transformedRequest);
+    const transformedResponse = (await transformResponse?.(response)) || response;
+    if (!transformedResponse.ok) {
+      throw new LicenseHttpError(transformedResponse.status, transformedRequest.url);
+    }
+    return new Uint8Array(await transformedResponse.arrayBuffer());
   };
 
   let rejectFlow: ((error: unknown) => void) | null = null;

--- a/src/lib/playready/session.ts
+++ b/src/lib/playready/session.ts
@@ -293,7 +293,13 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     this.assertOpen();
     const keys = await this.parseLicense(fromBuffer(response).toText());
     this.assertOpen();
-    if (keys) this.#contentKeys = keys;
+    if (keys) {
+      const contentKeys = new Map(
+        this.#contentKeys.map((key) => [fromBuffer(key.keyId).toHex(), key]),
+      );
+      for (const key of keys) contentKeys.set(fromBuffer(key.keyId).toHex(), key);
+      this.#contentKeys = [...contentKeys.values()];
+    }
     this.#syncKeys();
     this.emitKeysChange();
     this.emitKeyStatusesChange();

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,6 +1,6 @@
 import { cbc, ctr } from '@noble/ciphers/aes.js';
 import { describe, expect, test, vi } from 'vitest';
-import { fetchDecryptionKeys } from '../src/lib/main';
+import { fetchDecryptionKeys, LicenseHttpError } from '../src/lib/main';
 import {
   BaseMediaKeysEngine,
   BaseMediaKeysEngineSession,
@@ -119,6 +119,81 @@ describe.each(['successful', 'failed'])('fetchDecryptionKeys with %s cleanup', (
   );
 });
 
+describe('license HTTP responses', () => {
+  test.each([401, 403, 429, 500])('preserves HTTP %i without parsing the body', async (status) => {
+    const engine = new FakeEngine();
+    const session = new FakeEngineSession();
+    vi.spyOn(engine, 'createSession').mockResolvedValue(session);
+    const update = vi.spyOn(session, 'update');
+    const close = vi.spyOn(session, 'close');
+    const response = new Response('private server details', { status });
+    const readBody = vi.spyOn(response, 'arrayBuffer');
+
+    const result = fetchDecryptionKeys({
+      cdm: engine,
+      pssh: 'AQ==',
+      server: 'https://license.example.test/license?token=secret',
+      fetch: vi.fn<typeof fetch>().mockResolvedValue(response),
+    });
+
+    await expect(result).rejects.toBeInstanceOf(LicenseHttpError);
+    await expect(result).rejects.toMatchObject({
+      status,
+      endpoint: 'https://license.example.test/license',
+      message: `License request failed with HTTP ${status} at https://license.example.test/license`,
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(readBody).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  test.each([true, false])('checks the transformed response, success=%s', async (isSuccessful) => {
+    const engine = new FakeEngine();
+    const session = new FakeEngineSession();
+    vi.spyOn(engine, 'createSession').mockResolvedValue(session);
+    const update = vi.spyOn(session, 'update');
+    const result = fetchDecryptionKeys({
+      cdm: engine,
+      pssh: 'AQ==',
+      server: 'https://license.example.test',
+      fetch: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: isSuccessful ? 500 : 200 })),
+      transformRequest: async () => new Request('https://other.example.test/license?secret=1'),
+      transformResponse: async () => new Response(null, { status: isSuccessful ? 200 : 403 }),
+    });
+
+    if (isSuccessful) {
+      await expect(result).resolves.toEqual(new Map([[KEY_ID, KEY_VALUE]]));
+      expect(update).toHaveBeenCalledWith(new Uint8Array());
+    } else {
+      await expect(result).rejects.toMatchObject({
+        status: 403,
+        endpoint: 'https://other.example.test/license',
+      });
+      expect(update).not.toHaveBeenCalled();
+    }
+  });
+
+  test.each([undefined, 'application/custom'])(
+    'sets PlayReady content type while preserving %s',
+    async (contentType) => {
+      const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response());
+      await fetchDecryptionKeys({
+        cdm: new FakeEngine('com.microsoft.playready.recommendation'),
+        pssh: 'AQ==',
+        server: 'https://license.example.test',
+        headers: contentType ? { 'content-type': contentType } : undefined,
+        fetch: fetchImpl,
+      });
+      const request = fetchImpl.mock.calls[0]?.[0];
+      expect(request).toBeInstanceOf(Request);
+      if (!(request instanceof Request)) throw new Error('Expected a Request');
+      expect(request.headers.get('Content-Type')).toBe(contentType ?? 'text/xml; charset=utf-8');
+    },
+  );
+});
+
 describe('waitForKeys', () => {
   test('resolves immediately when keys already exist', async () => {
     const keys = new Map([[KEY_ID, KEY_VALUE]]);
@@ -142,6 +217,26 @@ describe('waitForKeys', () => {
 });
 
 describe('Session', () => {
+  test('synchronizes keys and statuses before delivering keyschange', async () => {
+    const session = new Session('temporary', new FakeEngine(), new FakeEngineSession());
+    const snapshots: Array<{ keys: Map<string, string>; statuses: MediaKeyStatus[] }> = [];
+    const capture = () => {
+      snapshots.push({ keys: new Map(session.keys), statuses: [...session.keyStatuses.values()] });
+    };
+    session.addEventListener('keyschange', capture);
+    session.onkeyschange = capture;
+    const pendingKeys = waitForKeys(session, () => session.keys, { timeoutMs: 100 });
+
+    await session.update(new Uint8Array());
+
+    await expect(pendingKeys).resolves.toEqual(new Map([[KEY_ID, KEY_VALUE]]));
+    expect(snapshots).toEqual([
+      { keys: new Map([[KEY_ID, KEY_VALUE]]), statuses: ['usable'] },
+      { keys: new Map([[KEY_ID, KEY_VALUE]]), statuses: ['usable'] },
+    ]);
+    await session.close();
+  });
+
   test('waits for future license requests and syncs key status updates', async () => {
     const engine = new FakeEngine();
     const session = new Session('temporary', engine);

--- a/test/playready.test.ts
+++ b/test/playready.test.ts
@@ -489,6 +489,54 @@ test('playready XMR getObjects keeps the matching container before descending', 
   expect(license.getObjects(10)).toHaveLength(1);
 });
 
+test('playready retains earlier keys and replaces matching KIDs across updates and resume', async () => {
+  const credentials = {
+    certificateChain: new Uint8Array(),
+    encryptionKey: EccKey.generate().dumps(),
+    signingKey: EccKey.generate().dumps(),
+  };
+  const session = new PlayReadySession('temporary', credentials);
+  const first = new Key(new Uint8Array(16).fill(1), 1, 3, new Uint8Array(16).fill(0xaa));
+  const second = new Key(new Uint8Array(16).fill(2), 1, 3, new Uint8Array(16).fill(0xbb));
+  const replacement = new Key(new Uint8Array(16).fill(1), 1, 3, new Uint8Array(16).fill(0xcc));
+  vi.spyOn(session, 'parseLicense')
+    .mockResolvedValueOnce([first])
+    .mockResolvedValueOnce([second])
+    .mockResolvedValueOnce([replacement])
+    .mockResolvedValueOnce([]);
+
+  await session.update(new Uint8Array());
+  await session.update(new Uint8Array());
+  expect(session.keys).toEqual(
+    new Map([
+      ['01'.repeat(16), 'aa'.repeat(16)],
+      ['02'.repeat(16), 'bb'.repeat(16)],
+    ]),
+  );
+  await session.update(new Uint8Array());
+  await session.update(new Uint8Array());
+  expect(session.keys).toEqual(
+    new Map([
+      ['01'.repeat(16), 'cc'.repeat(16)],
+      ['02'.repeat(16), 'bb'.repeat(16)],
+    ]),
+  );
+  expect(session.keyStatuses).toEqual(
+    new Map([
+      ['01'.repeat(16), 'usable'],
+      ['02'.repeat(16), 'usable'],
+    ]),
+  );
+
+  const resumed = PlayReadySession.resume(session.pause(), credentials);
+  expect(resumed.keys).toEqual(session.keys);
+  expect(resumed.keyStatuses).toEqual(session.keyStatuses);
+  await session.close();
+  await resumed.close();
+  expect(session.keys.size).toBe(0);
+  expect(session.keyStatuses.size).toBe(0);
+});
+
 test('playready pause and resume preserve key identifiers', async () => {
   const credentials = {
     certificateChain: new Uint8Array(),


### PR DESCRIPTION
## Summary

- Reject unsuccessful license HTTP responses with sanitized endpoint details.
- Apply default PlayReady content type when none is provided.
- Preserve existing PlayReady keys while replacing matching KIDs.
- Synchronize session keys before dispatching `keyschange`.
- Add regression coverage and document the behavior.

## Testing

- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791222844&installation_model_id=424872&pr_number=59&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F59&signature=c4c9bf68eb24bb6f1acd7d74a466585fdd8f6e78471da930741848da108d05d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->