### PR TITLE
fix(session): harden resumability and lifecycle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ async function main() {
 }
 ```
 
+### Saving and resuming native sessions
+
+Widevine and PlayReady can serialize an open session with `pause()`. This takes
+a snapshot; the original session stays open. Close it before restoring into the
+same engine, since `resumeSession()` rejects an already-open session ID:
+
+```ts
+const state = session.pause();
+await session.close();
+const resumed = engine.resumeSession(state);
+```
+
+Snapshots are versioned and validated when resumed. Existing unversioned
+snapshots remain readable. Resume with the same device credentials. Native
+Widevine `load()` returns `false`; it does not implement persistent-license
+storage. The EME wrapper's `keyStatuses` is read-only and matches KIDs by their
+bytes. Repeated `close()` calls are safe.
+
 ### PlayReady custom challenge data
 
 Pass application-specific data as a string when creating the engine:

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type { EncryptedPacket } from './decrypt';
 import { decryptPacketWithKeys } from './decrypt';
-import { fromHex, parseBufferSource } from './utils';
+import { parseBufferSource } from './utils';
+import { KeyStatusMap } from './key-status-map';
 export type {
   EncryptedPacket,
   EncryptionPattern,
@@ -78,7 +79,7 @@ export abstract class BaseMediaKeysEngineSession
 {
   protected isClosed = false;
 
-  sessionId = '';
+  readonly sessionId: string;
   sessionType: MediaKeySessionType;
   keyStatuses: Map<MediaKeyId, MediaKeyStatus>;
   keys: MediaKeysMap;
@@ -91,8 +92,9 @@ export abstract class BaseMediaKeysEngineSession
     | ((this: MediaKeysEngineSession, ev: CustomEvent<MediaKeyStatusesChangeEventInit>) => any)
     | null;
 
-  protected constructor(sessionType: MediaKeySessionType = 'temporary') {
+  protected constructor(sessionType: MediaKeySessionType = 'temporary', sessionId = '') {
     super();
+    this.sessionId = sessionId;
     this.sessionType = sessionType;
     this.keyStatuses = new Map();
     this.keys = new Map();
@@ -230,19 +232,19 @@ export const waitForKeys = (
 };
 
 const syncSessionKeys = (
-  target: Map<BufferSource, MediaKeyStatus>,
+  target: Map<MediaKeyId, MediaKeyStatus>,
   source: Map<MediaKeyId, MediaKeyStatus>,
 ) => {
   target.clear();
   for (const [keyId, status] of source) {
-    target.set(fromHex(keyId).toBuffer() as BufferSource, status);
+    target.set(keyId.toLowerCase(), status);
   }
 };
 
 export class Session extends EventTarget implements MediaKeySession {
   expiration: number;
-  closed: Promise<MediaKeySessionClosedReason>;
-  keyStatuses: Map<BufferSource, MediaKeyStatus>;
+  readonly closed: Promise<MediaKeySessionClosedReason>;
+  readonly keyStatuses: MediaKeyStatusMap;
 
   onmessage: ((this: MediaKeySession, ev: MediaKeyMessageEvent) => any) | null;
   onkeyschange: ((this: MediaKeySession, ev: Event) => any) | null;
@@ -257,6 +259,8 @@ export class Session extends EventTarget implements MediaKeySession {
   initDataType?: string | undefined;
 
   #closed: boolean;
+  #closePromise: Promise<void> | null = null;
+  #keyStatuses = new Map<MediaKeyId, MediaKeyStatus>();
   #engineSession: MediaKeysEngineSession | null;
   #engineSessionPromise: Promise<MediaKeysEngineSession>;
   #messageQueue: MediaKeyMessageEventInit[];
@@ -271,7 +275,7 @@ export class Session extends EventTarget implements MediaKeySession {
     this.closed = new Promise<MediaKeySessionClosedReason>((resolve) => {
       this.addEventListener('closed', () => resolve('closed-by-application'));
     });
-    this.keyStatuses = new Map();
+    this.keyStatuses = new KeyStatusMap(this.#keyStatuses);
 
     this.onmessage = null;
     this.onkeyschange = null;
@@ -301,9 +305,9 @@ export class Session extends EventTarget implements MediaKeySession {
   }
 
   async #getEngineSession() {
-    if (this.#closed) throw new Error('Session closed');
+    if (this.#closed || this.#closePromise) throw new Error('Session closed');
     const session = await this.#engineSessionPromise;
-    if (this.#closed) throw new Error('Session closed');
+    if (this.#closed || this.#closePromise) throw new Error('Session closed');
     return session;
   }
 
@@ -337,7 +341,7 @@ export class Session extends EventTarget implements MediaKeySession {
   #handleKeyStatusesChange = (event: Event) => {
     const { detail } = event as CustomEvent<MediaKeyStatusesChangeEventInit>;
     this.keys = new Map(detail.keys);
-    syncSessionKeys(this.keyStatuses, detail.keyStatuses);
+    syncSessionKeys(this.#keyStatuses, detail.keyStatuses);
 
     const keyStatusesChangeEvent = new Event('keystatuseschange');
     this.dispatchEvent(keyStatusesChangeEvent);
@@ -348,7 +352,7 @@ export class Session extends EventTarget implements MediaKeySession {
     if (this.#closed) return;
     this.#closed = true;
     this.keys.clear();
-    this.keyStatuses.clear();
+    this.#keyStatuses.clear();
     this.initData = undefined;
     this.initDataType = undefined;
     this.#messageQueue.length = 0;
@@ -368,7 +372,7 @@ export class Session extends EventTarget implements MediaKeySession {
 
   #syncFromEngineSession(session: MediaKeysEngineSession) {
     this.keys = new Map(session.keys);
-    syncSessionKeys(this.keyStatuses, session.keyStatuses);
+    syncSessionKeys(this.#keyStatuses, session.keyStatuses);
   }
 
   async load(_sessionId: string): Promise<boolean> {
@@ -391,9 +395,19 @@ export class Session extends EventTarget implements MediaKeySession {
   }
 
   async close(): Promise<void> {
-    const session = await this.#getEngineSession();
-    await session.close();
-    this.#handleClosed();
+    if (this.#closed) return;
+    if (!this.#closePromise) {
+      this.#closePromise = this.#engineSessionPromise
+        .then(async (session) => {
+          if (!this.#closed) await session.close();
+          this.#handleClosed();
+        })
+        .catch((error: unknown) => {
+          this.#closePromise = null;
+          throw error;
+        });
+    }
+    return this.#closePromise;
   }
 
   async remove(): Promise<void> {

--- a/src/lib/key-status-map.ts
+++ b/src/lib/key-status-map.ts
@@ -1,0 +1,51 @@
+import { fromBuffer, fromHex, parseBufferSource } from './utils';
+
+/** Read-only EME view; byte buffers returned to callers never own the stored KIDs. */
+export class KeyStatusMap implements MediaKeyStatusMap {
+  #statuses: ReadonlyMap<string, MediaKeyStatus>;
+
+  constructor(statuses: ReadonlyMap<string, MediaKeyStatus>) {
+    this.#statuses = statuses;
+  }
+
+  get size() {
+    return this.#statuses.size;
+  }
+
+  get(keyId: BufferSource) {
+    return this.#statuses.get(fromBuffer(parseBufferSource(keyId)).toHex());
+  }
+
+  has(keyId: BufferSource) {
+    return this.#statuses.has(fromBuffer(parseBufferSource(keyId)).toHex());
+  }
+
+  *entries(): Generator<[BufferSource, MediaKeyStatus], undefined> {
+    for (const [keyId, status] of this.#statuses) {
+      yield [Uint8Array.from(fromHex(keyId).toBuffer()).buffer, status];
+    }
+  }
+
+  *keys(): Generator<BufferSource, undefined> {
+    for (const keyId of this.#statuses.keys()) {
+      yield Uint8Array.from(fromHex(keyId).toBuffer()).buffer;
+    }
+  }
+
+  values() {
+    return this.#statuses.values();
+  }
+
+  [Symbol.iterator]() {
+    return this.entries();
+  }
+
+  forEach(
+    callback: (value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) => void,
+    thisArg?: unknown,
+  ) {
+    for (const [keyId, status] of this) {
+      callback.call(thisArg, status, keyId, this);
+    }
+  }
+}

--- a/src/lib/playready/engine.ts
+++ b/src/lib/playready/engine.ts
@@ -28,8 +28,8 @@ export class PlayReady extends BaseMediaKeysEngine {
     throw new Error('Server certificates are unsupported for PlayReady');
   }
 
-  #handleSessionDisposed = (sessionId: string) => {
-    this.sessions.delete(sessionId);
+  #handleSessionDisposed = (sessionId: string, session: MediaKeysEngineSession) => {
+    if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId);
   };
 
   #assertSessionCapacity() {
@@ -39,6 +39,9 @@ export class PlayReady extends BaseMediaKeysEngine {
   }
 
   #trackSession(session: MediaKeysEngineSession) {
+    if (this.sessions.has(session.sessionId)) {
+      throw new Error(`Session ${session.sessionId} is already open`);
+    }
     this.sessions.set(session.sessionId, session);
     return session;
   }

--- a/src/lib/playready/session.ts
+++ b/src/lib/playready/session.ts
@@ -1,6 +1,8 @@
 import { DOMParser, XMLSerializer, type Document, type Element } from '@xmldom/xmldom';
+import { z } from 'zod';
 import * as utils from '@noble/curves/utils.js';
-import { BaseMediaKeysEngineSession } from '../api';
+import { BaseMediaKeysEngineSession, type MediaKeysEngineSession } from '../api';
+import { hexBytesSchema, sessionStateSchema } from '../session-state';
 import {
   base64ToBytes,
   bytesToBase64,
@@ -80,8 +82,28 @@ type PlayReadySessionOptions = {
   mergeRevocationInfo?: (revInfoXml: string) => void;
 };
 
+const stateSchema = sessionStateSchema.extend({
+  keySystem: z
+    .literal('com.microsoft.playready.recommendation')
+    .default('com.microsoft.playready.recommendation'),
+  certificateChain: z.base64(),
+  encryptionKey: z.base64(),
+  signingKey: z.base64(),
+  clientVersion: z.string(),
+  rgbMagicConstantZero: z.base64(),
+  wmrmServerKey: z.object({ x: z.string().regex(/^\d+$/), y: z.string().regex(/^\d+$/) }),
+  customData: z.string().optional(),
+  keys: z.array(
+    z.object({
+      keyId: hexBytesSchema.length(32),
+      key: hexBytesSchema,
+      cipherType: z.number().int(),
+      keyType: z.number().int(),
+    }),
+  ),
+});
+
 export class PlayReadySession extends BaseMediaKeysEngineSession {
-  sessionId: string;
   expiration: number;
   closed: Promise<MediaKeySessionClosedReason>;
   sessionType: MediaKeySessionType;
@@ -101,17 +123,17 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
   static DeviceCredentials = PlayReadyDeviceCredentials;
 
   #contentKeys: Key[];
-  #dispose: (sessionId: string) => void;
+  #dispose: (sessionId: string, session: MediaKeysEngineSession) => void;
   #options: PlayReadySessionOptions;
 
   constructor(
     sessionType: MediaKeySessionType = 'temporary',
     deviceCredentials: PlayReadySessionCredentials,
-    dispose: (sessionId: string) => void = () => {},
+    dispose: (sessionId: string, session: MediaKeysEngineSession) => void = () => {},
     options: PlayReadySessionOptions = {},
+    sessionId = fromBuffer(getRandomBytes()).toBase64(),
   ) {
-    super(sessionType);
-    this.sessionId = fromBuffer(getRandomBytes()).toBase64();
+    super(sessionType, sessionId);
     this.expiration = NaN;
     this.closed = new Promise<MediaKeySessionClosedReason>((resolve) => {
       this.addEventListener('closed', () => resolve('closed-by-application'));
@@ -532,7 +554,7 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     this.initData = undefined;
     this.initDataType = undefined;
     this.#contentKeys.length = 0;
-    this.#dispose(this.sessionId);
+    this.#dispose(this.sessionId, this);
     this.dispatchEvent(new Event('closed'));
   }
 
@@ -551,6 +573,9 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
   pause() {
     this.assertOpen();
     const values = {
+      version: 1,
+      keySystem: 'com.microsoft.playready.recommendation',
+      customData: this.#options.customData,
       sessionId: this.sessionId,
       sessionType: this.sessionType,
       initData: this.initData ? fromBuffer(this.initData).toBase64() : undefined,
@@ -582,12 +607,20 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
   static resume(
     data: string,
     deviceCredentials: PlayReadySessionCredentials,
-    dispose?: (sessionId: string) => void,
+    dispose?: (sessionId: string, session: MediaKeysEngineSession) => void,
     options: PlayReadySessionOptions = {},
   ) {
-    const values = JSON.parse(data);
-    const session = new PlayReadySession(values.sessionType, deviceCredentials, dispose, options);
-    session.sessionId = values.sessionId;
+    const values = stateSchema.parse(JSON.parse(data));
+    const session = new PlayReadySession(
+      values.sessionType,
+      deviceCredentials,
+      dispose,
+      {
+        ...options,
+        customData: values.customData ?? options.customData,
+      },
+      values.sessionId,
+    );
     session.initData = values.initData ? fromBase64(values.initData).toBuffer() : undefined;
     session.initDataType = values.initDataType;
     session.certificateChain = fromBase64(values.certificateChain).toBuffer();
@@ -600,7 +633,7 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     };
     session.clientVersion = values.clientVersion;
     session.#contentKeys = values.keys.map(
-      (key: { keyId: string; key: string; keyType: number; cipherType: number }) =>
+      (key) =>
         new Key(
           fromHex(key.keyId).toBuffer(),
           key.keyType,

--- a/src/lib/remote/engine.ts
+++ b/src/lib/remote/engine.ts
@@ -130,8 +130,7 @@ class RemoteSession extends BaseMediaKeysEngineSession {
     dispose: (sessionId: string) => void,
     getServerCertificate: () => string | undefined,
   ) {
-    super(sessionType);
-    this.sessionId = sessionId;
+    super(sessionType, sessionId);
     this.#http = http;
     this.#dispose = dispose;
     this.#getServerCertificate = getServerCertificate;

--- a/src/lib/session-state.ts
+++ b/src/lib/session-state.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+// Unversioned snapshots were written before v1 and share its required fields.
+export const sessionStateSchema = z.object({
+  version: z.literal(1).default(1),
+  sessionId: z.string().min(1),
+  sessionType: z.enum(['temporary', 'persistent-license']),
+  initData: z.base64().optional(),
+  initDataType: z.string().optional(),
+});
+
+export const keyStatusSchema = z.enum([
+  'usable',
+  'expired',
+  'released',
+  'output-restricted',
+  'output-downscaled',
+  'status-pending',
+  'internal-error',
+  'usable-in-future',
+]);
+
+export const hexBytesSchema = z.string().regex(/^(?:[0-9a-fA-F]{2})+$/);

--- a/src/lib/widevine/engine.ts
+++ b/src/lib/widevine/engine.ts
@@ -12,6 +12,20 @@ export class Widevine extends BaseMediaKeysEngine {
   serverCertificate?: SignedDrmCertificate;
 
   static DeviceCredentials = WidevineDeviceCredentials;
+  #sessionNumber = 0;
+
+  #handleSessionDisposed = (sessionId: string, session: MediaKeysEngineSession) => {
+    if (this.sessions.get(sessionId) === session) this.sessions.delete(sessionId);
+  };
+
+  #trackSession(session: WidevineSession) {
+    if (this.sessions.has(session.sessionId)) {
+      throw new Error(`Session ${session.sessionId} is already open`);
+    }
+    this.sessions.set(session.sessionId, session);
+    this.#sessionNumber = Math.max(this.#sessionNumber, session.sessionNumber);
+    return session;
+  }
 
   constructor({ deviceCredentials }: { deviceCredentials: WidevineDeviceCredentials }) {
     super();
@@ -31,25 +45,20 @@ export class Widevine extends BaseMediaKeysEngine {
     const session = new WidevineSession(
       sessionType,
       this.deviceCredentials,
-      (sessionId) => {
-        this.sessions.delete(sessionId);
-      },
+      this.#handleSessionDisposed,
       () => this.serverCertificate,
+      this.#sessionNumber + 1,
     );
-    this.sessions.set(session.sessionId, session);
-    return session;
+    return this.#trackSession(session);
   }
 
   resumeSession(state: string) {
     const session = WidevineSession.resume(
       state,
       this.deviceCredentials,
-      (sessionId) => {
-        this.sessions.delete(sessionId);
-      },
+      this.#handleSessionDisposed,
       () => this.serverCertificate,
     );
-    this.sessions.set(session.sessionId, session);
-    return session;
+    return this.#trackSession(session);
   }
 }

--- a/src/lib/widevine/session.ts
+++ b/src/lib/widevine/session.ts
@@ -1,5 +1,7 @@
-import type { MediaKeyMessageEventInit } from '../api';
+import { z } from 'zod';
+import type { MediaKeyMessageEventInit, MediaKeysEngineSession } from '../api';
 import { BaseMediaKeysEngineSession } from '../api';
+import { hexBytesSchema, keyStatusSchema, sessionStateSchema } from '../session-state';
 import {
   License,
   LicenseRequest,
@@ -72,8 +74,31 @@ const generateKeyControlNonce = () => {
 
 type ServiceCertificateProvider = () => SignedDrmCertificate | undefined;
 
+const stateSchema = sessionStateSchema.extend({
+  keySystem: z.literal('com.widevine.alpha').default('com.widevine.alpha'),
+  sessionNumber: z
+    .number()
+    .int()
+    .positive()
+    .max(Number.MAX_SAFE_INTEGER - 1)
+    .default(1),
+  serviceCertificate: z.base64().optional(),
+  contexts: z.record(z.string(), z.object({ enc: z.base64(), auth: z.base64() })),
+  keys: z.record(
+    hexBytesSchema,
+    z.object({
+      id: hexBytesSchema,
+      value: hexBytesSchema,
+      type: z.string().default('CONTENT'),
+      level: z.string().optional(),
+      trackLabel: z.string().optional(),
+      permissions: z.array(z.string()).default([]),
+    }),
+  ),
+  keyStatuses: z.record(hexBytesSchema, keyStatusSchema),
+});
+
 export class WidevineSession extends BaseMediaKeysEngineSession {
-  sessionId: string;
   expiration: number;
   closed: Promise<MediaKeySessionClosedReason>;
   sessionType: SessionType;
@@ -86,18 +111,18 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
   log: Logger;
 
   #contentKeys: Map<string, Key>;
-  #dispose: (sessionId: string) => void;
+  #dispose: (sessionId: string, session: MediaKeysEngineSession) => void;
   #getServiceCertificate: ServiceCertificateProvider;
 
   constructor(
     sessionType: SessionType = 'temporary',
     deviceCredentials: WidevineDeviceCredentials,
-    dispose: (sessionId: string) => void = () => {},
+    dispose: (sessionId: string, session: MediaKeysEngineSession) => void = () => {},
     getServiceCertificate: ServiceCertificateProvider = () => undefined,
     sessionNumber = 1,
+    sessionId = generateSessionId(deviceCredentials.type ?? 'android'),
   ) {
-    super(sessionType);
-    this.sessionId = generateSessionId(deviceCredentials.type ?? 'android');
+    super(sessionType, sessionId);
     this.expiration = NaN;
     this.closed = new Promise<MediaKeySessionClosedReason>((resolve) => {
       this.addEventListener('closed', () => resolve('closed-by-application'));
@@ -212,10 +237,9 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     return { entity, bytes };
   }
 
-  async load(sessionId: string): Promise<boolean> {
+  async load(_sessionId: string): Promise<boolean> {
     this.assertOpen();
-    this.sessionId = sessionId;
-    return Promise.resolve(true);
+    return false;
   }
 
   async update(response: Uint8Array): Promise<void> {
@@ -326,7 +350,7 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     this.#contentKeys.clear();
     this.contexts.clear();
     this.serviceCertificate = undefined;
-    this.#dispose(this.sessionId);
+    this.#dispose(this.sessionId, this);
     this.dispatchEvent(new Event('closed'));
   }
 
@@ -337,6 +361,8 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
   pause() {
     this.assertOpen();
     const values = {
+      version: 1,
+      keySystem: 'com.widevine.alpha',
       sessionId: this.sessionId,
       sessionNumber: this.sessionNumber,
       sessionType: this.sessionType,
@@ -357,7 +383,14 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
       keys: Object.fromEntries(
         Array.from(this.#contentKeys.entries(), ([keyId, key]) => [
           keyId,
-          { id: key.id, value: key.value },
+          {
+            id: key.id,
+            value: key.value,
+            type: key.type,
+            level: key.level,
+            trackLabel: key.trackLabel,
+            permissions: key.permissions,
+          },
         ]),
       ),
       keyStatuses: Object.fromEntries(this.keyStatuses),
@@ -377,18 +410,18 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
   static resume(
     state: string,
     deviceCredentials: WidevineDeviceCredentials,
-    dispose?: (sessionId: string) => void,
+    dispose?: (sessionId: string, session: MediaKeysEngineSession) => void,
     getServiceCertificate: ServiceCertificateProvider = () => undefined,
   ) {
-    const values = JSON.parse(state);
+    const values = stateSchema.parse(JSON.parse(state));
     const session = new WidevineSession(
       values.sessionType,
       deviceCredentials,
       dispose,
       getServiceCertificate,
       values.sessionNumber,
+      values.sessionId,
     );
-    session.sessionId = values.sessionId;
     session.initData = values.initData ? fromBase64(values.initData).toBuffer() : undefined;
     session.initDataType = values.initDataType;
     session.serviceCertificate = values.serviceCertificate
@@ -398,26 +431,21 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
       Object.entries(values.contexts).map(([key, value]) => [
         key,
         {
-          enc: fromBase64((value as { enc: string; auth: string }).enc).toBuffer(),
-          auth: fromBase64((value as { enc: string; auth: string }).auth).toBuffer(),
+          enc: fromBase64(value.enc).toBuffer(),
+          auth: fromBase64(value.auth).toBuffer(),
         },
       ]),
     );
     session.#contentKeys = new Map(
-      Object.entries(values.keys).map(([keyId, value]) => {
-        const persistedKey = value as Key;
-        return [keyId, new Key(persistedKey.id, persistedKey.value)];
-      }),
+      Object.entries(values.keys).map(([keyId, key]) => [
+        keyId,
+        new Key(key.id, key.value, key.type, key.level, key.trackLabel, key.permissions),
+      ]),
     );
     session.keys = new Map(
       Array.from(session.#contentKeys.entries(), ([keyId, key]) => [keyId, key.value]),
     );
-    session.keyStatuses = new Map(
-      Object.entries(values.keyStatuses).map(([keyId, status]) => [
-        keyId,
-        status as MediaKeyStatus,
-      ]),
-    );
+    session.keyStatuses = new Map(Object.entries(values.keyStatuses));
     return session;
   }
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -10,7 +10,7 @@ import {
   waitForKeys,
   type EncryptedPacket,
 } from '../src/lib/api';
-import { fromBuffer, fromHex } from '../src/lib/utils';
+import { fromBuffer, fromHex, parseBufferSource } from '../src/lib/utils';
 
 const KEY_ID = '00112233445566778899aabbccddeeff';
 const KEY_VALUE = 'ffeeddccbbaa99887766554433221100';
@@ -142,6 +142,71 @@ describe('waitForKeys', () => {
 });
 
 describe('Session', () => {
+  test('key statuses match fresh buffers and views by bytes and expose read-only iteration', async () => {
+    const native = new FakeEngineSession();
+    const session = new Session('temporary', new FakeEngine(), native);
+    const statuses = session.keyStatuses;
+    expect(statuses.size).toBe(0);
+    expect([...statuses]).toEqual([]);
+    await session.update(new Uint8Array());
+    const kid = Uint8Array.from(fromHex(KEY_ID).toBuffer());
+    const padded = new Uint8Array(20);
+    padded.set(kid, 2);
+    for (const lookup of [kid, kid.buffer, new DataView(padded.buffer, 2, 16)]) {
+      expect(statuses.get(lookup)).toBe('usable');
+      expect(statuses.has(lookup)).toBe(true);
+    }
+    expect(statuses.has(new Uint8Array(16))).toBe(false);
+    expect(statuses.get(new Uint8Array(16))).toBeUndefined();
+    expect(statuses).not.toHaveProperty('set');
+    expect(statuses).not.toHaveProperty('clear');
+    const callback = vi.fn();
+    const receiver = {};
+    statuses.forEach(callback, receiver);
+    expect(callback).toHaveBeenCalledWith('usable', expect.any(ArrayBuffer), statuses);
+    expect(callback.mock.contexts).toEqual([receiver]);
+    expect([...statuses.values()]).toEqual(['usable']);
+    expect([...statuses.entries()]).toEqual([[kid.buffer, 'usable']]);
+    const exposed = statuses.keys().next().value;
+    if (!(exposed instanceof ArrayBuffer)) throw new Error('Expected key bytes');
+    new Uint8Array(exposed).fill(0);
+    expect(statuses.get(kid)).toBe('usable');
+    native.dispatchEvent(
+      new CustomEvent('keystatuseschange', {
+        detail: { keys: new Map(), keyStatuses: new Map() },
+      }),
+    );
+    expect(session.keyStatuses).toBe(statuses);
+    expect(statuses.size).toBe(0);
+    await session.close();
+  });
+
+  test('concurrent and repeated close call the engine once and preserve the closed promise', async () => {
+    const native = new FakeEngineSession();
+    const engineSession = Promise.withResolvers<FakeEngineSession>();
+    const session = new Session('temporary', new FakeEngine(), engineSession.promise);
+    const closed = session.closed;
+    const close = vi.spyOn(native, 'close');
+    const first = session.close();
+    const second = session.close();
+    engineSession.resolve(native);
+    await Promise.all([first, second]);
+    await session.close();
+    expect(close).toHaveBeenCalledOnce();
+    expect(session.closed).toBe(closed);
+    await expect(closed).resolves.toBe('closed-by-application');
+  });
+
+  test('a failed close can be retried', async () => {
+    const native = new FakeEngineSession();
+    const close = vi.spyOn(native, 'close').mockRejectedValueOnce(new Error('Close failed'));
+    const session = new Session('temporary', new FakeEngine(), native);
+    await expect(session.close()).rejects.toThrow('Close failed');
+    await session.close();
+    expect(close).toHaveBeenCalledTimes(2);
+    await expect(session.closed).resolves.toBe('closed-by-application');
+  });
+
   test('waits for future license requests and syncs key status updates', async () => {
     const engine = new FakeEngine();
     const session = new Session('temporary', engine);
@@ -158,7 +223,7 @@ describe('Session', () => {
     expect(keys.get(KEY_ID)).toBe(KEY_VALUE);
 
     const [storedKeyId, status] = Array.from(session.keyStatuses.entries())[0]!;
-    expect(fromBuffer(storedKeyId as Uint8Array).toHex()).toBe(KEY_ID);
+    expect(fromBuffer(parseBufferSource(storedKeyId)).toHex()).toBe(KEY_ID);
     expect(status).toBe('usable');
 
     expect(session.pause()).toBe('paused-state');

--- a/test/serve-session-concurrency.test.ts
+++ b/test/serve-session-concurrency.test.ts
@@ -4,8 +4,8 @@ import { config, sessions } from '../src/cli/commands/serve/state';
 import { BaseMediaKeysEngine, BaseMediaKeysEngineSession, Session } from '../src/lib/api';
 
 class TestSession extends BaseMediaKeysEngineSession {
-  constructor() {
-    super();
+  constructor(id = '') {
+    super('temporary', id);
   }
 
   async generateRequest(initData: Uint8Array) {
@@ -48,8 +48,7 @@ afterEach(async () => {
 
 const openSession = (id = 'session', secret = '') => {
   const engine = new TestEngine();
-  const native = engine.createSession();
-  native.sessionId = id;
+  const native = new TestSession(id);
   const session = new Session('temporary', engine, native);
   sessions.set(`${secret}:${id}`, session);
   return { session, native };

--- a/test/session-registry.test.ts
+++ b/test/session-registry.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+import { EccKey } from '../src/lib/crypto/ecc-key';
+import { CertificateChain } from '../src/lib/playready/bcert';
+import { PlayReadyDeviceCredentials } from '../src/lib/playready/device-credentials';
+import { PlayReady } from '../src/lib/playready/engine';
+import { PlayReadySession } from '../src/lib/playready/session';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import { Widevine } from '../src/lib/widevine/engine';
+import { WidevineSession } from '../src/lib/widevine/session';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+} from '../src/lib/widevine/proto';
+
+const createWidevine = () =>
+  new Widevine({
+    deviceCredentials: new WidevineDeviceCredentials(
+      ClientIdentification.create({
+        token: SignedDrmCertificate.encode({
+          drmCertificate: DrmCertificate.encode({ systemId: 1 }).finish(),
+        }).finish(),
+      }),
+    ),
+  });
+
+const createPlayReady = () =>
+  new PlayReady({
+    deviceCredentials: new PlayReadyDeviceCredentials({
+      encryptionKey: EccKey.generate().dumps(),
+      signingKey: EccKey.generate().dumps(),
+      // Registry tests only need a serializable device, not a provisioned certificate.
+      groupCertificate: new CertificateChain({
+        signature: new TextEncoder().encode('CHAI'),
+        version: 1,
+        total_length: 36,
+        flags: 0,
+        certificate_count: 1,
+        certificates: [
+          {
+            signature: new TextEncoder().encode('CERT'),
+            version: 1,
+            total_length: 16,
+            certificate_length: 16,
+            attributes: [],
+          },
+        ],
+      }).dumps(),
+    }),
+  });
+
+const parseState = (state: string) => z.record(z.string(), z.unknown()).parse(JSON.parse(state));
+
+describe.each([
+  { name: 'Widevine', createEngine: createWidevine },
+  { name: 'PlayReady', createEngine: createPlayReady },
+])('$name session ownership', ({ createEngine }) => {
+  test('rejects duplicate live resumes and releases only the owning session', async () => {
+    const engine = createEngine();
+    const original = engine.createSession();
+    if (!original.pause) throw new Error('Missing serialization');
+    const state = original.pause();
+    expect(() => engine.resumeSession(state)).toThrow('already open');
+    expect(engine.sessions.get(original.sessionId)).toBe(original);
+    expect(engine.sessions.size).toBe(1);
+
+    await original.close();
+    expect(engine.sessions.size).toBe(0);
+    const resumed = engine.resumeSession(state);
+    await original.close();
+    expect(engine.sessions.get(resumed.sessionId)).toBe(resumed);
+    await resumed.close();
+    expect(engine.sessions.size).toBe(0);
+  });
+
+  test('closing an untracked clone cannot dispose the original', async () => {
+    const engine = createEngine();
+    const original = engine.createSession();
+    if (!(original instanceof WidevineSession || original instanceof PlayReadySession)) {
+      throw new Error('Expected a native session');
+    }
+    const clone = original.resume(original.pause());
+    await clone.close();
+    expect(engine.sessions.get(original.sessionId)).toBe(original);
+    await original.close();
+    expect(engine.sessions.size).toBe(0);
+  });
+
+  test('reads legacy snapshots and rejects invalid state without changing the registry', async () => {
+    const engine = createEngine();
+    const original = engine.createSession();
+    if (!original.pause) throw new Error('Missing serialization');
+    const state = parseState(original.pause());
+    await original.close();
+    for (const invalid of [
+      { ...state, version: 2 },
+      { ...state, sessionId: '' },
+      { ...state, sessionType: 'banana' },
+      { ...state, initData: 'not base64!' },
+      { ...state, keys: null },
+      { ...state, keySystem: 'unsupported' },
+    ]) {
+      expect(() => engine.resumeSession(JSON.stringify(invalid))).toThrow();
+      expect(engine.sessions.size).toBe(0);
+    }
+    const { version: _version, keySystem: _keySystem, ...legacy } = state;
+    const resumed = engine.resumeSession(JSON.stringify(legacy));
+    expect(resumed.sessionId).toBe(original.sessionId);
+    expect(engine.sessions.get(resumed.sessionId)).toBe(resumed);
+    await resumed.close();
+  });
+});
+
+test('unsupported Widevine load leaves identity and registry unchanged', async () => {
+  const engine = createWidevine();
+  const session = engine.createSession();
+  const id = session.sessionId;
+  await expect(session.load('another-session')).resolves.toBe(false);
+  expect(session.sessionId).toBe(id);
+  expect(engine.sessions.get(id)).toBe(session);
+  await session.close();
+  expect(engine.sessions.size).toBe(0);
+});
+
+test('Widevine session counters advance past created and restored sessions', async () => {
+  const engine = createWidevine();
+  const first = engine.createSession();
+  const second = engine.createSession();
+  expect(first.sessionNumber).toBe(1);
+  expect(second.sessionNumber).toBe(2);
+  const state = second.pause();
+  await Promise.all([first.close(), second.close()]);
+  const restoredEngine = createWidevine();
+  const restored = restoredEngine.resumeSession(state);
+  const next = restoredEngine.createSession();
+  expect(restored.sessionNumber).toBe(2);
+  expect(next.sessionNumber).toBe(3);
+  await Promise.all([restored.close(), next.close()]);
+});
+
+test('Widevine pause and resume retain key inspection metadata', async () => {
+  const engine = createWidevine();
+  const original = engine.createSession();
+  const keyId = '00112233445566778899aabbccddeeff';
+  const key = {
+    id: keyId,
+    value: 'ffeeddccbbaa99887766554433221100',
+    type: 'CONTENT',
+    level: 'SW_SECURE_CRYPTO',
+    trackLabel: 'HD',
+    permissions: ['allowDecrypt'],
+  };
+  const state = { ...parseState(original.pause()), keys: { [keyId]: key } };
+  await original.close();
+  const restored = engine.resumeSession(JSON.stringify(state));
+  const roundtrip = restored.pause();
+  await restored.close();
+  const session = engine.resumeSession(roundtrip);
+  expect(await session.getKeys()).toEqual([expect.objectContaining(key)]);
+  expect(session.keys.get(keyId)).toBe(key.value);
+  await session.close();
+});

--- a/test/session-resumability.test.ts
+++ b/test/session-resumability.test.ts
@@ -40,6 +40,7 @@ describe('Widevine Session Resumability', () => {
     expect(state.length).toBeGreaterThan(0);
 
     // Resume session using CDM methods
+    await session.close();
     const resumed = cdm.resumeSession(state);
     expect(resumed).toBeDefined();
     expect(resumed.sessionId).toBe(originalSessionId);
@@ -125,6 +126,7 @@ describe('Widevine Session Resumability', () => {
     const state = session.pause();
 
     // Resume
+    await session.close();
     const resumed = cdm.resumeSession(state);
     expect(resumed.sessionType).toBe('persistent-license');
 
@@ -159,6 +161,7 @@ describe('PlayReady Session Resumability', () => {
     expect(state.length).toBeGreaterThan(0);
 
     // Resume session using CDM methods
+    await session.close();
     const resumed = cdm.resumeSession(state);
     expect(resumed).toBeDefined();
     expect(resumed.sessionId).toBe(originalSessionId);
@@ -247,6 +250,7 @@ describe('PlayReady Session Resumability', () => {
     const state = session.pause();
 
     // Resume
+    await session.close();
     const resumed = cdm.resumeSession(state);
     expect(resumed.sessionType).toBe('persistent-license');
 


### PR DESCRIPTION
## Summary

- Add validated, versioned snapshots for Widevine and PlayReady session pause/resume.
- Prevent duplicate session IDs and safely track disposed sessions.
- Make session closing idempotent and retryable after failures.
- Expose read-only key status views with byte-based KID matching.
- Correct native Widevine `load()` behavior and preserve session metadata on resume.

## Testing

- Added and updated Vitest coverage for session resumability, registry handling, key status maps, and concurrent/repeated close calls.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791223765&installation_model_id=424872&pr_number=60&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F60&signature=435ba38f37753b805d66ccaf7609fd5992b3373e4e16084a213c53add364d574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->