### PR TITLE
fix(parser): harden DRM input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,18 @@ rejects malformed boxes, raw DRM headers, and other MP4 box types. The returned
 `serializePsshBox` returns full box bytes; `psshBoxToBase64` returns base64. Both
 write a normal 32-bit size field, including for inputs parsed with extended sizes.
 
+Widevine and PlayReady challenge generation use the same bounded box parser,
+including extended-size and size-to-end boxes. A box sequence must contain the
+requested DRM system; malformed boxes are rejected instead of treated as raw
+payloads. Widevine still accepts non-box opaque initialization data for vendor
+compatibility. PlayReady also accepts raw UTF-16LE WRMHEADER XML, complete PROs,
+and standalone type-1 records. PRO and record lengths must match their contents;
+headers support Unicode and an optional UTF-16LE BOM.
+
+`fromHex` rejects odd-length input and non-hexadecimal characters. Empty input
+converts to an empty buffer or string. WVD export rejects private-key and client-ID
+fields larger than 65,535 bytes before writing the file.
+
 IDs accept 16-byte arrays, UUID strings, or 32 hex digits. Inspection returns
 lowercase hex in UUID byte order, accounting for PlayReady's GUID byte order.
 `getPsshKeyIds` prefers nonempty version 1 box KIDs, then reads Widevine protobuf

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -77,12 +77,6 @@ export const tryGetUtf16Le = (bytes: Uint8Array) => {
     return null;
   }
 
-  for (let i = 1; i < bytes.length; i += 2) {
-    if (bytes[i] !== 0) {
-      return null;
-    }
-  }
-
   try {
     const decoder = new TextDecoder('utf-16le', { fatal: true });
     return decoder.decode(bytes);

--- a/src/lib/playready/object.ts
+++ b/src/lib/playready/object.ts
@@ -1,0 +1,46 @@
+import { DOMParser } from '@xmldom/xmldom';
+import { tryGetUtf16Le } from '../buffer';
+
+/** Detect raw headers by XML structure, not by the byte values of their text. */
+export const tryReadWrmHeader = (bytes: Uint8Array) => {
+  const xml = tryGetUtf16Le(bytes);
+  if (!xml?.trim().startsWith('<')) return null;
+  try {
+    const document = new DOMParser({
+      onError: (_level, message) => {
+        throw new Error(message);
+      },
+    }).parseFromString(xml, 'application/xml');
+    return document.documentElement?.localName === 'WRMHEADER' ? xml : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Read a complete PRO, enforcing both total and individual record lengths. */
+export const readPlayreadyObject = (bytes: Uint8Array) => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (bytes.length < 6 || view.getUint32(0, true) !== bytes.length) {
+    throw new Error('Invalid PlayReady Object length');
+  }
+  const count = view.getUint16(4, true);
+  const headers: string[] = [];
+  let cursor = 6;
+  for (let index = 0; index < count; index++) {
+    if (cursor + 4 > bytes.length) throw new Error('Truncated PlayReady record');
+    const type = view.getUint16(cursor, true);
+    const length = view.getUint16(cursor + 2, true);
+    cursor += 4;
+    if (cursor + length > bytes.length) throw new Error('Truncated PlayReady record');
+    if (type === 1) {
+      const header = tryReadWrmHeader(bytes.subarray(cursor, cursor + length));
+      if (header === null) throw new Error('Invalid UTF-16LE WRMHEADER record');
+      headers.push(header);
+    }
+    cursor += length;
+  }
+  if (cursor !== bytes.length || !headers.length) {
+    throw new Error('Invalid PlayReady Object records');
+  }
+  return headers;
+};

--- a/src/lib/playready/pssh.ts
+++ b/src/lib/playready/pssh.ts
@@ -1,132 +1,45 @@
-import { tryGetUtf16Le } from '../buffer';
-import { BinaryReader, compareArrays, fromBase64 } from '../utils';
+import { isPsshBoxSequence, parsePsshBoxes, PSSH_SYSTEM_IDS } from '../pssh';
+import { fromBase64 } from '../utils';
 import { InvalidPssh } from './exceptions';
-
-class PlayreadyObject {
-  type: number;
-  length: number;
-  wrmHeader: string | null;
-
-  constructor(reader: BinaryReader) {
-    this.type = reader.readUint16(true);
-    this.length = reader.readUint16(true);
-    const data = reader.readBytes(this.length);
-    this.wrmHeader = this.type === 1 ? tryGetUtf16Le(data) : null;
-  }
-}
-
-class PlayreadyHeader {
-  length: number;
-  recordCount: number;
-  records: PlayreadyObject[];
-
-  constructor(reader: BinaryReader) {
-    this.length = reader.readUint32(true);
-    this.recordCount = reader.readUint16(true);
-
-    this.records = [];
-    for (let i = 0; i < this.recordCount; i++) {
-      this.records.push(new PlayreadyObject(reader));
-    }
-  }
-}
+import { readPlayreadyObject, tryReadWrmHeader } from './object';
 
 export class Pssh {
   PLAYREADY_SYSTEM_ID = new Uint8Array([
     0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86, 0xab, 0x92, 0xe6, 0x5b, 0xe0, 0x88, 0x5f, 0x95,
   ]);
-  #PSSH_TYPE = 'pssh';
 
   wrmHeaders: string[];
 
   constructor(data: Uint8Array | string) {
     const bytes = typeof data === 'string' ? fromBase64(data).toBuffer() : data;
-    if (!bytes.length) {
-      throw new InvalidPssh('Data must not be empty');
-    }
-
-    this.wrmHeaders = this.#readWrmHeaders(bytes).filter(Boolean) as string[];
-    if (!this.wrmHeaders.length) {
-      throw new InvalidPssh('Could not parse data as a PSSH Box nor a PlayReady Object');
-    }
-  }
-
-  #readWrmHeaders(bytes: Uint8Array) {
-    const string = tryGetUtf16Le(bytes);
-    if (string !== null) {
-      return [string];
-    }
-
-    const psshPayload = this.#extractPlayreadyPsshPayload(bytes);
-    if (psshPayload) {
-      const wrmHeader = tryGetUtf16Le(psshPayload);
-      if (wrmHeader) {
-        return [wrmHeader];
-      }
-
-      const reader = new BinaryReader(psshPayload);
-      return new PlayreadyHeader(reader).records.map((record) => record.wrmHeader);
-    }
-
+    if (!bytes.length) throw new InvalidPssh('Data must not be empty');
     try {
-      const reader = new BinaryReader(bytes);
-      const isPlayreadyHeader = reader.readUint16(true) > 3;
-      reader.reset();
-
-      if (isPlayreadyHeader) {
-        return new PlayreadyHeader(reader).records.map((record) => record.wrmHeader);
+      if (isPsshBoxSequence(bytes)) {
+        const box = parsePsshBoxes(bytes).find((box) => box.systemId === PSSH_SYSTEM_IDS.playready);
+        if (!box) throw new Error('No PlayReady PSSH box found');
+        this.wrmHeaders = this.#readHeaders(box.data);
+      } else {
+        this.wrmHeaders = this.#readHeaders(bytes);
       }
-
-      return [new PlayreadyObject(reader).wrmHeader];
-    } catch {
-      throw new InvalidPssh('Could not parse data as a PSSH Box nor a PlayReady Object');
+    } catch (error) {
+      throw new InvalidPssh(error instanceof Error ? error.message : 'Invalid PlayReady PSSH');
     }
   }
 
-  #extractPlayreadyPsshPayload(bytes: Uint8Array) {
-    if (bytes.length < 8) return null;
+  #readHeaders(bytes: Uint8Array) {
+    const header = tryReadWrmHeader(bytes);
+    if (header !== null) return [header];
 
-    let offset = 0;
-    let sawPsshBox = false;
-
-    while (offset + 8 <= bytes.length) {
-      const reader = new BinaryReader(bytes.subarray(offset));
-      const boxLength = reader.readUint32();
-      const boxType = new TextDecoder().decode(reader.readBytes(4));
-
-      if (boxType !== this.#PSSH_TYPE) {
-        return sawPsshBox ? null : null;
+    // Preserve support for a standalone type-1 record as well as a complete PRO.
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    if (bytes.length >= 4 && view.getUint16(0, true) === 1) {
+      if (view.getUint16(2, true) !== bytes.length - 4) {
+        throw new Error('Invalid PlayReady record length');
       }
-      if (boxLength < 32 || offset + boxLength > bytes.length) {
-        throw new InvalidPssh('The Playready PSSH is invalid or empty.');
-      }
-
-      sawPsshBox = true;
-      const version = reader.readUint8();
-      reader.readBytes(3);
-      const systemId = reader.readBytes(16);
-
-      if (version === 1) {
-        const keyIdCount = reader.readUint32();
-        reader.readBytes(keyIdCount * 16);
-      } else if (version !== 0) {
-        throw new InvalidPssh(`Unsupported PSSH version ${version}`);
-      }
-
-      const dataLength = reader.readUint32();
-      const data = reader.readBytes(dataLength);
-
-      if (compareArrays(systemId, this.PLAYREADY_SYSTEM_ID)) {
-        return data;
-      }
-
-      offset += boxLength;
+      const record = tryReadWrmHeader(bytes.subarray(4));
+      if (record === null) throw new Error('Invalid UTF-16LE WRMHEADER record');
+      return [record];
     }
-
-    if (sawPsshBox) {
-      throw new InvalidPssh('The Playready PSSH is invalid or empty.');
-    }
-
-    return null;
+    return readPlayreadyObject(bytes);
   }
 }

--- a/src/lib/playready/wrmheader.ts
+++ b/src/lib/playready/wrmheader.ts
@@ -152,7 +152,8 @@ const parseInput = (data: string | Uint8Array) => {
   }
 
   const decoded = fromBase64(data).toBuffer();
-  const xml = tryGetUtf16Le(decoded) ?? new TextDecoder().decode(decoded);
+  const utf16 = tryGetUtf16Le(decoded);
+  const xml = utf16?.trim().startsWith('<') ? utf16 : new TextDecoder().decode(decoded);
   if (!xml.trim().startsWith('<')) {
     throw new InvalidWrmHeader('Data is not a valid WRMHEADER');
   }

--- a/src/lib/pssh.ts
+++ b/src/lib/pssh.ts
@@ -1,4 +1,5 @@
 import { WrmHeader } from './playready/wrmheader';
+import { readPlayreadyObject } from './playready/object';
 import { fromBase64, fromBuffer, fromHex } from './utils';
 import { WidevinePsshData } from './widevine/proto';
 
@@ -53,6 +54,11 @@ export const createPsshBox = (
   if (options.keyIds !== undefined) throw new Error('Version 0 boxes cannot contain box key IDs');
   return { ...common, version: 0, keyIds: [] };
 };
+
+/** Recognize the box marker even when its size/version fields are malformed. */
+export const isPsshBoxSequence = (bytes: Uint8Array) =>
+  bytes.length >= 8 &&
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(4) === 0x70737368;
 
 /** Parse a sequence of full PSSH boxes. Raw DRM headers and other MP4 boxes are rejected. */
 export const parsePsshBoxes = (input: Uint8Array | string): ParsedPsshBox[] => {
@@ -156,33 +162,11 @@ const swapGuidByteOrder = (bytes: Uint8Array) => {
 };
 
 const readPlayreadyHeaders = (data: Uint8Array) => {
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  if (data.length < 6 || view.getUint32(0, true) !== data.length) {
-    throw new Error('Invalid PlayReady Object length');
-  }
-  const headers: WrmHeader[] = [];
-  let cursor = 6;
-  const count = view.getUint16(4, true);
-  for (let index = 0; index < count; index++) {
-    if (cursor + 4 > data.length) throw new Error('Truncated PlayReady record');
-    const type = view.getUint16(cursor, true);
-    const length = view.getUint16(cursor + 2, true);
-    cursor += 4;
-    if (cursor + length > data.length) throw new Error('Truncated PlayReady record');
-    if (type === 1) {
-      if (length % 2) throw new Error('Invalid UTF-16LE PlayReady header');
-      const xml = new TextDecoder('utf-16le', { fatal: true }).decode(
-        data.subarray(cursor, cursor + length),
-      );
-      const header = new WrmHeader(xml);
-      if (header.version === 'UNKNOWN') throw new Error('Unsupported PlayReady header version');
-      headers.push(header);
-    }
-    cursor += length;
-  }
-  if (cursor !== data.length || !headers.length)
-    throw new Error('Invalid PlayReady Object records');
-  return headers;
+  return readPlayreadyObject(data).map((xml) => {
+    const header = new WrmHeader(xml);
+    if (header.version === 'UNKNOWN') throw new Error('Unsupported PlayReady header version');
+    return header;
+  });
 };
 
 /** Inspect box KIDs first, falling back to Widevine protobuf or PlayReady Object KIDs. */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -75,19 +75,21 @@ export const fromBuffer = (data: Uint8Array) => ({
   },
 });
 
-const parseHex = (hex: string) => hex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16));
-
-export const fromHex = (data: string) => ({
-  toBase64: () => {
-    return btoa(String.fromCharCode(...parseHex(data)));
-  },
-  toBuffer: () => {
-    return new Uint8Array(parseHex(data)) as unknown as Uint8Array;
-  },
-  toText: () => {
-    return decode(new Uint8Array(parseHex(data)));
-  },
-});
+/** Decode whole bytes. Empty input produces an empty buffer. */
+export const fromHex = (data: string) => {
+  if (data.length % 2 !== 0 || !/^[\da-f]*$/i.test(data)) {
+    throw new Error('Hex input must contain an even number of hexadecimal digits');
+  }
+  const bytes = new Uint8Array(data.length / 2);
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Number.parseInt(data.slice(index * 2, index * 2 + 2), 16);
+  }
+  return {
+    toBuffer: () => new Uint8Array(bytes),
+    toBase64: () => fromBuffer(bytes).toBase64(),
+    toText: () => decode(bytes),
+  };
+};
 
 export const parseBufferSource = (data: BytesLike) => toBytes(data);
 

--- a/src/lib/widevine/pssh.ts
+++ b/src/lib/widevine/pssh.ts
@@ -1,56 +1,19 @@
 import { fromBase64 } from '../utils';
 import { WidevinePsshData } from './proto';
-import { areBytesEqual, tryDecodeExactly } from './protobuf';
-
-const WV_SYSTEM_ID = new Uint8Array([
-  237, 239, 139, 169, 121, 214, 74, 206, 163, 200, 39, 220, 213, 29, 33, 237,
-]);
-
-const readUint32BE = (data: Uint8Array, offset: number) =>
-  (data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3];
-
-const findWidevineInitData = (data: Uint8Array) => {
-  for (let offset = 0; offset + 32 <= data.length; ) {
-    const size = readUint32BE(data, offset);
-    if (size < 32 || offset + size > data.length) break;
-
-    const type = data.subarray(offset + 4, offset + 8);
-    if (!areBytesEqual(type, new TextEncoder().encode('pssh'))) {
-      offset += size;
-      continue;
-    }
-
-    const version = data[offset + 8];
-    let cursor = offset + 12;
-    const systemId = data.subarray(cursor, cursor + 16);
-    cursor += 16;
-
-    if (version === 1) {
-      const keyIdCount = readUint32BE(data, cursor);
-      cursor += 4 + keyIdCount * 16;
-      if (cursor + 4 > offset + size) break;
-    }
-
-    const initDataSize = readUint32BE(data, cursor);
-    cursor += 4;
-    if (cursor + initDataSize > offset + size) break;
-
-    if (areBytesEqual(systemId, WV_SYSTEM_ID)) {
-      return data.subarray(cursor, cursor + initDataSize);
-    }
-
-    offset += size;
-  }
-
-  return null;
-};
+import { tryDecodeExactly } from './protobuf';
+import { isPsshBoxSequence, parsePsshBoxes, PSSH_SYSTEM_IDS } from '../pssh';
 
 const normalizeInput = (data: Uint8Array | string) =>
   typeof data === 'string' ? fromBase64(data).toBuffer() : data;
 
 const createPssh = (initData: Uint8Array | string) => {
   const input = normalizeInput(initData);
-  const payload = findWidevineInitData(input) ?? input;
+  // Non-box input remains an opaque payload for compatibility with vendor headers.
+  const boxes = isPsshBoxSequence(input) ? parsePsshBoxes(input) : null;
+  const payload = boxes
+    ? boxes.find((box) => box.systemId === PSSH_SYSTEM_IDS.widevine)?.data
+    : input;
+  if (!payload) throw new Error('No Widevine PSSH box found');
   const parsed = tryDecodeExactly(payload, WidevinePsshData);
 
   return {

--- a/src/lib/widevine/wvd.ts
+++ b/src/lib/widevine/wvd.ts
@@ -106,6 +106,8 @@ export const buildWvd = (wvdData: {
   clientId: Uint8Array;
 }) => {
   const { deviceType, securityLevel, privateKey, clientId } = wvdData;
+  if (privateKey.length > 0xffff) throw new Error('WVD private key exceeds the 16-bit size limit');
+  if (clientId.length > 0xffff) throw new Error('WVD client ID exceeds the 16-bit size limit');
 
   // Private key length and client ID length
   const privateKeyLen = privateKey.length;

--- a/test/hex.test.ts
+++ b/test/hex.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest';
+import { fromBuffer, fromHex } from '../src/lib/utils';
+
+test.each(['z0', '0z', 'zz', 'a', 'abc', '00 00', '0x12', '-1', '00\n'])(
+  'rejects invalid hex %j',
+  (input) => {
+    expect(() => fromHex(input)).toThrow('even number of hexadecimal digits');
+  },
+);
+
+test.each(['', '00', 'aAbBcC', '0041ff'])('converts hex %j consistently', (input) => {
+  const expected = Buffer.from(input, 'hex');
+  const converted = fromHex(input);
+  expect(converted.toBuffer()).toEqual(new Uint8Array(expected));
+  expect(converted.toBase64()).toBe(expected.toString('base64'));
+  expect(converted.toText()).toBe(expected.toString('utf8'));
+  expect(fromBuffer(converted.toBuffer()).toHex()).toBe(input.toLowerCase());
+});
+
+test('hex conversion handles large buffers without spreading bytes onto the stack', () => {
+  expect(fromHex('ab'.repeat(200_000)).toBase64()).toBe(
+    Buffer.alloc(200_000, 0xab).toString('base64'),
+  );
+});

--- a/test/playready-pssh.test.ts
+++ b/test/playready-pssh.test.ts
@@ -113,3 +113,46 @@ test('playready PSSH advances over non-header records inside a PlayReady header'
 test('playready PSSH rejects empty payloads', () => {
   expect(() => new Pssh(new Uint8Array())).toThrowError(new InvalidPssh('Data must not be empty'));
 });
+
+test.each(['Привет 世界 😀', '\ufeffПривет'])(
+  'preserves Unicode in raw, record and PRO headers: %s',
+  (text) => {
+    const xml = WRM_HEADER.replace(
+      '<DATA></DATA>',
+      `<DATA><LA_URL>https://example.test/${text}</LA_URL></DATA>`,
+    );
+    const bytes = encodeUtf16Le(`\ufeff${xml}`);
+    const pro = createPlayreadyHeader([{ type: 1, data: bytes }]);
+    for (const input of [bytes, pro.subarray(6), pro, createPsshBox(PLAYREADY_SYSTEM_ID, pro)]) {
+      expect(new Pssh(input).wrmHeaders).toEqual([xml]);
+    }
+  },
+);
+
+test.each([
+  new Uint8Array([0x00, 0xd8]),
+  new Uint8Array([0x00, 0xdc]),
+  new Uint8Array([0x3c]),
+  encodeUtf16Le('<OTHER></OTHER>'),
+  encodeUtf16Le('<WRMHEADER><DATA></WRMHEADER>'),
+])('rejects invalid UTF-16LE or XML in type-1 records', (bytes) => {
+  expect(() => new Pssh(createPlayreadyHeader([{ type: 1, data: bytes }]))).toThrow();
+});
+
+test('enforces PRO total length, record count and record boundaries', () => {
+  const pro = createPlayreadyHeader([{ type: 1, data: encodeUtf16Le(WRM_HEADER) }]);
+  const invalid = [pro.subarray(0, pro.length - 1), new Uint8Array([...pro, 0])];
+  for (const [offset, value] of [
+    [0, pro.length - 1],
+    [4, 2],
+    [8, pro.length],
+  ] as const) {
+    const copy = new Uint8Array(pro);
+    new DataView(copy.buffer).setUint16(offset, value, true);
+    invalid.push(copy);
+  }
+  for (const bytes of invalid) {
+    expect(() => new Pssh(bytes)).toThrow();
+    expect(() => new Pssh(createPsshBox(PLAYREADY_SYSTEM_ID, bytes))).toThrow();
+  }
+});

--- a/test/playready-wrmheader.test.ts
+++ b/test/playready-wrmheader.test.ts
@@ -91,3 +91,13 @@ test('verifies WRMHEADER COCKTAIL checksums without node-specific crypto', async
 
   expect(await header.keyIds[0].verify(CONTENT_KEY)).toBe(true);
 });
+
+test('decodes base64 UTF-8 and UTF-16LE headers after Unicode detection', () => {
+  const xml =
+    '<WRMHEADER version="4.0.0.0"><DATA><LA_URL>https://example.test/许可/😀</LA_URL></DATA></WRMHEADER>';
+  for (const encoding of ['utf8', 'utf16le'] as const) {
+    expect(new WrmHeader(Buffer.from(xml, encoding).toString('base64')).laUrl).toBe(
+      'https://example.test/许可/😀',
+    );
+  }
+});

--- a/test/pssh-acquisition.test.ts
+++ b/test/pssh-acquisition.test.ts
@@ -1,0 +1,154 @@
+import { readFile } from 'node:fs/promises';
+import { assert, expect, test } from 'vitest';
+import {
+  PlayReady,
+  PlayReadyDeviceCredentials,
+  Widevine,
+  WidevineDeviceCredentials,
+} from '../src/lib';
+import { createPsshBox, parsePsshBoxes, PSSH_SYSTEM_IDS, serializePsshBox } from '../src/lib/pssh';
+import { Pssh } from '../src/lib/playready/pssh';
+import { createPssh } from '../src/lib/widevine/pssh';
+import { LicenseRequest, SignedMessage, WidevinePsshData } from '../src/lib/widevine/proto';
+
+const xml =
+  '<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0"><DATA><LA_URL>https://example.test/许可/Привет/😀</LA_URL></DATA></WRMHEADER>';
+const pro = new Uint8Array(10 + xml.length * 2);
+const proView = new DataView(pro.buffer);
+proView.setUint32(0, pro.length, true);
+proView.setUint16(4, 1, true);
+proView.setUint16(6, 1, true);
+proView.setUint16(8, pro.length - 10, true);
+pro.set(Buffer.from(xml, 'utf16le'), 10);
+const payload = WidevinePsshData.encode(
+  WidevinePsshData.create({ provider: 'parser-test' }),
+).finish();
+const widevineBox = serializePsshBox(
+  createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine, data: payload }),
+);
+const playreadyBox = serializePsshBox(
+  createPsshBox({ systemId: PSSH_SYSTEM_IDS.playready, data: pro }),
+);
+
+const variants = (box: Uint8Array, other: Uint8Array) => {
+  const extended = new Uint8Array(box.length + 8);
+  const view = new DataView(extended.buffer);
+  view.setUint32(0, 1);
+  extended.set(box.subarray(4, 8), 4);
+  view.setBigUint64(8, BigInt(extended.length));
+  extended.set(box.subarray(8), 16);
+  const toEnd = new Uint8Array(box);
+  toEnd.fill(0, 0, 4);
+  const parsed = parsePsshBoxes(box)[0];
+  assert(parsed);
+  const version1 = serializePsshBox(
+    createPsshBox({ ...parsed, version: 1, keyIds: ['ab'.repeat(16)] }),
+  );
+  return [
+    { name: 'normal', bytes: box },
+    { name: 'extended', bytes: extended },
+    { name: 'size-to-end', bytes: toEnd },
+    { name: 'version 1', bytes: version1 },
+    { name: 'concatenated', bytes: new Uint8Array([...other, ...extended]) },
+    { name: 'raw', bytes: parsed.data },
+  ];
+};
+
+const widevineInputs = variants(widevineBox, playreadyBox);
+const playreadyInputs = variants(playreadyBox, widevineBox);
+
+test.each(widevineInputs)('Widevine acquisition parses $name', ({ bytes, name }) => {
+  expect(createPssh(bytes).toBuffer()).toEqual(payload);
+  if (name !== 'raw')
+    expect(
+      parsePsshBoxes(bytes).find((box) => box.systemId === PSSH_SYSTEM_IDS.widevine)?.data,
+    ).toEqual(payload);
+});
+
+test.each(playreadyInputs)('PlayReady acquisition parses $name', ({ bytes, name }) => {
+  expect(new Pssh(bytes).wrmHeaders).toEqual([xml]);
+  if (name !== 'raw')
+    expect(
+      parsePsshBoxes(bytes).find((box) => box.systemId === PSSH_SYSTEM_IDS.playready)?.data,
+    ).toEqual(pro);
+});
+
+test.each([widevineBox, playreadyBox])(
+  'both acquisition parsers reject malformed box sequences',
+  (box) => {
+    const version = new Uint8Array(box);
+    version[8] = 2;
+    const length = new Uint8Array(box);
+    new DataView(length.buffer).setUint32(28, box.length);
+    const smallBox = new Uint8Array(box);
+    new DataView(smallBox.buffer).setUint32(0, 8);
+    const malformed = [
+      version,
+      length,
+      smallBox,
+      box.subarray(0, 20),
+      new Uint8Array([...box, 0]),
+      new Uint8Array([...length, ...widevineBox]),
+    ];
+    for (const bytes of malformed) {
+      expect(() => parsePsshBoxes(bytes)).toThrow();
+      expect(() => createPssh(bytes)).toThrow();
+      expect(() => new Pssh(bytes)).toThrow();
+    }
+  },
+);
+
+test('rejects a box sequence that has no matching DRM system', () => {
+  expect(() => createPssh(playreadyBox)).toThrow('No Widevine PSSH');
+  expect(() => new Pssh(widevineBox)).toThrow('No PlayReady PSSH');
+});
+
+const wvdPath = process.env.VITEST_WVD_PATH;
+const prdPath = process.env.VITEST_PRD_PATH;
+
+test.skipIf(!wvdPath).each(widevineInputs)(
+  'Widevine challenge preserves payload from $name',
+  async ({ bytes }) => {
+    assert(wvdPath, 'Set VITEST_WVD_PATH to enable offline challenge tests');
+    const engine = new Widevine({
+      deviceCredentials: await WidevineDeviceCredentials.from({ wvd: await readFile(wvdPath) }),
+    });
+    const session = engine.createSession();
+    const messages: Uint8Array[] = [];
+    session.onmessage = (event) => {
+      messages.push(event.detail.message);
+    };
+    try {
+      await session.generateRequest(bytes);
+      expect(messages).toHaveLength(1);
+      const message = messages[0];
+      assert(message);
+      const request = LicenseRequest.decode(SignedMessage.decode(message).msg);
+      expect(request.contentId?.widevinePsshData?.psshData).toEqual([payload]);
+    } finally {
+      await session.close();
+    }
+  },
+);
+
+test.skipIf(!prdPath).each(playreadyInputs)(
+  'PlayReady challenge preserves Unicode header from $name',
+  async ({ bytes }) => {
+    assert(prdPath, 'Set VITEST_PRD_PATH to enable offline challenge tests');
+    const engine = new PlayReady({
+      deviceCredentials: await PlayReadyDeviceCredentials.from({ prd: await readFile(prdPath) }),
+    });
+    const session = engine.createSession();
+    const messages: Uint8Array[] = [];
+    session.onmessage = (event) => {
+      messages.push(event.detail.message);
+    };
+    try {
+      await session.generateRequest(bytes);
+      expect(messages).toHaveLength(1);
+      expect(new TextDecoder().decode(messages[0])).toContain(xml);
+    } finally {
+      await session.close();
+    }
+  },
+);

--- a/test/wvd-format.test.ts
+++ b/test/wvd-format.test.ts
@@ -100,6 +100,22 @@ describe('tryGetUtf16Le', () => {
 
   test('returns null for non-UTF-16LE input', () => {
     expect(tryGetUtf16Le(new Uint8Array([0x41, 0x42, 0x43]))).toBeNull();
-    expect(tryGetUtf16Le(new Uint8Array([0x41, 0x01]))).toBeNull();
+    expect(tryGetUtf16Le(new Uint8Array([0x00, 0xd8]))).toBeNull();
   });
+});
+
+test('WVD fields roundtrip at the maximum length and reject overflow', () => {
+  const fields = {
+    deviceType: WVD_DEVICE_TYPES.android,
+    securityLevel: 3,
+    privateKey: new Uint8Array(0xffff).fill(0xab),
+    clientId: new Uint8Array(0xffff).fill(0xcd),
+  };
+  expect(parseWvd(buildWvd(fields))).toMatchObject(fields);
+  expect(() => buildWvd({ ...fields, privateKey: new Uint8Array(0x10000) })).toThrow(
+    'private key exceeds',
+  );
+  expect(() => buildWvd({ ...fields, clientId: new Uint8Array(0x10000) })).toThrow(
+    'client ID exceeds',
+  );
 });


### PR DESCRIPTION
## Summary

- Validate PSSH box sequences, PlayReady objects, UTF-16LE/XML headers, and hexadecimal input.
- Support extended-size and size-to-end PSSH boxes, Unicode PlayReady headers, and vendor-compatible Widevine payloads.
- Reject oversized WVD fields before serialization and add regression coverage for malformed inputs.

## Testing

- Added and updated Vitest coverage for hex conversion, PlayReady parsing, PSSH acquisition, Unicode headers, and WVD field limits.
- Offline challenge tests cover Widevine and PlayReady input variants when device paths are configured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791224501&installation_model_id=424872&pr_number=61&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F61&signature=bce025acae7d8ad2391cdf43ff9b6fadfc18e3edeec356f4fc662616783eaed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->