### PR TITLE
fix(extension): quote download command arguments

### DIFF
--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -8,6 +8,7 @@ import { Section } from '../components/section';
 import { Cell } from '../components/cell';
 import { copyKey } from '../utils/key';
 import { formatRelativeTime } from '../utils/date';
+import { buildDownloadCommand } from '../utils/command';
 
 type KeySettingsProps = {
   key: KeyInfo;
@@ -15,9 +16,7 @@ type KeySettingsProps = {
 };
 
 export const KeySettings: Component<KeySettingsProps> = (props) => {
-  const [command, setCommand] = createSignal<string>(
-    ['N_m3u8DL-RE', props.key.mpd, '--key', `${props.key.id}:${props.key.value}`].join(' '),
-  );
+  const [command, setCommand] = createSignal(buildDownloadCommand(props.key));
 
   const getMainLayoutElement = () => {
     return document.querySelector<HTMLDivElement>('#root > main');
@@ -62,7 +61,7 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
             Added
           </Cell>
         </Section>
-        <Section header="Command builder">
+        <Section header="Command builder (Bash / Zsh)">
           <Cell class="w-full">
             <textarea
               class="font-mono outline-none bg-transparent border-none w-full"

--- a/src/extension/entrypoints/popup/utils/command.ts
+++ b/src/extension/entrypoints/popup/utils/command.ts
@@ -4,4 +4,4 @@ import type { KeyInfo } from '@/utils/storage';
 const quoteShellArgument = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
 
 export const buildDownloadCommand = (key: Pick<KeyInfo, 'mpd' | 'id' | 'value'>) =>
-  `N_m3u8DL-RE ${quoteShellArgument(key.mpd)} --key ${quoteShellArgument(`${key.id}:${key.value}`)}`;
+  `N_m3u8DL-RE ${quoteShellArgument(key.mpd ?? '')} --key ${quoteShellArgument(`${key.id}:${key.value}`)}`;

--- a/src/extension/entrypoints/popup/utils/command.ts
+++ b/src/extension/entrypoints/popup/utils/command.ts
@@ -1,0 +1,7 @@
+import type { KeyInfo } from '@/utils/storage';
+
+// POSIX shell quoting: leave single quotes briefly to insert a literal apostrophe.
+const quoteShellArgument = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
+
+export const buildDownloadCommand = (key: Pick<KeyInfo, 'mpd' | 'id' | 'value'>) =>
+  `N_m3u8DL-RE ${quoteShellArgument(key.mpd)} --key ${quoteShellArgument(`${key.id}:${key.value}`)}`;

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -8,7 +8,7 @@ export type KeyInfo = {
   id: string;
   value: string;
   url: string;
-  mpd: string;
+  mpd?: string;
   pssh: string;
   createdAt: number;
 };

--- a/test/download-command.test.ts
+++ b/test/download-command.test.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from 'node:child_process';
+import { expect, test } from 'vitest';
+import { buildDownloadCommand } from '../src/extension/entrypoints/popup/utils/command';
+
+test
+  .skipIf(process.platform === 'win32')
+  .each([
+    'https://example.com/manifest.mpd',
+    'https://example.com/$0manifest.mpd?first=1&second=2',
+    'https://example.com/a b/"quoted"/it\'s.mpd',
+    'https://example.com/$(printf expanded)/`printf expanded`/manifest.mpd',
+    'https://example.com/back\\slash;*?[x]\nmanifest.mpd',
+    '',
+  ])('preserves download arguments in Bash: %j', (mpd) => {
+  const key = { mpd, id: '0123456789abcdef', value: 'abcdef0123456789' };
+  const command = buildDownloadCommand(key);
+  // Stand in for the downloader so the real shell parses the generated command.
+  const output = execFileSync(
+    'bash',
+    ['--noprofile', '--norc', '-c', `function N_m3u8DL-RE() { printf '%s\\0' "$@"; }\n${command}`],
+    { encoding: 'utf8' },
+  );
+  expect(output.split('\0')).toEqual([mpd, '--key', `${key.id}:${key.value}`, '']);
+});

--- a/test/download-command.test.ts
+++ b/test/download-command.test.ts
@@ -2,6 +2,15 @@ import { execFileSync } from 'node:child_process';
 import { expect, test } from 'vitest';
 import { buildDownloadCommand } from '../src/extension/entrypoints/popup/utils/command';
 
+test.each([
+  { id: '0123456789abcdef', value: 'abcdef0123456789' },
+  { id: '0123456789abcdef', value: 'abcdef0123456789', mpd: undefined },
+])('builds an editable command without a manifest URL: %j', (key) => {
+  expect(buildDownloadCommand(key)).toBe(
+    "N_m3u8DL-RE '' --key '0123456789abcdef:abcdef0123456789'",
+  );
+});
+
 test
   .skipIf(process.platform === 'win32')
   .each([


### PR DESCRIPTION
## Summary

- Quote manifest URLs and key arguments in generated Bash/Zsh download commands.
- Add coverage for shell metacharacters, whitespace, quotes, and empty URLs.

## Testing

- Added Vitest coverage using Bash argument parsing across representative URL inputs.
- Windows skips the Bash-specific test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791226689&installation_model_id=424872&pr_number=63&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F63&signature=6560468bb094e27688623d806ff28d2766f4c09ddec070639f4be46aacf7111c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->