### PR TITLE
feat(extension): show DRM status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With EME interception enabled, the extension inspects ClearKey license responses
 
 Experimental request interception detects streaming manifests in page fetch and XMLHttpRequest responses. Requests made inside workers are not inspected.
 
-The toolbar badge uses `W`, `P`, or `C` for Widevine, PlayReady, or ClearKey, followed by a count capped at `99+`:
+The toolbar badge shows a count capped at `99+`, followed by `W`, `P`, or `C` for Widevine, PlayReady, or ClearKey, such as `3W` or `99+W`:
 
 - Gray: intercepted key IDs/statuses only, without content keys.
 - Blue: content keys available from saved history for the domain.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ With EME interception enabled, the extension inspects ClearKey license responses
 
 Experimental request interception detects streaming manifests in page fetch and XMLHttpRequest responses. Requests made inside workers are not inspected.
 
+The toolbar badge uses `W`, `P`, or `C` for Widevine, PlayReady, or ClearKey, followed by a count capped at `99+`:
+
+- Gray: intercepted key IDs/statuses only, without content keys.
+- Blue: content keys available from saved history for the domain.
+- Green: content keys retrieved during this page visit, including keys retrieved again.
+- Orange with `!`: retrieval failed. Hover over the icon for the error.
+
+Navigation or reload clears the current result; saved content keys then appear blue. The tooltip explains the count and lists DRM results from this visit. Older history without DRM metadata shows only the number. Green indicates key retrieval, not verified playback.
+
 ### Installing Chrome extension
 
 **Developer Mode** needs to be enabled in `chrome://extensions/` page

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,3 +1,10 @@
+import {
+  getBadgeAppearance,
+  getBadgeDrmSystem,
+  getBadgeKey,
+  getBadgeStorage,
+  type BadgeResult,
+} from '@/utils/badge';
 import { appStorage, getRecentKeysForUrl, isCapturedKey } from '@/utils/storage';
 import { getDrmFailureStorage } from '@/utils/storage';
 import type { DrmStage, KeyInfo } from '@/utils/storage';
@@ -201,7 +208,13 @@ export default defineBackground({
         }
       }
     };
-    browser.tabs.onRemoved.addListener(closeTabSessions);
+    browser.tabs.onRemoved.addListener((tabId) => {
+      closeTabSessions(tabId);
+      void (badgeUpdates.get(tabId) ?? Promise.resolve())
+        .catch(() => {})
+        .then(() => getBadgeStorage(tabId).removeValue())
+        .catch((error: unknown) => console.warn('[okova] Unable to clear badge', error));
+    });
 
     const loadClient = async () => {
       console.log('[okova] Loading DRM client...');
@@ -227,28 +240,41 @@ export default defineBackground({
       }
     };
 
-    const getBadgeText = (count: number) => {
-      if (count === 0) return '';
-      if (count > 99) return '99+';
-      return String(count);
-    };
-
-    const getKeysCountForUrl = async (url?: string | null) => {
-      const [recentKeys, recentKeysByDomain] = await Promise.all([
-        appStorage.recentKeys.getValue(),
-        appStorage.recentKeysByDomain.getValue(),
-      ]);
-      return getRecentKeysForUrl(url, recentKeysByDomain, recentKeys).length;
-    };
-
-    const updateBadgeForTab = async (tab?: Browser.tabs.Tab | null) => {
-      if (typeof tab?.id !== 'number') return;
-
-      const count = await getKeysCountForUrl(tab.url);
-      await browser.action.setBadgeText({
-        tabId: tab.id,
-        text: getBadgeText(count),
-      });
+    // Serialize badge writes so an older refresh cannot overwrite a newer result or navigation.
+    const badgeUpdates = new Map<number, Promise<void>>();
+    const updateBadgeForTab = (tab?: Browser.tabs.Tab | null, result?: BadgeResult | null) => {
+      const tabId = tab?.id;
+      if (typeof tabId !== 'number') return Promise.resolve();
+      const update = (badgeUpdates.get(tabId) ?? Promise.resolve())
+        .catch(() => {})
+        .then(async () => {
+          const badgeStorage = getBadgeStorage(tabId);
+          if (result === null) await badgeStorage.removeValue();
+          else if (result) {
+            const previous = (await badgeStorage.getValue()) ?? [];
+            await badgeStorage.setValue([
+              ...previous.filter((entry) => entry.system !== result.system),
+              result,
+            ]);
+          }
+          const [recentKeys, recentKeysByDomain, storedResult] = await Promise.all([
+            appStorage.recentKeys.getValue(),
+            appStorage.recentKeysByDomain.getValue(),
+            badgeStorage.getValue(),
+          ]);
+          const keys = getRecentKeysForUrl(tab?.url, recentKeysByDomain, recentKeys);
+          const badge = getBadgeAppearance(keys, storedResult);
+          await browser.action.setBadgeBackgroundColor({ tabId, color: badge.color });
+          await browser.action.setBadgeTextColor({ tabId, color: '#FFFFFF' });
+          await browser.action.setTitle({ tabId, title: badge.title });
+          await browser.action.setBadgeText({ tabId, text: badge.text });
+        });
+      badgeUpdates.set(tabId, update);
+      const cleanup = () => {
+        if (badgeUpdates.get(tabId) === update) badgeUpdates.delete(tabId);
+      };
+      void update.then(cleanup, cleanup);
+      return update;
     };
 
     const updateBadgeForTabInBackground = (tab?: Browser.tabs.Tab | null) => {
@@ -268,7 +294,7 @@ export default defineBackground({
 
     const updateActiveTabBadges = async () => {
       const activeTabs = await browser.tabs.query({ active: true });
-      const results = await Promise.allSettled(activeTabs.map(updateBadgeForTab));
+      const results = await Promise.allSettled(activeTabs.map((tab) => updateBadgeForTab(tab)));
       for (const result of results) {
         if (result.status === 'rejected') {
           console.warn('[okova] Unable to update extension badge', result.reason);
@@ -298,6 +324,11 @@ export default defineBackground({
 
     browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
       if (changeInfo.status === 'loading') closeTabSessions(tabId);
+      if (changeInfo.status === 'loading' || changeInfo.url) {
+        void updateBadgeForTab(tab, null).catch((error: unknown) => {
+          console.warn('[okova] Unable to reset badge', error);
+        });
+      }
       if (changeInfo.url || changeInfo.status === 'complete') {
         updateBadgeForTabInBackground(tab);
       }
@@ -341,6 +372,15 @@ export default defineBackground({
       let stage: DrmStage = 'setup';
       const tabId = sender.tab?.id;
       const tabGeneration = tabId === undefined ? 0 : (tabGenerations.get(tabId) ?? 0);
+      const system = getBadgeDrmSystem(message.keySystem);
+      const recordBadgeResult = async (result: BadgeResult) => {
+        if (tabId === undefined || tabGeneration !== (tabGenerations.get(tabId) ?? 0)) return;
+        try {
+          await updateBadgeForTab(sender.tab, result);
+        } catch (error) {
+          console.warn('[okova] Unable to update badge result', error);
+        }
+      };
       const clearFailure = async () => {
         if (tabId === undefined || tabGeneration !== (tabGenerations.get(tabId) ?? 0)) return;
         try {
@@ -389,6 +429,7 @@ export default defineBackground({
           if (clearKeys?.length) {
             const results = clearKeys.map((key) => ({
               ...key,
+              drmSystem: system,
               url: message.url,
               mpd: message.mpd,
               pssh: message.initData,
@@ -398,6 +439,7 @@ export default defineBackground({
             await setRecentKeys(results);
             await run(appStorage.allKeys.add(...results));
             await run(clearFailure());
+            await recordBadgeResult({ kind: 'success', system, keys: results.map(getBadgeKey) });
             stage = 'close';
             if (sessionKey) await closeSession(sessionKey);
             respond({ keys: results });
@@ -410,6 +452,7 @@ export default defineBackground({
         if (settings?.emeInterception && message.action === 'keystatuseschange') {
           const keyStatuses = message.keyStatuses as Record<string, string>;
           const keys = Object.entries(keyStatuses).map(([id, status]) => ({
+            drmSystem: system,
             id: fromBase64(id).toHex(),
             value: status,
             url: message.url,
@@ -563,6 +606,7 @@ export default defineBackground({
           const keys = new Map(session.keys);
           if (!keys.size) throw new NoContentKeysError();
           const results = Array.from(keys, ([id, value]) => ({
+            drmSystem: system,
             id,
             value,
             url: message.url,
@@ -574,6 +618,7 @@ export default defineBackground({
           await setRecentKeys(results);
           await run(appStorage.allKeys.add(...results));
           await run(clearFailure());
+          await recordBadgeResult({ kind: 'success', system, keys: results.map(getBadgeKey) });
           stage = 'close';
           await closeSession(sessionKey);
           respond({ keys: results });
@@ -605,6 +650,11 @@ export default defineBackground({
                 error: error instanceof Error ? error.message : String(error),
                 url: sender.tab?.url ?? message.url ?? '',
                 createdAt: Date.now(),
+              });
+              await recordBadgeResult({
+                kind: 'failure',
+                system,
+                error: error instanceof Error ? error.message : String(error),
               });
             }
           } catch (diagnosticError) {

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -265,7 +265,7 @@ export default defineBackground({
           const keys = getRecentKeysForUrl(tab?.url, recentKeysByDomain, recentKeys);
           const badge = getBadgeAppearance(keys, storedResult);
           await browser.action.setBadgeBackgroundColor({ tabId, color: badge.color });
-          await browser.action.setBadgeTextColor({ tabId, color: '#FFFFFF' });
+          await browser.action.setBadgeTextColor?.({ tabId, color: '#FFFFFF' });
           await browser.action.setTitle({ tabId, title: badge.title });
           await browser.action.setBadgeText({ tabId, text: badge.text });
         });
@@ -323,8 +323,8 @@ export default defineBackground({
     });
 
     browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-      if (changeInfo.status === 'loading') closeTabSessions(tabId);
       if (changeInfo.status === 'loading' || changeInfo.url) {
+        closeTabSessions(tabId);
         void updateBadgeForTab(tab, null).catch((error: unknown) => {
           console.warn('[okova] Unable to reset badge', error);
         });

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -132,6 +132,7 @@ export default defineUnlistedScript(() => {
       const request = sessionRequests.get(session);
       await request?.ready;
       const response = await send({
+        keySystem: getKeySystem(session),
         serverCertificate: getServerCertificate(session),
         sessionToken: request?.token,
         action: messageType,

--- a/src/extension/utils/badge.ts
+++ b/src/extension/utils/badge.ts
@@ -69,13 +69,13 @@ export const getBadgeAppearance = (keys: KeyInfo[], results: BadgeResult[] | nul
   const count = displayed.length > 99 ? '99+' : String(displayed.length);
   if (captured.length) {
     return {
-      text: `${system ?? ''}${count}`,
+      text: `${count}${system ?? ''}`,
       color: isFresh ? '#16803C' : '#2169EB',
       title: `Okova: ${captured.length} content keys ${isFresh ? 'retrieved this visit' : 'available from history'}${details}`,
     };
   }
   return {
-    text: `${latest?.drmSystem ?? ''}${count}`,
+    text: `${count}${latest?.drmSystem ?? ''}`,
     color: '#666666',
     title: `Okova: ${keys.length} key IDs observed; no content keys${details}`,
   };

--- a/src/extension/utils/badge.ts
+++ b/src/extension/utils/badge.ts
@@ -1,0 +1,82 @@
+import { storage } from '#imports';
+import { isCapturedKey, type KeyInfo, type BadgeDrmSystem } from './storage';
+
+const DRM_SYSTEMS = {
+  W: 'Widevine',
+  P: 'PlayReady',
+  C: 'ClearKey',
+} as const;
+
+export type BadgeResult =
+  | { kind: 'success'; system: BadgeDrmSystem | undefined; keys: string[] }
+  | { kind: 'failure'; system: BadgeDrmSystem | undefined; error: string };
+
+export const getBadgeStorage = (tabId: number) =>
+  storage.defineItem<BadgeResult[]>(`session:badge-result:${tabId}`);
+
+export const getBadgeDrmSystem = (keySystem: unknown): BadgeDrmSystem | undefined => {
+  switch (keySystem) {
+    case 'com.widevine.alpha':
+      return 'W';
+    case 'com.microsoft.playready':
+    case 'com.microsoft.playready.recommendation':
+    case 'com.microsoft.playready.recommendation.3000':
+    case 'com.microsoft.playready.hardware':
+      return 'P';
+    case 'org.w3.clearkey':
+      return 'C';
+    default:
+      return undefined;
+  }
+};
+
+export const getBadgeKey = (key: KeyInfo) => `${key.id}:${key.value}`;
+
+export const getBadgeAppearance = (keys: KeyInfo[], results: BadgeResult[] | null) => {
+  const result = results?.at(-1);
+  const captured = keys.filter(isCapturedKey);
+  const displayed = captured.length ? captured : keys;
+  const latest = displayed.reduce<KeyInfo | undefined>(
+    (previous, key) => (!previous || key.createdAt >= previous.createdAt ? key : previous),
+    undefined,
+  );
+  const isFresh =
+    result?.kind === 'success' &&
+    captured.some(
+      (key) => key.drmSystem === result.system && result.keys.includes(getBadgeKey(key)),
+    );
+  const system = result?.kind === 'failure' || isFresh ? result?.system : latest?.drmSystem;
+  const name = system ? DRM_SYSTEMS[system] : 'DRM';
+  const breakdown = Object.entries(DRM_SYSTEMS)
+    .map(([code, label]) => {
+      const outcome = results?.find((entry) => entry.system === code);
+      if (outcome?.kind === 'failure') return `${label}: retrieval failed`;
+      if (outcome?.kind === 'success')
+        return `${label}: ${outcome.keys.length} content keys retrieved this visit`;
+      const count = displayed.filter((key) => key.drmSystem === code).length;
+      return count ? `${label}: ${count} ${captured.length ? 'content keys' : 'key IDs'}` : '';
+    })
+    .filter(Boolean);
+  const details = breakdown.length ? `\n${breakdown.join('\n')}` : '';
+  if (result?.kind === 'failure') {
+    return {
+      text: `${system ?? ''}!`,
+      color: '#C75300',
+      title: `Okova: ${name} retrieval failed\n${result.error}${details}`,
+    };
+  }
+  if (!displayed.length) return { text: '', color: '#666666', title: 'Okova' };
+  const count = displayed.length > 99 ? '99+' : String(displayed.length);
+  if (captured.length) {
+    return {
+      text: `${system ?? ''}${count}`,
+      color: isFresh ? '#16803C' : '#2169EB',
+      title: `Okova: ${captured.length} content keys ${isFresh ? 'retrieved this visit' : 'available from history'}${details}`,
+    };
+  }
+  return {
+    text: `${latest?.drmSystem ?? ''}${count}`,
+    color: '#666666',
+    title: `Okova: ${keys.length} key IDs observed; no content keys${details}`,
+  };
+};

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -4,7 +4,10 @@ import { PlayReadyDeviceCredentials } from '../../../lib/playready/device-creden
 import { fromBase64, fromBuffer } from '../../../lib';
 import { asJson } from './utils';
 
+export type BadgeDrmSystem = 'W' | 'P' | 'C';
+
 export type KeyInfo = {
+  drmSystem?: BadgeDrmSystem;
   id: string;
   value: string;
   url: string;

--- a/test/extension-badge.test.ts
+++ b/test/extension-badge.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest';
+import { getBadgeAppearance, getBadgeDrmSystem, getBadgeKey } from '../src/extension/utils/badge';
+import type { KeyInfo } from '../src/extension/utils/storage';
+
+const key: KeyInfo = {
+  drmSystem: 'W',
+  id: '00112233445566778899aabbccddeeff',
+  value: 'ffeeddccbbaa99887766554433221100',
+  url: 'https://example.com/video',
+  pssh: '',
+  createdAt: 1,
+};
+
+test('distinguishes observed IDs, saved keys, fresh keys and failures', () => {
+  expect(getBadgeAppearance([{ ...key, value: 'usable' }], null)).toMatchObject({
+    text: 'W1',
+    color: '#666666',
+    title: expect.stringContaining('1 key IDs observed'),
+  });
+  expect(getBadgeAppearance([key, { ...key, id: 'other', value: 'usable' }], null)).toMatchObject({
+    text: 'W1',
+    color: '#2169EB',
+    title: expect.stringContaining('1 content keys available from history'),
+  });
+  expect(
+    getBadgeAppearance([key], [{ kind: 'success', system: 'W', keys: [getBadgeKey(key)] }]),
+  ).toMatchObject({
+    text: 'W1',
+    color: '#16803C',
+  });
+  expect(
+    getBadgeAppearance([key], [{ kind: 'failure', system: 'P', error: 'No client' }]),
+  ).toMatchObject({
+    text: 'P!',
+    color: '#C75300',
+    title: expect.stringContaining('No client'),
+  });
+});
+
+test('handles empty and legacy history without guessing the DRM system, and caps counts', () => {
+  expect(getBadgeAppearance([], null)).toMatchObject({ text: '', title: 'Okova' });
+  expect(getBadgeAppearance([{ ...key, drmSystem: undefined }], null).text).toBe('1');
+  expect(
+    getBadgeAppearance(
+      Array.from({ length: 100 }, (_, id) => ({ ...key, id: String(id) })),
+      null,
+    ).text,
+  ).toBe('W99+');
+});
+
+test('shows the latest DRM result and retains the other systems in the tooltip', () => {
+  const clearKey: KeyInfo = { ...key, drmSystem: 'C' };
+  const badge = getBadgeAppearance(
+    [clearKey],
+    [
+      { kind: 'success', system: 'W', keys: [getBadgeKey(key)] },
+      { kind: 'success', system: 'C', keys: [getBadgeKey(clearKey)] },
+    ],
+  );
+  expect(badge.text).toBe('C1');
+  expect(badge.title).toContain('Widevine: 1 content keys retrieved this visit');
+  expect(badge.title).toContain('ClearKey: 1 content keys retrieved this visit');
+});
+
+test.each([
+  ['com.widevine.alpha', 'W'],
+  ['com.microsoft.playready.recommendation.3000', 'P'],
+  ['com.microsoft.playready.hardware', 'P'],
+  ['org.w3.clearkey', 'C'],
+  ['unsupported', undefined],
+])('maps %s to %s', (system, expected) => {
+  expect(getBadgeDrmSystem(system)).toBe(expected);
+});

--- a/test/extension-badge.test.ts
+++ b/test/extension-badge.test.ts
@@ -13,19 +13,19 @@ const key: KeyInfo = {
 
 test('distinguishes observed IDs, saved keys, fresh keys and failures', () => {
   expect(getBadgeAppearance([{ ...key, value: 'usable' }], null)).toMatchObject({
-    text: 'W1',
+    text: '1W',
     color: '#666666',
     title: expect.stringContaining('1 key IDs observed'),
   });
   expect(getBadgeAppearance([key, { ...key, id: 'other', value: 'usable' }], null)).toMatchObject({
-    text: 'W1',
+    text: '1W',
     color: '#2169EB',
     title: expect.stringContaining('1 content keys available from history'),
   });
   expect(
     getBadgeAppearance([key], [{ kind: 'success', system: 'W', keys: [getBadgeKey(key)] }]),
   ).toMatchObject({
-    text: 'W1',
+    text: '1W',
     color: '#16803C',
   });
   expect(
@@ -45,7 +45,7 @@ test('handles empty and legacy history without guessing the DRM system, and caps
       Array.from({ length: 100 }, (_, id) => ({ ...key, id: String(id) })),
       null,
     ).text,
-  ).toBe('W99+');
+  ).toBe('99+W');
 });
 
 test('shows the latest DRM result and retains the other systems in the tooltip', () => {
@@ -57,7 +57,7 @@ test('shows the latest DRM result and retains the other systems in the tooltip',
       { kind: 'success', system: 'C', keys: [getBadgeKey(clearKey)] },
     ],
   );
-  expect(badge.text).toBe('C1');
+  expect(badge.text).toBe('1C');
   expect(badge.title).toContain('Widevine: 1 content keys retrieved this visit');
   expect(badge.title).toContain('ClearKey: 1 content keys retrieved this visit');
 });

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -93,87 +93,99 @@ test.each(
   },
 );
 
-test('uses distinct tokens despite empty native IDs and waits for background creation', async () => {
-  class NativeSession extends EventTarget {
-    sessionId = '';
-    closedResult = Promise.withResolvers<MediaKeySessionClosedReason>();
-    closed = this.closedResult.promise;
-    keyStatuses = new Map();
-    async generateRequest(type: string, data: BufferSource) {
-      expect(type).toBe('cenc');
-      expect(data).toBeInstanceOf(Uint8Array);
+test.each(['com.widevine.alpha', 'com.microsoft.playready.recommendation'])(
+  'preserves %s in license requests, uses distinct tokens and waits for background creation',
+  async (keySystem) => {
+    class NativeSession extends EventTarget {
+      sessionId = '';
+      closedResult = Promise.withResolvers<MediaKeySessionClosedReason>();
+      closed = this.closedResult.promise;
+      keyStatuses = new Map();
+      async generateRequest(type: string, data: BufferSource) {
+        expect(type).toBe('cenc');
+        expect(data).toBeInstanceOf(Uint8Array);
+      }
+      async update(response: BufferSource) {
+        expect(response).toBeInstanceOf(Uint8Array);
+      }
     }
-    async update(response: BufferSource) {
-      expect(response).toBeInstanceOf(Uint8Array);
+    class NativeKeys {
+      createSession() {
+        return new NativeSession();
+      }
+      async setServerCertificate() {
+        return true;
+      }
     }
-  }
-  class NativeKeys {
-    createSession() {
-      return new NativeSession();
+    class NativeAccess {
+      keySystem = keySystem;
+      async createMediaKeys() {
+        return new NativeKeys();
+      }
     }
-    async setServerCertificate() {
-      return true;
-    }
-  }
-  vi.stubGlobal('MediaKeySession', NativeSession);
-  vi.stubGlobal('MediaKeys', NativeKeys);
-  vi.stubGlobal('window', { MPD_LIST: new Map() });
-  const creations = [Promise.withResolvers<unknown>(), Promise.withResolvers<unknown>()];
-  let creationIndex = 0;
-  vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
-    if (message.action === 'generateRequest') return creations[creationIndex++]!.promise;
-    if (message.action === 'license-request') return btoa('challenge');
-    if (message.action === 'update') return { keys: [] };
-  });
-  eme.main();
+    vi.stubGlobal('MediaKeySystemAccess', NativeAccess);
+    vi.stubGlobal('MediaKeySession', NativeSession);
+    vi.stubGlobal('MediaKeys', NativeKeys);
+    vi.stubGlobal('window', { MPD_LIST: new Map() });
+    const creations = [Promise.withResolvers<unknown>(), Promise.withResolvers<unknown>()];
+    let creationIndex = 0;
+    vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
+      if (message.action === 'generateRequest') return creations[creationIndex++]!.promise;
+      if (message.action === 'license-request') return btoa('challenge');
+      if (message.action === 'update') return { keys: [] };
+    });
+    eme.main();
 
-  const first = new NativeSession();
-  const second = new NativeSession();
-  const initData = new TextEncoder().encode('same pssh');
-  const generating = [
-    first.generateRequest('cenc', initData),
-    second.generateRequest('cenc', initData),
-  ];
-  await Promise.resolve();
-  const tokens = vi.mocked(sendDrmMessage).mock.calls.map(([message]) => message.sessionToken);
-  expect(tokens).toHaveLength(2);
-  expect(tokens[0]).toEqual(expect.any(String));
-  expect(tokens[1]).not.toBe(tokens[0]);
+    const keys = await new NativeAccess().createMediaKeys();
+    const first = keys.createSession();
+    const second = keys.createSession();
+    const initData = new TextEncoder().encode('same pssh');
+    const generating = [
+      first.generateRequest('cenc', initData),
+      second.generateRequest('cenc', initData),
+    ];
+    await Promise.resolve();
+    const tokens = vi.mocked(sendDrmMessage).mock.calls.map(([message]) => message.sessionToken);
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).toEqual(expect.any(String));
+    expect(tokens[1]).not.toBe(tokens[0]);
 
-  const handled = Promise.withResolvers<void>();
-  first.addEventListener('message', () => handled.resolve());
-  first.dispatchEvent(
-    new MediaKeyMessageEvent('message', {
-      messageType: 'license-request',
-      message: initData.buffer,
-    }),
-  );
-  await Promise.resolve();
-  expect(sendDrmMessage).toHaveBeenCalledTimes(2);
-  creations[1]!.resolve(undefined);
-  await generating[1];
-  expect(sendDrmMessage).toHaveBeenCalledTimes(2);
-  creations[0]!.resolve(undefined);
-  await Promise.all([generating[0], handled.promise]);
-  expect(sendDrmMessage).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      action: 'license-request',
-      sessionToken: tokens[0],
-    }),
-  );
+    const handled = Promise.withResolvers<void>();
+    first.addEventListener('message', () => handled.resolve());
+    first.dispatchEvent(
+      new MediaKeyMessageEvent('message', {
+        messageType: 'license-request',
+        message: initData.buffer,
+      }),
+    );
+    await Promise.resolve();
+    expect(sendDrmMessage).toHaveBeenCalledTimes(2);
+    creations[1]!.resolve(undefined);
+    await generating[1];
+    expect(sendDrmMessage).toHaveBeenCalledTimes(2);
+    creations[0]!.resolve(undefined);
+    await Promise.all([generating[0], handled.promise]);
+    expect(sendDrmMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'license-request',
+        keySystem,
+        sessionToken: tokens[0],
+      }),
+    );
 
-  await second.update(initData);
-  expect(sendDrmMessage).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      action: 'update',
-      sessionToken: tokens[1],
-    }),
-  );
-  first.closedResult.resolve('closed-by-application');
-  await first.closed;
-  await Promise.resolve();
-  expect(sendDrmMessage).toHaveBeenLastCalledWith({ action: 'close', sessionToken: tokens[0] });
-});
+    await second.update(initData);
+    expect(sendDrmMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'update',
+        sessionToken: tokens[1],
+      }),
+    );
+    first.closedResult.resolve('closed-by-application');
+    await first.closed;
+    await Promise.resolve();
+    expect(sendDrmMessage).toHaveBeenLastCalledWith({ action: 'close', sessionToken: tokens[0] });
+  },
+);
 
 test('associates accepted certificate views with MediaKeys and preserves certificate requests', async () => {
   const nativeSetCertificate = vi

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -17,6 +17,7 @@ vi.mock('../src/lib/widevine/device-credentials', () => ({
 }));
 
 const key: KeyInfo = {
+  drmSystem: 'W',
   id: '00112233445566778899aabbccddeeff',
   value: 'ffeeddccbbaa99887766554433221100',
   url: 'https://example.com/video',

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -855,7 +855,7 @@ test('badge changes from observed to fresh, saved on navigation, and failed unti
     theme: 'auto',
   });
   await send('keystatuseschange', 'observed', sender, { keyStatuses: { AAECAw: 'usable' } });
-  await expectBadge('W1', '#666666');
+  await expectBadge('1W', '#666666');
 
   const context = {
     keySystem: 'org.w3.clearkey',
@@ -866,18 +866,18 @@ test('badge changes from observed to fresh, saved on navigation, and failed unti
     ),
   };
   await send('update', 'clear', sender, context);
-  await expectBadge('C1', '#16803C');
+  await expectBadge('1C', '#16803C');
   updated.mock.calls[0]![0](1, { status: 'loading' }, sender.tab);
-  await expectBadge('C1', '#2169EB');
+  await expectBadge('1C', '#2169EB');
   expect(await getBadgeStorage(1).getValue()).toBeNull();
   await send('update', 'clear', sender, context);
-  await expectBadge('C1', '#16803C');
+  await expectBadge('1C', '#16803C');
   updated.mock.calls[0]![0](
     1,
     { url: 'https://example.com/next' },
     { ...sender.tab, url: 'https://example.com/next' },
   );
-  await expectBadge('C1', '#2169EB');
+  await expectBadge('1C', '#2169EB');
 
   await appStorage.settings.setValue({
     spoofing: true,
@@ -891,11 +891,58 @@ test('badge changes from observed to fresh, saved on navigation, and failed unti
   await send('keystatuseschange', 'observed', sender, { keyStatuses: { AAECAw: 'usable' } });
   await expectBadge('W!', '#C75300');
   await send('update', 'clear', sender, context);
-  await expectBadge('C1', '#16803C');
+  await expectBadge('1C', '#16803C');
   updated.mock.calls[0]![0](
     1,
     { status: 'loading' },
     { ...sender.tab, url: 'https://unrelated.example' },
   );
   await expectBadge('', '#666666');
+});
+
+test.each(['success', 'failure'])(
+  'URL-only navigation invalidates an in-flight license %s',
+  async (outcome) => {
+    const updated = vi.spyOn(browser.tabs.onUpdated, 'addListener');
+    const send = startBackground();
+    const sender = { tab: { ...tab(1), url: 'https://example.com/video' } };
+    await send('generateRequest', 'old-page', sender);
+    const started = Promise.withResolvers<void>();
+    const completed = Promise.withResolvers<void>();
+    vi.mocked(Session.prototype.update).mockImplementationOnce(async function (this: Session) {
+      started.resolve();
+      await completed.promise;
+      this.keys.set('00112233445566778899aabbccddeeff', 'ffeeddccbbaa99887766554433221100');
+    });
+    const updating = send('update', 'old-page', sender);
+    await started.promise;
+    const nextTab = { ...sender.tab, url: 'https://example.com/next' };
+    updated.mock.calls[0]![0](1, { url: nextTab.url }, nextTab);
+    if (outcome === 'success') completed.resolve();
+    else completed.reject(new Error('Old page license failed'));
+    await updating;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await getBadgeStorage(1).getValue()).toBeNull();
+    expect(await getDrmFailureStorage(1).getValue()).toBeNull();
+    expect(browser.action.setBadgeText).toHaveBeenLastCalledWith({ tabId: 1, text: '' });
+    expect(browser.action.setTitle).toHaveBeenLastCalledWith({ tabId: 1, title: 'Okova' });
+  },
+);
+
+test('sets the badge text and tooltip when text-color control is unavailable', async () => {
+  const descriptor = Object.getOwnPropertyDescriptor(browser.action, 'setBadgeTextColor');
+  if (!descriptor) throw new Error('Missing fake-browser text-color method');
+  Reflect.deleteProperty(browser.action, 'setBadgeTextColor');
+  try {
+    const send = startBackground();
+    vi.mocked(appStorage.clients.active.getValue).mockResolvedValue(null);
+    await send('generateRequest', 'missing-client', { tab: tab(1) });
+    expect(browser.action.setBadgeText).toHaveBeenLastCalledWith({ tabId: 1, text: 'W!' });
+    expect(browser.action.setTitle).toHaveBeenLastCalledWith({
+      tabId: 1,
+      title: expect.stringContaining('Widevine retrieval failed'),
+    });
+  } finally {
+    Object.defineProperty(browser.action, 'setBadgeTextColor', descriptor);
+  }
 });

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { browser, type Browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing';
 import background from '../src/extension/entrypoints/background';
+import { getBadgeStorage } from '../src/extension/utils/badge';
 import { appStorage, getDrmFailureStorage } from '../src/extension/utils/storage';
 import * as certificateUtils from '../src/lib/widevine/certificate';
 import { fromBase64, fromBuffer } from '../src/lib/utils';
@@ -55,6 +56,9 @@ beforeEach(async () => {
   );
   vi.spyOn(browser.tabs, 'query').mockImplementation(async () => []);
   vi.spyOn(browser.action, 'setBadgeText').mockResolvedValue();
+  vi.spyOn(browser.action, 'setBadgeBackgroundColor').mockResolvedValue();
+  vi.spyOn(browser.action, 'setBadgeTextColor').mockResolvedValue();
+  vi.spyOn(browser.action, 'setTitle').mockResolvedValue();
   sessions.length = 0;
   vi.spyOn(Session.prototype, 'generateRequest').mockImplementation(async function (this: Session) {
     sessions.push(this);
@@ -428,6 +432,8 @@ test.each(['deadline', 'removal', 'navigation', 'close'])(
         error: 'DRM request timed out after 25000ms',
       });
       await getDrmFailureStorage(1).removeValue();
+      expect(await getBadgeStorage(1).getValue()).toMatchObject([{ kind: 'failure', system: 'W' }]);
+      await getBadgeStorage(1).removeValue();
     }
     if (action === 'close') expect(await getDrmFailureStorage(1).getValue()).toBeNull();
     expect(await browser.storage.session.get(null)).toEqual({});
@@ -717,6 +723,7 @@ test.each(['https://example.com/video', 'https://other.example/video'])(
     );
     expect(readHistory).not.toHaveBeenCalled();
     const captured = {
+      drmSystem: 'W',
       ...oldKey,
       value: 'ffeeddccbbaa99887766554433221100',
       url,
@@ -830,4 +837,65 @@ test('a queued request responds by its own deadline while earlier cleanup is sti
   expect(Session.prototype.generateRequest).toHaveBeenCalledOnce();
   expect(Session.prototype.close).toHaveBeenCalledOnce();
   expect(vi.getTimerCount()).toBe(0);
+});
+
+test('badge changes from observed to fresh, saved on navigation, and failed until retrieval succeeds', async () => {
+  const updated = vi.spyOn(browser.tabs.onUpdated, 'addListener');
+  const sender = { tab: { ...tab(1), url: 'https://example.com/video' } };
+  const send = startBackground();
+  const expectBadge = async (text: string, color: string) => {
+    await vi.advanceTimersByTimeAsync(0);
+    expect(browser.action.setBadgeText).toHaveBeenLastCalledWith({ tabId: 1, text });
+    expect(browser.action.setBadgeBackgroundColor).toHaveBeenLastCalledWith({ tabId: 1, color });
+  };
+  await appStorage.settings.setValue({
+    spoofing: false,
+    emeInterception: true,
+    requestInterception: false,
+    theme: 'auto',
+  });
+  await send('keystatuseschange', 'observed', sender, { keyStatuses: { AAECAw: 'usable' } });
+  await expectBadge('W1', '#666666');
+
+  const context = {
+    keySystem: 'org.w3.clearkey',
+    message: new TextEncoder().encode(
+      JSON.stringify({
+        keys: [{ kty: 'oct', kid: 'AAECAwQFBgcICQoLDA0ODw', k: 'tQ0bJVWb6b0KPL6KtZIy_A' }],
+      }),
+    ),
+  };
+  await send('update', 'clear', sender, context);
+  await expectBadge('C1', '#16803C');
+  updated.mock.calls[0]![0](1, { status: 'loading' }, sender.tab);
+  await expectBadge('C1', '#2169EB');
+  expect(await getBadgeStorage(1).getValue()).toBeNull();
+  await send('update', 'clear', sender, context);
+  await expectBadge('C1', '#16803C');
+  updated.mock.calls[0]![0](
+    1,
+    { url: 'https://example.com/next' },
+    { ...sender.tab, url: 'https://example.com/next' },
+  );
+  await expectBadge('C1', '#2169EB');
+
+  await appStorage.settings.setValue({
+    spoofing: true,
+    emeInterception: true,
+    requestInterception: false,
+    theme: 'auto',
+  });
+  vi.mocked(appStorage.clients.active.getValue).mockResolvedValue(null);
+  await send('generateRequest', 'failure', sender);
+  await expectBadge('W!', '#C75300');
+  await send('keystatuseschange', 'observed', sender, { keyStatuses: { AAECAw: 'usable' } });
+  await expectBadge('W!', '#C75300');
+  await send('update', 'clear', sender, context);
+  await expectBadge('C1', '#16803C');
+  updated.mock.calls[0]![0](
+    1,
+    { status: 'loading' },
+    { ...sender.tab, url: 'https://unrelated.example' },
+  );
+  await expectBadge('', '#666666');
 });


### PR DESCRIPTION
## Summary

- Add Widevine, PlayReady, and ClearKey status badges with key counts and retrieval state.
- Track observed IDs, saved content keys, fresh retrievals, and failures per tab.
- Reset badge state on navigation and document badge behavior in the README.

## Testing

- Added badge appearance and DRM-system mapping tests.
- Extended background session tests for badge updates, navigation resets, and retrieval failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791229816&installation_model_id=424872&pr_number=64&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F64&signature=1d438d1775ba6418f324d0a7b8305406af3d9479c2866e87ff8cb8191abc68a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->