### PR TITLE
test(extension): add Bitmovin DRM E2E coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 VITEST_WVD_PATH=./clients/samsung_sm-a025g_16.0.0_1baa3b6e_22589_l3.wvd
+VITEST_WIDEVINE_CLIENT_PATH=./clients/device.wvd
 VITEST_WIDEVINE_CLIENT_ID_PATH=./clients/device_client_id_blob
 VITEST_WIDEVINE_PRIVATE_KEY_PATH=./clients/device_private_key
 VITEST_PRD_PATH=./clients/hisense_smarttv_he55a7000euwts_sl2000.prd

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ![GitHub Downloads (all assets, latest release)](https://img.shields.io/github/downloads/azot-labs/okova/latest/total?style=flat&color=black)
 [![npm downloads](https://img.shields.io/npm/dt/okova?style=flat&color=black)](https://www.npmjs.com/package/okova)
 
-Okova is a set of tools (JavaScript library, command-line utility and browser extension) for diagnosing, researching, and pentesting [DRM](https://www.urbandictionary.com/define.php?term=DRM) systems used in playable media content.
+Okova is a toolkit (browser extension, command-line tool, and JavaScript library) for inspecting DRM-protected media and working with Widevine, PlayReady, and ClearKey.
 
-> Okova is still in the early stages of development, so until version 1.0 is released, performance may be unstable and major changes may be made
+> Okova is under active development. APIs and behavior may change before version 1.0.
 
 ## Features
 
@@ -30,11 +30,9 @@ The toolbar badge shows a count capped at `99+`, followed by `W`, `P`, or `C` fo
 - Green: content keys retrieved during this page visit, including keys retrieved again.
 - Orange with `!`: retrieval failed. Hover over the icon for the error.
 
-Navigation or reload clears the current result; saved content keys then appear blue. The tooltip explains the count and lists DRM results from this visit. Older history without DRM metadata shows only the number. Green indicates key retrieval, not verified playback.
+Reloading or navigating clears the current result; saved keys then appear blue. Hover over the badge for details. Green indicates key retrieval, not verified playback.
 
 ### Installing Chrome extension
-
-**Developer Mode** needs to be enabled in `chrome://extensions/` page
 
 1. Download archive from [latest release](https://github.com/azot-labs/okova/releases/latest)
 2. Go to `chrome://extensions/` page
@@ -51,33 +49,6 @@ Navigation or reload clears the current result; saved content keys then appear b
 > Temporary add-on is not persistent and will be removed after browser restart
 
 [Read Mozilla's guide](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing)
-
-### End-to-end test
-
-The headless E2E test uses Vitest with Playwright to load the built Chrome extension, enable
-Spoofing, import a Widevine client, and retrieve keys from the live
-[Bitmovin DRM demo](https://bitmovin.com/demos/drm). It checks that fresh Widevine content keys
-are saved for Bitmovin and displayed in the popup. Successful video playback is not required.
-
-Install the browser once:
-
-```bash
-pnpm exec playwright install chromium
-```
-
-Set `VITEST_WIDEVINE_CLIENT_PATH` in `.env` to an absolute path to your `.wvd` file, or a path
-relative to the repository root. Then run:
-
-```bash
-pnpm test:e2e
-```
-
-The command builds the extension before testing. Each run uses a temporary browser profile,
-which is deleted afterward. The test skips when the client path is unset or the file is
-missing. It runs separately from `pnpm test` because it depends on the live demo and license
-server. Network failures, Cloudflare verification, unsupported native Widevine, and rejected
-credentials fail the test rather than skipping it. The browser must support native Widevine
-as well as extension loading; importing a `.wvd` alone does not provide browser EME support.
 
 ## Command-line tool
 
@@ -99,6 +70,8 @@ Convert DRM client files `./drm-files/device_client_id_blob` and `./drm-files/de
 okova client pack ./drm-files ./unknown_android-sdk-built-for-x86.wvd
 ```
 
+Output example:
+
 ```text
 Client packed: /Users/.../unknown_android-sdk-built-for-x86.wvd
 ```
@@ -108,6 +81,8 @@ Show DRM client info:
 ```bash
 okova client info ./unknown_android-sdk-built-for-x86.wvd
 ```
+
+Output example:
 
 ```text
 application_name: org.chromium.webview_shell
@@ -182,22 +157,10 @@ async function main() {
 }
 ```
 
-`fetchDecryptionKeys` rejects unsuccessful HTTP responses with `LicenseHttpError`,
-which exposes `status` and `endpoint`. The endpoint excludes URL credentials, query
-parameters, and fragments; the error does not include the response body. Status is
-checked after any `transformResponse` callback. PlayReady requests default to
-`Content-Type: text/xml; charset=utf-8` unless you provide that header.
-
-Acquisition has a 30-second overall deadline. Pass `timeoutMs` to change it and
-`signal` to cancel, including pending license HTTP requests. Request transforms
-retain the acquisition signal even when they return a new `Request`. Custom
-fetch implementations and transforms should honor that signal; cancellation stops
-waiting for them and prevents further exchanges when they eventually finish.
-Cleanup has a separate one-second grace period and does not replace the original
-result or error. License POSTs are never automatically retried.
-
-A completed update must provide content keys or emit a message for another
-exchange. Otherwise, the helper rejects with `NoContentKeysError`.
+`fetchDecryptionKeys` handles license exchanges with a 30-second default timeout.
+Use `timeoutMs` to change the deadline and `signal` to cancel. It throws
+`LicenseHttpError` for unsuccessful HTTP responses and `NoContentKeysError` when
+an exchange finishes without content keys. License requests are not automatically retried.
 
 ### Saving and resuming native sessions
 
@@ -211,11 +174,8 @@ await session.close();
 const resumed = engine.resumeSession(state);
 ```
 
-Snapshots are versioned and validated when resumed. Existing unversioned
-snapshots remain readable. Resume with the same device credentials. Native
-Widevine `load()` returns `false`; it does not implement persistent-license
-storage. The EME wrapper's `keyStatuses` is read-only and matches KIDs by their
-bytes. Repeated `close()` calls are safe.
+Resume with the same device credentials. Native Widevine sessions do not support
+persistent-license storage through `load()`.
 
 ### PlayReady custom challenge data
 
@@ -226,36 +186,17 @@ const engine = new PlayReady({ deviceCredentials, customData: applicationData })
 const keys = await fetchDecryptionKeys({ cdm: engine, pssh, server: licenseUrl });
 ```
 
-The engine includes it as XML-escaped text in the signed `<CustomData>` element
-for new and resumed sessions. Omitting `customData` omits the element; an empty
-string produces an empty element. Pass the original text, without XML escaping.
-Direct calls can override it with
-`session.getLicenseChallenge(wrmHeader, revocationListsXml, customData)`.
+Pass the original text without XML escaping. Remote clients accept the same
+`customData` option; REST clients include it in the `POST /sessions` body.
 
-Remote integrations accept the same `customData` constructor option on `Remote`.
-REST clients supply the optional string in the `POST /sessions` JSON body; it
-applies to PlayReady challenges generated by that session.
+### Remote sessions
 
-`POST /sessions` accepts `keySystem` and selects the first authorized device for
-that system when `client` is omitted. An explicit client must match the requested
-system. Omitting both fields preserves the first configured device as the default.
-The response includes `id`, the resolved `client` path, and the canonical
-`keySystem`. `sessionType` accepts only `temporary` or `persistent-license`; this
-validation does not add persistent storage support.
+`POST /sessions` accepts `keySystem` and an optional `client`. Without a client,
+the server selects the first authorized device for that DRM system. An explicit
+client must match the requested system.
 
-Supported DRM names are `com.widevine.alpha`, `com.microsoft.playready`,
-`com.microsoft.playready.recommendation`,
-`com.microsoft.playready.recommendation.3000`, and
-`com.microsoft.playready.hardware`. PlayReady aliases resolve to
-`com.microsoft.playready.recommendation`; they do not imply hardware CDM support.
-The extension checks these names against the selected device and reports a
-mismatch in the popup. Its DRM operations time out after 25 seconds and cancel on
-tab navigation, tab removal, or an explicit session close.
-
-Remote sessions accept one mutation at a time. Overlapping challenge generation,
-certificate changes, updates, close, or delete requests return HTTP 409. Wait for
-the active request to finish before retrying. Requests for different sessions
-can run concurrently; key retrieval remains available during mutations.
+Wait for each session mutation to finish before starting another; overlapping
+requests return HTTP 409. Requests for different sessions can run concurrently.
 
 The server limits sessions and concurrent requests across all users and devices.
 In `okova.config.json`, optional `sessionLimits` fields override these defaults:
@@ -271,16 +212,9 @@ In `okova.config.json`, optional `sessionLimits` fields override these defaults:
 }
 ```
 
-Limits must be positive integers. Excess session opens or concurrent requests
-return HTTP 503; clients can retry after existing work finishes or sessions close.
-Session capacity includes opens still loading a device. Each request for an
-existing session refreshes its idle timer. Idle expiry closes the native session,
-clears its keys, and releases waiting requests. Keep sessions active while using
-them and create a new one after expiry. Server shutdown also closes sessions.
-
-`GET /sessions/:id/keys` returns HTTP 504 if no key-status event arrives before
-`keyWaitTimeoutMs`. Disconnecting cancels that request's wait without closing the
-session. Each session keeps its own certificates and custom PlayReady data.
+Limits must be positive integers. Exceeding session or request limits returns
+HTTP 503. Idle sessions expire and must be recreated. Waiting for keys beyond
+`keyWaitTimeoutMs` returns HTTP 504.
 
 ### Inspect, edit, and convert PSSH boxes
 
@@ -306,43 +240,17 @@ console.log(box.systemId, box.version, getPsshKeyIds(box));
 const restored = convertPsshBox(box, 'widevine');
 ```
 
-`parsePsshBoxes` accepts bytes or base64 containing one or more full PSSH boxes. It
-rejects malformed boxes, raw DRM headers, and other MP4 box types. The returned
-`ParsedPsshBox` exposes `systemId`, `version`, `flags`, `keyIds`, and raw payload
-`data`. Unknown system IDs and opaque payloads can be parsed and serialized.
-`serializePsshBox` returns full box bytes; `psshBoxToBase64` returns base64. Both
-write a normal 32-bit size field, including for inputs parsed with extended sizes.
+`parsePsshBoxes` accepts bytes or base64 containing full PSSH boxes.
+`serializePsshBox` returns bytes; `psshBoxToBase64` returns base64.
+IDs accept 16-byte arrays, UUID strings, or 32 hex digits.
 
-Widevine and PlayReady challenge generation use the same bounded box parser,
-including extended-size and size-to-end boxes. A box sequence must contain the
-requested DRM system; malformed boxes are rejected instead of treated as raw
-payloads. Widevine still accepts non-box opaque initialization data for vendor
-compatibility. PlayReady also accepts raw UTF-16LE WRMHEADER XML, complete PROs,
-and standalone type-1 records. PRO and record lengths must match their contents;
-headers support Unicode and an optional UTF-16LE BOM.
+Use `getPsshKeyIds` to inspect KIDs and `setPsshKeyIds` to replace Widevine KIDs.
+PlayReady KID replacement is not supported. Editing and conversion return new
+boxes without changing their inputs.
 
-`fromHex` rejects odd-length input and non-hexadecimal characters. Empty input
-converts to an empty buffer or string. WVD export rejects private-key and client-ID
-fields larger than 65,535 bytes before writing the file.
-
-IDs accept 16-byte arrays, UUID strings, or 32 hex digits. Inspection returns
-lowercase hex in UUID byte order, accounting for PlayReady's GUID byte order.
-`getPsshKeyIds` prefers nonempty version 1 box KIDs, then reads Widevine protobuf
-or PlayReady Object headers, versions 4.0 through 4.3. `createPsshBox` wraps raw
-payload bytes or base64; its `keyIds` option is only available with `version: 1`
-and sets box KIDs. Use `setPsshKeyIds` to populate or replace Widevine payload KIDs.
-It also updates version 1 box KIDs and preserves other protobuf fields. Editing
-and conversion return new boxes without changing their inputs. PlayReady KID
-replacement is not supported.
-
-Conversion carries KIDs, box version, flags, and `cenc`/`cbcs` encryption signaling.
-Widevine data without an explicit scheme defaults to AES-CTR. Unsupported or mixed
-PlayReady algorithms are rejected. Conversion discards other source metadata,
-including license URLs, provider data, custom attributes, and checksums. Supply
-`laUrl` when converting to PlayReady if needed. Generated PlayReady 4.3 headers
-omit checksums because computing them requires content keys. Converted headers
-may not meet a particular license server's requirements. See Microsoft's
-[PlayReady header specification](https://learn.microsoft.com/en-us/playready/specifications/playready-header-specification).
+Conversion preserves KIDs and encryption signaling but discards other metadata,
+including license URLs and checksums. Supply `laUrl` when converting to PlayReady
+if needed. Converted headers may not meet every license server's requirements.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ Navigation or reload clears the current result; saved content keys then appear b
 
 [Read Mozilla's guide](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing)
 
+### End-to-end test
+
+The headless E2E test uses Vitest with Playwright to load the built Chrome extension, enable
+Spoofing, import a Widevine client, and retrieve keys from the live
+[Bitmovin DRM demo](https://bitmovin.com/demos/drm). It checks that fresh Widevine content keys
+are saved for Bitmovin and displayed in the popup. Successful video playback is not required.
+
+Install the browser once:
+
+```bash
+pnpm exec playwright install chromium
+```
+
+Set `VITEST_WIDEVINE_CLIENT_PATH` in `.env` to an absolute path to your `.wvd` file, or a path
+relative to the repository root. Then run:
+
+```bash
+pnpm test:e2e
+```
+
+The command builds the extension before testing. Each run uses a temporary browser profile,
+which is deleted afterward. The test skips when the client path is unset or the file is
+missing. It runs separately from `pnpm test` because it depends on the live demo and license
+server. Network failures, Cloudflare verification, unsupported native Widevine, and rejected
+credentials fail the test rather than skipping it. The browser must support native Widevine
+as well as extension loading; importing a `.wvd` alone does not provide browser EME support.
+
 ## Command-line tool
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "postinstall": "node scripts/postinstall.js",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "pnpm run build:chrome && vitest run --config vitest.e2e.config.ts"
   },
   "repository": {
     "type": "git",
@@ -102,6 +103,7 @@
     "clsx": "^2.1.1",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.66.0",
+    "playwright": "^1.63.0",
     "postcss": "^8.5.15",
     "solid-icons": "^1.2.0",
     "solid-js": "^1.9.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       oxlint:
         specifier: ^1.66.0
         version: 1.66.0
+      playwright:
+        specifier: ^1.63.0
+        version: 1.63.0
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -2213,6 +2216,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4550,6 +4563,12 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.63.0: {}
+
+  playwright@1.63.0:
+    dependencies:
+      playwright-core: 1.63.0
 
   postcss@8.5.15:
     dependencies:

--- a/test/e2e/bitmovin.test.ts
+++ b/test/e2e/bitmovin.test.ts
@@ -56,6 +56,16 @@ test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabl
       await popup.getByRole('link', { name: 'Clients', exact: true }).click();
       await popup.getByLabel('Import client').setInputFiles(resolve(clientPath));
       await expect.poll(() => popup.getByText(/^Widevine L\d$/).count()).toBe(1);
+      // The UI updates before the imported client has finished writing to storage.
+      await expect
+        .poll(() =>
+          worker.evaluate(async () => {
+            const raw: unknown = (await chrome.storage.local.get('clients')).clients;
+            const clients: unknown = typeof raw === 'string' ? JSON.parse(raw) : raw;
+            return Array.isArray(clients) && clients.length === 1;
+          }),
+        )
+        .toBe(true);
       // Returning to the dashboard persists the sole imported client as active.
       await popup.goto(popupUrl);
       await expect.poll(() => popup.getByText('Active', { exact: true }).count()).toBe(1);

--- a/test/e2e/bitmovin.test.ts
+++ b/test/e2e/bitmovin.test.ts
@@ -1,0 +1,138 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import { chromium } from 'playwright';
+import { expect, test } from 'vitest';
+import { z } from 'zod';
+
+declare const chrome: typeof import('wxt/browser').browser;
+
+const storedKeys = z.array(
+  z.object({
+    id: z.string(),
+    value: z.string(),
+    url: z.string(),
+    drmSystem: z.string().optional(),
+    createdAt: z.number(),
+  }),
+);
+
+test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabled', async ({
+  skip,
+}) => {
+  const clientPath = process.env.VITEST_WIDEVINE_CLIENT_PATH;
+  if (!clientPath || !existsSync(resolve(clientPath))) {
+    skip('VITEST_WIDEVINE_CLIENT_PATH is unset or the .wvd file does not exist');
+    return;
+  }
+
+  const extensionPath = resolve('.output/chrome-mv3');
+  const profilePath = await mkdtemp(join(tmpdir(), 'okova-e2e-'));
+  try {
+    const context = await chromium.launchPersistentContext(profilePath, {
+      channel: 'chromium',
+      headless: true,
+      // Disabling component updates also prevents native Widevine from registering.
+      ignoreDefaultArgs: ['--disable-component-update'],
+      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
+    });
+    try {
+      context.setDefaultTimeout(20_000);
+      const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      const popupUrl = `chrome-extension://${new URL(worker.url()).hostname}/popup.html`;
+      const popup = await context.newPage();
+      await popup.goto(popupUrl);
+      await popup.getByRole('link', { name: 'Settings', exact: true }).click();
+      const spoofingRow = popup.locator('label').filter({ hasText: 'Spoofing' });
+      const spoofing = spoofingRow.getByRole('checkbox');
+      await spoofingRow.locator('label').click();
+      await expect.poll(() => spoofing.isChecked()).toBe(true);
+      await popup.goto(popupUrl);
+      await popup.getByRole('link', { name: 'Settings', exact: true }).click();
+      await expect.poll(() => spoofing.isChecked()).toBe(true);
+
+      await popup.goto(popupUrl);
+      await popup.getByRole('link', { name: 'Clients', exact: true }).click();
+      await popup.getByLabel('Import client').setInputFiles(resolve(clientPath));
+      await expect.poll(() => popup.getByText(/^Widevine L\d$/).count()).toBe(1);
+      // Returning to the dashboard persists the sole imported client as active.
+      await popup.goto(popupUrl);
+      await expect.poll(() => popup.getByText('Active', { exact: true }).count()).toBe(1);
+      await expect
+        .poll(() =>
+          worker.evaluate(async () =>
+            Boolean((await chrome.storage.local.get('active-client'))['active-client']),
+          ),
+        )
+        .toBe(true);
+
+      const readKeys = async () => {
+        const raw: unknown = await worker.evaluate(async () => {
+          const storage = await chrome.storage.local.get('all-keys');
+          return storage['all-keys'];
+        });
+        return storedKeys.parse(typeof raw === 'string' ? JSON.parse(raw) : (raw ?? []));
+      };
+      expect((await readKeys()).length).toBe(0);
+      const startedAt = Date.now();
+      const demo = await context.newPage();
+      // Bitmovin challenges the default HeadlessChrome user agent with HTTP 403.
+      const session = await context.newCDPSession(demo);
+      await session.send('Emulation.setUserAgentOverride', {
+        userAgent: await demo.evaluate(() =>
+          navigator.userAgent.replace('HeadlessChrome/', 'Chrome/'),
+        ),
+      });
+      const response = await demo.goto('https://bitmovin.com/demos/drm', {
+        waitUntil: 'domcontentloaded',
+      });
+      expect(
+        response?.status(),
+        'Bitmovin must serve the DRM demo. HTTP 403 can indicate a Cloudflare verification page.',
+      ).toBe(200);
+      await demo.locator('#available-drm-systems').waitFor();
+      await expect
+        .poll(() => demo.locator('#available-drm-systems').inputValue(), {
+          timeout: 30_000,
+          message: 'The Bitmovin demo must detect native Widevine support in the test browser',
+        })
+        .toBe('widevine');
+      // Native playback may reject the substituted license after Okova has captured its keys.
+      await demo.locator('#player-container video').evaluate((video: HTMLVideoElement) => {
+        video.muted = true;
+        void video.play().catch(() => {});
+      });
+
+      await expect
+        .poll(
+          async () =>
+            (await readKeys()).some(
+              (key) =>
+                key.drmSystem === 'W' &&
+                new URL(key.url).hostname === 'bitmovin.com' &&
+                key.createdAt >= startedAt &&
+                /^[0-9a-f]{32}$/i.test(key.id) &&
+                /^[0-9a-f]{32}$/i.test(key.value),
+            ),
+          { timeout: 60_000, message: 'Expected a newly captured Widevine key from Bitmovin' },
+        )
+        .toBe(true);
+
+      // All Keys avoids changing the active website tab used by dashboard filtering.
+      await popup.getByRole('link', { name: 'Keys', exact: true }).click();
+      await expect
+        .poll(() =>
+          popup
+            .locator('code')
+            .filter({ hasText: /^[0-9a-f]{32}:[0-9a-f]{32}$/i })
+            .count(),
+        )
+        .toBeGreaterThan(0);
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await rm(profilePath, { recursive: true, force: true });
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,11 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import { WxtVitest } from 'wxt/testing';
 
 export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'test/e2e/**'],
+  },
   plugins: [WxtVitest()],
   resolve: {
     alias: {

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,12 @@
+import { loadEnv } from 'vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/e2e/**/*.test.ts'],
+    env: loadEnv('test', process.cwd(), 'VITEST_'),
+    testTimeout: 150_000,
+    hookTimeout: 30_000,
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

- Add a Playwright/Vitest E2E test for Widevine key capture from the Bitmovin DRM demo.
- Verify extension spoofing, client import, persisted active client state, and captured keys.
- Document E2E setup and add dedicated configuration and dependencies.

## Testing

- `pnpm test:e2e` (requires a configured `.wvd` client and native Widevine support).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791268831&installation_model_id=424872&pr_number=65&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F65&signature=b8feac8c3db5ffbede1dba4e782528904e44963cdb266063d60ba14702955b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->