### PR TITLE
feat(extension): support DRM client playback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ VITEST_WIDEVINE_CLIENT_PATH=./clients/device.wvd
 VITEST_WIDEVINE_CLIENT_ID_PATH=./clients/device_client_id_blob
 VITEST_WIDEVINE_PRIVATE_KEY_PATH=./clients/device_private_key
 VITEST_PRD_PATH=./clients/hisense_smarttv_he55a7000euwts_sl2000.prd
+# Optional Chromium binary for E2E tests, which use temporary profiles.
+VITEST_CHROMIUM_BINARY=
+# Optional development browser. Leave empty to use the default Chromium browser.
+WXT_CHROMIUM_BINARY=
+WXT_BROWSER_AUTOSTART=true

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Okova is a toolkit (browser extension, command-line tool, and JavaScript library
 
 With EME interception enabled, the extension inspects ClearKey license responses and saves their key IDs and keys as hex. ClearKey capture works without an imported device or spoofing enabled.
 
+Import a Widevine or PlayReady client in **Clients**. Okova automatically enables **Spoofing** and **Playback** when you add a client. Select the client you want to use, then reload the video page.
+
+- **Spoofing** uses your active client to retrieve content keys.
+- **Playback** lets supported videos keep playing while Okova retrieves their keys, including in browsers without built-in Widevine or PlayReady.
+
+Playback depends on the website, browser, and client. Offline licenses and hardware-protected playback are not supported.
+
 Experimental request interception detects streaming manifests in page fetch and XMLHttpRequest responses. Requests made inside workers are not inspected.
 
 The toolbar badge shows a count capped at `99+`, followed by `W`, `P`, or `C` for Widevine, PlayReady, or ClearKey, such as `3W` or `99+W`:

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -598,7 +598,7 @@ export default defineBackground({
             ).toBase64();
             stage = 'storage';
             await run(persistSession(sessionKey, sessionEntry));
-            respond();
+            respond({ challenge: sessionEntry.challenge });
             return;
           }
 

--- a/src/extension/entrypoints/content.ts
+++ b/src/extension/entrypoints/content.ts
@@ -1,5 +1,13 @@
+import { CLIENT_KEY_SYSTEMS } from '@okova/lib/key-system';
 import { appStorage } from '@/utils/storage';
 import type { PublicPath } from 'wxt/browser';
+
+const getActiveClientKeySystem = async () => {
+  const client = await appStorage.clients.active.raw.getValue();
+  if (!client) return null;
+  if (typeof client === 'string' || client.type === 'wvd') return CLIENT_KEY_SYSTEMS.widevine;
+  return CLIENT_KEY_SYSTEMS.playready;
+};
 
 const inject = async (script: PublicPath) => {
   return new Promise((resolve) => {
@@ -30,7 +38,7 @@ export default defineContentScript({
     }
     if (settings?.emeInterception) {
       console.log(`[okova] Injecting EME interception...`);
-      inject('/eme.js');
+      inject(settings.spoofing && settings.clientPlayback ? '/eme-playback.js' : '/eme.js');
     }
 
     // Listen for event from injected script
@@ -44,7 +52,10 @@ export default defineContentScript({
         const { requestId, log } = event.data;
         const message = { ...log, url: window.location.href };
         try {
-          const body = await browser.runtime.sendMessage(message);
+          const body =
+            log.action === 'playback-config'
+              ? await getActiveClientKeySystem()
+              : await browser.runtime.sendMessage(message);
           // Firefox blocks page scripts from reading object detail created in a content script.
           window.dispatchEvent(
             new CustomEvent('drm-message-response', {

--- a/src/extension/entrypoints/content.ts
+++ b/src/extension/entrypoints/content.ts
@@ -9,14 +9,18 @@ const getActiveClientKeySystem = async () => {
   return CLIENT_KEY_SYSTEMS.playready;
 };
 
-const inject = async (script: PublicPath) => {
-  return new Promise((resolve) => {
+const inject = (script: PublicPath) => {
+  return new Promise<void>((resolve, reject) => {
     const element = document.createElement('script');
     element.type = 'text/javascript';
     element.src = browser.runtime.getURL(script);
     element.onload = function () {
       element.remove();
-      resolve(true);
+      resolve();
+    };
+    element.onerror = () => {
+      element.remove();
+      reject(new Error(`Failed to inject ${script}`));
     };
     (document.head || document.documentElement).appendChild(element);
   });
@@ -29,17 +33,6 @@ export default defineContentScript({
   async main() {
     // Checking if interception enabled
     const settings = await appStorage.settings.getValue();
-
-    // Injecting scripts into current page
-    inject('/manifest.js');
-    if (settings?.requestInterception) {
-      console.log(`[okova] Injecting request interception...`);
-      inject('/network.js');
-    }
-    if (settings?.emeInterception) {
-      console.log(`[okova] Injecting EME interception...`);
-      inject(settings.spoofing && settings.clientPlayback ? '/eme-playback.js' : '/eme.js');
-    }
 
     // Listen for event from injected script
     window.addEventListener(
@@ -75,5 +68,18 @@ export default defineContentScript({
       },
       false,
     );
+    try {
+      await inject('/manifest.js');
+      const scripts: Promise<void>[] = [];
+      if (settings?.requestInterception) scripts.push(inject('/network.js'));
+      if (settings?.emeInterception) {
+        scripts.push(
+          inject(settings.spoofing && settings.clientPlayback ? '/eme-playback.js' : '/eme.js'),
+        );
+      }
+      await Promise.all(scripts);
+    } catch (error) {
+      console.warn('[okova] Script injection failed', error);
+    }
   },
 });

--- a/src/extension/entrypoints/eme-playback.ts
+++ b/src/extension/entrypoints/eme-playback.ts
@@ -1,0 +1,7 @@
+import { installDrmPlayback } from '@/utils/drm-playback';
+import { installEmeInterception } from './eme';
+
+export default defineUnlistedScript(() => {
+  installDrmPlayback();
+  installEmeInterception();
+});

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -178,12 +178,12 @@ export const installEmeInterception = () => {
         mpd: window.MPD_LIST.get(session.initData!),
       });
 
-      if (result) {
+      if (result?.keys) {
         const { keys } = result;
         console.groupCollapsed(`[okova] [${session.sessionId}] Received keys from our CDM`);
         for (const { id, value } of keys) console.log(`${id}:${value}`);
         console.groupEnd();
-      } else {
+      } else if (!result) {
         setTimeout(() => {
           if (session.keyStatuses.size === 0) return;
           onKeyStatusesChange(session);

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -1,4 +1,4 @@
-import { toBytes, fromBuffer, fromBase64 } from '@okova/lib/utils';
+import { toBytes, bytesToBase64, fromBase64 } from '@okova/lib/utils';
 import { sendDrmMessage } from '@/utils/drm-bridge';
 import { playbackSessions } from '@/utils/playback-sessions';
 import { isClearKeyRequest } from '@/utils/clearkey';
@@ -10,6 +10,13 @@ declare global {
     messages?: Map<MediaKeyMessageType, string>;
   }
 }
+
+// Service-certificate requests, renewals, releases, and ClearKey stay with the browser.
+const isPassthroughMessage = (keySystem: string | undefined, event: MediaKeyMessageEvent) =>
+  keySystem === 'org.w3.clearkey' ||
+  event.messageType === 'license-release' ||
+  event.messageType === 'license-renewal' ||
+  (event.messageType === 'license-request' && bytesToBase64(event.message) === 'CAQ=');
 
 export const installEmeInterception = () => {
   const send = async (data: Record<string, unknown>): Promise<any> => {
@@ -45,7 +52,7 @@ export const installEmeInterception = () => {
       session: MediaKeySession,
     ) => {
       session.initDataType = initDataType;
-      session.initData = fromBuffer(toBytes(initData)).toBase64();
+      session.initData = bytesToBase64(initData);
       session.messages = new Map();
       const token = crypto.randomUUID();
       const ready = send({
@@ -81,7 +88,7 @@ export const installEmeInterception = () => {
 
       const keyStatuses: Record<string, string> = {};
       for (const [id, status] of session.keyStatuses.entries()) {
-        keyStatuses[fromBuffer(toBytes(id)).toBase64()] = status;
+        keyStatuses[bytesToBase64(id)] = status;
       }
 
       await send({
@@ -100,7 +107,7 @@ export const installEmeInterception = () => {
     const onMessage = async (event: MediaKeyMessageEvent) => {
       const { message, messageType } = event;
       const session = event.target as MediaKeySession;
-      session.messages?.set(messageType, fromBuffer(toBytes(message)).toBase64());
+      session.messages?.set(messageType, bytesToBase64(message));
 
       console.groupCollapsed(
         `[okova] [${session.sessionId}] New message from browser CDM: ${messageType}`,
@@ -111,16 +118,7 @@ export const installEmeInterception = () => {
       console.log(`Message: ${session.messages?.get(messageType)}`);
       console.groupEnd();
 
-      if (
-        getKeySystem(session) === 'org.w3.clearkey' ||
-        ['license-release', 'license-renewal'].includes(messageType)
-      ) {
-        return;
-      }
-
-      // Widevine's service-certificate request must reach the license server unchanged.
-      if (messageType === 'license-request' && fromBuffer(toBytes(message)).toBase64() === 'CAQ=')
-        return;
+      if (isPassthroughMessage(getKeySystem(session), event)) return;
 
       const request = sessionRequests.get(session);
       await request?.ready;
@@ -157,10 +155,8 @@ export const installEmeInterception = () => {
       session: MediaKeySession,
     ): Promise<BufferSource | undefined> => {
       const sessionId = session.sessionId;
-      const message = ArrayBuffer.isView(response)
-        ? new Uint8Array(response.buffer, response.byteOffset, response.byteLength)
-        : new Uint8Array(response);
-      const messageBase64 = fromBuffer(toBytes(message)).toBase64();
+      const message = toBytes(response);
+      const messageBase64 = bytesToBase64(message);
 
       console.groupCollapsed(`[okova] [${session.sessionId}] Update session with response`);
       console.log(`Initialization data type: ${session.initDataType}`);
@@ -237,13 +233,7 @@ export const installEmeInterception = () => {
             const mediaKeys = sessionMediaKeys.get(session);
             if (mediaKeys) mediaKeysSystems.set(mediaKeys, 'org.w3.clearkey');
           }
-          if (
-            getKeySystem(session) === 'org.w3.clearkey' ||
-            event.messageType === 'license-release' ||
-            event.messageType === 'license-renewal' ||
-            (event.messageType === 'license-request' &&
-              fromBuffer(toBytes(event.message)).toBase64() === 'CAQ=')
-          ) {
+          if (isPassthroughMessage(getKeySystem(session), event)) {
             void onMessage(event);
             return;
           }
@@ -303,7 +293,7 @@ export const installEmeInterception = () => {
       MediaKeys.prototype,
       'setServerCertificate',
       async (setServerCertificate, mediaKeys, [certificate]) => {
-        const encodedCertificate = fromBuffer(toBytes(certificate)).toBase64();
+        const encodedCertificate = bytesToBase64(certificate);
         const result = await setServerCertificate.call(mediaKeys, certificate);
         if (result) mediaKeysCertificates.set(mediaKeys, encodedCertificate);
         return result;

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -1,4 +1,6 @@
+import { toBytes, fromBuffer, fromBase64 } from '@okova/lib/utils';
 import { sendDrmMessage } from '@/utils/drm-bridge';
+import { playbackSessions } from '@/utils/playback-sessions';
 import { isClearKeyRequest } from '@/utils/clearkey';
 
 declare global {
@@ -9,17 +11,7 @@ declare global {
   }
 }
 
-export default defineUnlistedScript(() => {
-  const base64 = {
-    parse: (s: any) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0)),
-    stringify: (buffer: BufferSource) => {
-      const bytes = ArrayBuffer.isView(buffer)
-        ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
-        : new Uint8Array(buffer);
-      return btoa(String.fromCharCode(...bytes));
-    },
-  };
-
+export const installEmeInterception = () => {
   const send = async (data: Record<string, unknown>): Promise<any> => {
     try {
       return await sendDrmMessage(data);
@@ -53,7 +45,7 @@ export default defineUnlistedScript(() => {
       session: MediaKeySession,
     ) => {
       session.initDataType = initDataType;
-      session.initData = base64.stringify(initData);
+      session.initData = fromBuffer(toBytes(initData)).toBase64();
       session.messages = new Map();
       const token = crypto.randomUUID();
       const ready = send({
@@ -89,7 +81,7 @@ export default defineUnlistedScript(() => {
 
       const keyStatuses: Record<string, string> = {};
       for (const [id, status] of session.keyStatuses.entries()) {
-        keyStatuses[base64.stringify(id)] = status;
+        keyStatuses[fromBuffer(toBytes(id)).toBase64()] = status;
       }
 
       await send({
@@ -108,7 +100,7 @@ export default defineUnlistedScript(() => {
     const onMessage = async (event: MediaKeyMessageEvent) => {
       const { message, messageType } = event;
       const session = event.target as MediaKeySession;
-      session.messages?.set(messageType, base64.stringify(message));
+      session.messages?.set(messageType, fromBuffer(toBytes(message)).toBase64());
 
       console.groupCollapsed(
         `[okova] [${session.sessionId}] New message from browser CDM: ${messageType}`,
@@ -127,7 +119,8 @@ export default defineUnlistedScript(() => {
       }
 
       // Widevine's service-certificate request must reach the license server unchanged.
-      if (messageType === 'license-request' && base64.stringify(message) === 'CAQ=') return;
+      if (messageType === 'license-request' && fromBuffer(toBytes(message)).toBase64() === 'CAQ=')
+        return;
 
       const request = sessionRequests.get(session);
       await request?.ready;
@@ -144,7 +137,7 @@ export default defineUnlistedScript(() => {
         return;
       }
 
-      const challenge = base64.parse(response);
+      const challenge = fromBase64(response).toBuffer();
 
       console.groupCollapsed(
         `[okova] [${session.sessionId}] Swapping a message from CDM with ours`,
@@ -167,7 +160,7 @@ export default defineUnlistedScript(() => {
       const message = ArrayBuffer.isView(response)
         ? new Uint8Array(response.buffer, response.byteOffset, response.byteLength)
         : new Uint8Array(response);
-      const messageBase64 = base64.stringify(message);
+      const messageBase64 = fromBuffer(toBytes(message)).toBase64();
 
       console.groupCollapsed(`[okova] [${session.sessionId}] Update session with response`);
       console.log(`Initialization data type: ${session.initDataType}`);
@@ -226,7 +219,7 @@ export default defineUnlistedScript(() => {
     };
 
     const interceptSessionEvents = (session: MediaKeySession) => {
-      if (interceptedSessions.has(session)) return;
+      if (playbackSessions.has(session) || interceptedSessions.has(session)) return;
       interceptedSessions.add(session);
       // Stop native delivery before any application listener runs. After the bridge
       // responds, let the browser dispatch the replacement to the original listeners.
@@ -248,7 +241,8 @@ export default defineUnlistedScript(() => {
             getKeySystem(session) === 'org.w3.clearkey' ||
             event.messageType === 'license-release' ||
             event.messageType === 'license-renewal' ||
-            (event.messageType === 'license-request' && base64.stringify(event.message) === 'CAQ=')
+            (event.messageType === 'license-request' &&
+              fromBuffer(toBytes(event.message)).toBase64() === 'CAQ=')
           ) {
             void onMessage(event);
             return;
@@ -309,7 +303,7 @@ export default defineUnlistedScript(() => {
       MediaKeys.prototype,
       'setServerCertificate',
       async (setServerCertificate, mediaKeys, [certificate]) => {
-        const encodedCertificate = base64.stringify(certificate);
+        const encodedCertificate = fromBuffer(toBytes(certificate)).toBase64();
         const result = await setServerCertificate.call(mediaKeys, certificate);
         if (result) mediaKeysCertificates.set(mediaKeys, encodedCertificate);
         return result;
@@ -346,4 +340,6 @@ export default defineUnlistedScript(() => {
   patchEncryptedMediaExtensions();
 
   console.log('[okova] EME interception added');
-});
+};
+
+export default defineUnlistedScript(installEmeInterception);

--- a/src/extension/entrypoints/popup/components/cell-import-client.tsx
+++ b/src/extension/entrypoints/popup/components/cell-import-client.tsx
@@ -52,14 +52,16 @@ export const CellImportClient: Component<{
       await appStorage.clients.active.setValue(client);
       setActiveClient(client);
     }
-    const nextSettings = {
-      ...settings,
-      emeInterception: true,
-      spoofing: true,
-      clientPlayback: true,
-    };
-    await appStorage.settings.setValue(nextSettings);
-    setSettings(nextSettings);
+    if (clients().length === 0) {
+      const nextSettings = {
+        ...settings,
+        emeInterception: true,
+        spoofing: true,
+        clientPlayback: true,
+      };
+      await appStorage.settings.setValue(nextSettings);
+      setSettings(nextSettings);
+    }
     setClients(newClients);
   };
 

--- a/src/extension/entrypoints/popup/components/cell-import-client.tsx
+++ b/src/extension/entrypoints/popup/components/cell-import-client.tsx
@@ -3,14 +3,15 @@ import { TbOutlineShieldPlus as TbShieldPlus } from 'solid-icons/tb';
 import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
 import { Cell } from './cell';
-import { useActiveClient, useClients } from '../utils/state';
+import { useActiveClient, useClients, useSettings } from '../utils/state';
 import { appStorage, Client } from '@/utils/storage';
 
 export const CellImportClient: Component<{
   disabled?: boolean;
   onChange?: (client: Client) => void;
 }> = (props) => {
-  const [, setActiveClient] = useActiveClient();
+  const [activeClient, setActiveClient] = useActiveClient();
+  const [settings, setSettings] = useSettings();
   const [clients, setClients] = useClients();
 
   const importClient = async (files: File[]) => {
@@ -44,24 +45,31 @@ export const CellImportClient: Component<{
     }
   };
 
-  const applyClient = (client?: Client) => {
-    if (!client) return;
-    props.onChange?.(client);
-  };
-
-  const addClient = async (client: Client) => {
+  const completeClientImport = async (client: Client) => {
     const newClients = [...clients(), client];
-    setClients(newClients);
     await appStorage.clients.add(client);
-    if (newClients.length === 1) setActiveClient(client);
+    if (!activeClient()) {
+      await appStorage.clients.active.setValue(client);
+      setActiveClient(client);
+    }
+    const nextSettings = {
+      ...settings,
+      emeInterception: true,
+      spoofing: true,
+      clientPlayback: true,
+    };
+    await appStorage.settings.setValue(nextSettings);
+    setSettings(nextSettings);
+    setClients(newClients);
   };
 
   const handleFileChange = async (event: Event) => {
-    const files = Array.from((event.target as HTMLInputElement).files || []);
+    if (!(event.target instanceof HTMLInputElement)) return;
+    const files = Array.from(event.target.files || []);
     const client = await importClient(files);
     if (!client) return;
-    applyClient(client);
-    addClient(client);
+    await completeClientImport(client);
+    props.onChange?.(client);
   };
 
   return (

--- a/src/extension/entrypoints/popup/components/layout.tsx
+++ b/src/extension/entrypoints/popup/components/layout.tsx
@@ -5,7 +5,7 @@ export const Layout: Component<{ children: JSX.Element; className?: string }> = 
   return (
     <main
       class={cn(
-        'px-4 py-4 pr-0 min-w-[500px] min-h-[500px] bg-[#EFEFF4] text-neutral-950 transition-colors dark:bg-neutral-950 dark:text-neutral-50',
+        'px-4 py-4 pr-0 min-h-[500px] bg-[#EFEFF4] text-neutral-950 transition-colors dark:bg-neutral-950 dark:text-neutral-50',
         props.className,
       )}
     >

--- a/src/extension/entrypoints/popup/routes/settings.tsx
+++ b/src/extension/entrypoints/popup/routes/settings.tsx
@@ -53,7 +53,7 @@ export const Settings = () => {
       <List>
         <Section
           header="General"
-          footer="When enabled, it will not be possible to play protected media."
+          footer="Spoofing can interrupt playback. Enable Playback to play supported videos with your active client. Reload the video page after changing these settings."
         >
           <Cell
             title="You can view logs from an Encrypted Media Extensions (EME) session in Developer Tools under the Console tab"
@@ -64,7 +64,6 @@ export const Settings = () => {
                 checked={settings.emeInterception}
                 onChange={(e) => {
                   const checked = e.target.checked;
-                  if (!checked) switchSpoofing(false);
                   switchEmeInterception(checked);
                 }}
               />
@@ -73,17 +72,32 @@ export const Settings = () => {
             EME interception
           </Cell>
           <Cell
-            subtitle="Inject our own license request"
+            subtitle="Use the active client to obtain content keys"
             component="label"
             disabled={!settings.emeInterception}
             after={
               <Switch
+                disabled={!settings.emeInterception}
                 checked={settings.spoofing}
                 onChange={(e) => switchSpoofing(e.target.checked)}
               />
             }
           >
             Spoofing
+          </Cell>
+          <Cell
+            subtitle="Use the active client to play protected content"
+            component="label"
+            disabled={!settings.emeInterception || !settings.spoofing}
+            after={
+              <Switch
+                disabled={!settings.emeInterception || !settings.spoofing}
+                checked={settings.clientPlayback ?? false}
+                onChange={(event) => updateSettings({ clientPlayback: event.target.checked })}
+              />
+            }
+          >
+            Playback
           </Cell>
         </Section>
         <Section

--- a/src/extension/entrypoints/popup/routes/settings.tsx
+++ b/src/extension/entrypoints/popup/routes/settings.tsx
@@ -92,7 +92,7 @@ export const Settings = () => {
             after={
               <Switch
                 disabled={!settings.emeInterception || !settings.spoofing}
-                checked={settings.clientPlayback ?? false}
+                checked={settings.clientPlayback}
                 onChange={(event) => updateSettings({ clientPlayback: event.target.checked })}
               />
             }

--- a/src/extension/entrypoints/popup/styles.css
+++ b/src/extension/entrypoints/popup/styles.css
@@ -42,7 +42,6 @@
   html,
   body,
   #root {
-    min-width: 500px; /* Max: 800px */
     min-height: 500px; /* Max: 600px */
     background: var(--popup-bg);
     color: var(--popup-fg);
@@ -53,6 +52,7 @@
   }
 
   html {
+    min-width: 500px; /* Let children fit the space left by the scrollbar. */
     overflow-y: auto; /* Adds scrollbar inside if needed */
     scrollbar-gutter: stable; /* Keeps layout steady */
   }

--- a/src/extension/entrypoints/popup/utils/state.ts
+++ b/src/extension/entrypoints/popup/utils/state.ts
@@ -24,6 +24,7 @@ export const useActiveTabUrl = () => activeTabUrlSignal;
 const defaultSettings: Settings = {
   emeInterception: true,
   spoofing: false,
+  clientPlayback: false,
   requestInterception: false,
   theme: 'auto',
 };

--- a/src/extension/utils/drm-playback.ts
+++ b/src/extension/utils/drm-playback.ts
@@ -14,6 +14,7 @@ const INSTALLED = Symbol.for('okova.drm-playback.installed');
 const CLEARKEY = 'org.w3.clearkey';
 const hexKey = z.string().regex(/^[a-f\d]{32}$/i);
 const licenseKeys = z.object({ keys: z.array(z.object({ id: hexKey, value: hexKey })).min(1) });
+const licenseChallenge = z.object({ challenge: z.string().min(1) });
 const hexToBase64Url = (hex: string) =>
   fromHex(hex).toBase64().replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
 const encodeJsonUtf8 = (value: unknown) => new TextEncoder().encode(JSON.stringify(value));
@@ -72,6 +73,18 @@ export const installDrmPlayback = () => {
           serverCertificate,
           mpd: initData ? window.MPD_LIST?.get(initData) : undefined,
         });
+      const dispatchChallenge = (challenge: ArrayBuffer) => {
+        // Deliver as a task, after generateRequest or update has resolved.
+        setTimeout(() => {
+          if (closed) return;
+          const event = new MediaKeyMessageEvent('message', {
+            messageType: 'license-request',
+            message: challenge,
+          });
+          forwardedMessages.add(event);
+          session.dispatchEvent(event);
+        }, 0);
+      };
       // Keep ClearKey requests local. The player only receives challenges from the active client.
       nativeListen.call(session, 'message', (event) => {
         if (!forwardedMessages.has(event)) event.stopImmediatePropagation();
@@ -113,16 +126,7 @@ export const installDrmPlayback = () => {
         return ready.then((challenge) => {
           if (closed) throw new DOMException('Session is closed', 'InvalidStateError');
           isCallable = true;
-          // Deliver the challenge as a task, after generateRequest has resolved.
-          setTimeout(() => {
-            if (closed) return;
-            const event = new MediaKeyMessageEvent('message', {
-              messageType: 'license-request',
-              message: challenge,
-            });
-            forwardedMessages.add(event);
-            session.dispatchEvent(event);
-          }, 0);
+          dispatchChallenge(challenge);
         });
       };
       session.update = async (response) => {
@@ -134,6 +138,12 @@ export const installDrmPlayback = () => {
           message,
           messageBase64: bytesToBase64(message),
         });
+        const nextChallenge = licenseChallenge.safeParse(result);
+        if (keySystem === WIDEVINE && nextChallenge.success) {
+          if (closed) throw new DOMException('Session is closed', 'InvalidStateError');
+          dispatchChallenge(fromBase64(nextChallenge.data.challenge).toBuffer().buffer);
+          return;
+        }
         const parsed = licenseKeys.safeParse(result);
         if (!parsed.success)
           throw new DOMException(
@@ -168,14 +178,15 @@ export const installDrmPlayback = () => {
 
   navigator.requestMediaKeySystemAccess = async (keySystem, configurations) => {
     const isPlayReady = keySystem === PLAYREADY || keySystem === 'com.microsoft.playready';
-    if (
+    const isHardwarePlayReady =
       keySystem === 'com.microsoft.playready.recommendation.3000' ||
-      keySystem === 'com.microsoft.playready.hardware'
-    ) {
-      throw unsupported('Hardware DRM is unavailable during client playback');
-    }
-    if (keySystem !== WIDEVINE && !isPlayReady) return requestAccess(keySystem, configurations);
+      keySystem === 'com.microsoft.playready.hardware';
+    if (keySystem !== WIDEVINE && !isPlayReady && !isHardwarePlayReady)
+      return requestAccess(keySystem, configurations);
     const activeSystem = await sendDrmMessage({ action: 'playback-config' });
+    if (activeSystem === null) return requestAccess(keySystem, configurations);
+    if (isHardwarePlayReady)
+      throw unsupported('Hardware DRM is unavailable during client playback');
     if (activeSystem !== (isPlayReady ? PLAYREADY : WIDEVINE)) {
       throw unsupported('Select a matching DRM client in Okova');
     }

--- a/src/extension/utils/drm-playback.ts
+++ b/src/extension/utils/drm-playback.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { CLIENT_KEY_SYSTEMS, type ClientKeySystem } from '@okova/lib/key-system';
-import { toBytes, fromBuffer, fromHex, fromBase64 } from '@okova/lib/utils';
+import { toBytes, bytesToBase64, fromHex, fromBase64 } from '@okova/lib/utils';
 import { getPsshKeyIds, parsePsshBoxes, PSSH_SYSTEM_IDS } from '@okova/lib/pssh';
 import { playbackSessions } from './playback-sessions';
 import { sendDrmMessage } from './drm-bridge';
@@ -10,6 +10,7 @@ type PlaybackKeySystem = ClientKeySystem | 'com.microsoft.playready';
 type SessionRequest =
   | { action: 'generateRequest' | 'license-request' | 'close' }
   | { action: 'update'; message: Uint8Array; messageBase64: string };
+const INSTALLED = Symbol.for('okova.drm-playback.installed');
 const CLEARKEY = 'org.w3.clearkey';
 const hexKey = z.string().regex(/^[a-f\d]{32}$/i);
 const licenseKeys = z.object({ keys: z.array(z.object({ id: hexKey, value: hexKey })).min(1) });
@@ -29,6 +30,7 @@ const unsupported = (message: string) => new DOMException(message, 'NotSupported
 
 /** Temporary-session adapter. Native ClearKey owns attachment and decryption. */
 export const installDrmPlayback = () => {
+  if (Reflect.get(navigator, INSTALLED)) return;
   const requestAccess = navigator.requestMediaKeySystemAccess.bind(navigator);
   const nativeCreateKeys = MediaKeySystemAccess.prototype.createMediaKeys;
   const nativeCreateSession = MediaKeys.prototype.createSession;
@@ -45,7 +47,7 @@ export const installDrmPlayback = () => {
       if (!toBytes(certificate).length) throw new TypeError('Empty server certificate');
       if (keySystem !== WIDEVINE) return false;
       // The background Widevine client validates and uses this certificate.
-      serverCertificate = fromBuffer(toBytes(certificate)).toBase64();
+      serverCertificate = bytesToBase64(certificate);
       return true;
     };
     mediaKeys.createSession = (sessionType = 'temporary') => {
@@ -57,7 +59,8 @@ export const installDrmPlayback = () => {
       const forwardedMessages = new WeakSet<Event>();
       let closed = false;
       let initData: string | undefined;
-      let ready: Promise<ArrayBuffer> | undefined;
+      let initialized = false;
+      let isCallable = false;
       const sendSessionRequest = (request: SessionRequest) =>
         sendDrmMessage({
           ...request,
@@ -74,11 +77,12 @@ export const installDrmPlayback = () => {
         if (!forwardedMessages.has(event)) event.stopImmediatePropagation();
       });
       session.generateRequest = (initDataType, data) => {
-        if (ready || closed)
+        if (initialized || closed)
           return Promise.reject(
             new DOMException('Session already initialized or closed', 'InvalidStateError'),
           );
-        ready = (async () => {
+        initialized = true;
+        const ready = (async () => {
           if (initDataType !== 'cenc')
             throw unsupported('Playback requires cenc initialization data');
           const source = toBytes(data);
@@ -87,13 +91,15 @@ export const installDrmPlayback = () => {
             .flatMap(getPsshKeyIds);
           if (!kids.length)
             throw unsupported('Playback requires key IDs in the DRM initialization data');
-          initData = fromBuffer(source).toBase64();
+          initData = bytesToBase64(source);
           await nativeGenerate.call(
             session,
             'keyids',
             encodeJsonUtf8({ kids: kids.map(hexToBase64Url) }),
           );
+          if (closed) throw new DOMException('Session is closed', 'InvalidStateError');
           await sendSessionRequest({ action: 'generateRequest' });
+          if (closed) throw new DOMException('Session is closed', 'InvalidStateError');
           const challenge = await sendSessionRequest({ action: 'license-request' });
           if (typeof challenge !== 'string' || !challenge.length) {
             throw new DOMException(
@@ -105,6 +111,8 @@ export const installDrmPlayback = () => {
           return fromBase64(challenge).toBuffer().buffer;
         })();
         return ready.then((challenge) => {
+          if (closed) throw new DOMException('Session is closed', 'InvalidStateError');
+          isCallable = true;
           // Deliver the challenge as a task, after generateRequest has resolved.
           setTimeout(() => {
             if (closed) return;
@@ -118,13 +126,13 @@ export const installDrmPlayback = () => {
         });
       };
       session.update = async (response) => {
-        if (!ready || closed) throw new DOMException('Session is not active', 'InvalidStateError');
+        if (!isCallable || closed)
+          throw new DOMException('Session is not active', 'InvalidStateError');
         const message = new Uint8Array(toBytes(response));
-        await ready;
         const result = await sendSessionRequest({
           action: 'update',
           message,
-          messageBase64: fromBuffer(message).toBase64(),
+          messageBase64: bytesToBase64(message),
         });
         const parsed = licenseKeys.safeParse(result);
         if (!parsed.success)
@@ -249,4 +257,5 @@ export const installDrmPlayback = () => {
     }
     throw unsupported('No compatible ClearKey configuration for client playback');
   };
+  Object.defineProperty(navigator, INSTALLED, { value: true });
 };

--- a/src/extension/utils/drm-playback.ts
+++ b/src/extension/utils/drm-playback.ts
@@ -1,0 +1,252 @@
+import { z } from 'zod';
+import { CLIENT_KEY_SYSTEMS, type ClientKeySystem } from '@okova/lib/key-system';
+import { toBytes, fromBuffer, fromHex, fromBase64 } from '@okova/lib/utils';
+import { getPsshKeyIds, parsePsshBoxes, PSSH_SYSTEM_IDS } from '@okova/lib/pssh';
+import { playbackSessions } from './playback-sessions';
+import { sendDrmMessage } from './drm-bridge';
+
+const { widevine: WIDEVINE, playready: PLAYREADY } = CLIENT_KEY_SYSTEMS;
+type PlaybackKeySystem = ClientKeySystem | 'com.microsoft.playready';
+type SessionRequest =
+  | { action: 'generateRequest' | 'license-request' | 'close' }
+  | { action: 'update'; message: Uint8Array; messageBase64: string };
+const CLEARKEY = 'org.w3.clearkey';
+const hexKey = z.string().regex(/^[a-f\d]{32}$/i);
+const licenseKeys = z.object({ keys: z.array(z.object({ id: hexKey, value: hexKey })).min(1) });
+const hexToBase64Url = (hex: string) =>
+  fromHex(hex).toBase64().replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+const encodeJsonUtf8 = (value: unknown) => new TextEncoder().encode(JSON.stringify(value));
+// Windows PlayReady EME messages wrap the SOAP challenge and headers in UTF-16LE XML.
+const encodePlayReadyMessage = (challenge: string) => {
+  const xml = `<PlayReadyKeyMessage type="LicenseAcquisition"><LicenseAcquisition version="1.0"><Challenge encoding="base64encoded">${challenge}</Challenge><HttpHeaders><HttpHeader><name>Content-Type</name><value>text/xml; charset=utf-8</value></HttpHeader><HttpHeader><name>SOAPAction</name><value>http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense</value></HttpHeader></HttpHeaders></LicenseAcquisition></PlayReadyKeyMessage>`;
+  const message = new ArrayBuffer(xml.length * 2);
+  const view = new DataView(message);
+  for (let index = 0; index < xml.length; index++)
+    view.setUint16(index * 2, xml.charCodeAt(index), true);
+  return message;
+};
+const unsupported = (message: string) => new DOMException(message, 'NotSupportedError');
+
+/** Temporary-session adapter. Native ClearKey owns attachment and decryption. */
+export const installDrmPlayback = () => {
+  const requestAccess = navigator.requestMediaKeySystemAccess.bind(navigator);
+  const nativeCreateKeys = MediaKeySystemAccess.prototype.createMediaKeys;
+  const nativeCreateSession = MediaKeys.prototype.createSession;
+  const nativeGenerate = MediaKeySession.prototype.generateRequest;
+  const nativeUpdate = MediaKeySession.prototype.update;
+  const nativeClose = MediaKeySession.prototype.close;
+
+  const nativeListen = MediaKeySession.prototype.addEventListener;
+
+  const adaptMediaKeys = (mediaKeys: MediaKeys, keySystem: PlaybackKeySystem) => {
+    const systemId = keySystem === WIDEVINE ? PSSH_SYSTEM_IDS.widevine : PSSH_SYSTEM_IDS.playready;
+    let serverCertificate: string | undefined;
+    mediaKeys.setServerCertificate = async (certificate) => {
+      if (!toBytes(certificate).length) throw new TypeError('Empty server certificate');
+      if (keySystem !== WIDEVINE) return false;
+      // The background Widevine client validates and uses this certificate.
+      serverCertificate = fromBuffer(toBytes(certificate)).toBase64();
+      return true;
+    };
+    mediaKeys.createSession = (sessionType = 'temporary') => {
+      if (sessionType !== 'temporary')
+        throw unsupported('Playback supports temporary sessions only');
+      const session = nativeCreateSession.call(mediaKeys, sessionType);
+      playbackSessions.add(session);
+      const sessionToken = crypto.randomUUID();
+      const forwardedMessages = new WeakSet<Event>();
+      let closed = false;
+      let initData: string | undefined;
+      let ready: Promise<ArrayBuffer> | undefined;
+      const sendSessionRequest = (request: SessionRequest) =>
+        sendDrmMessage({
+          ...request,
+          sessionToken,
+          sessionId: session.sessionId,
+          keySystem,
+          initDataType: 'cenc',
+          initData,
+          serverCertificate,
+          mpd: initData ? window.MPD_LIST?.get(initData) : undefined,
+        });
+      // Keep ClearKey requests local. The player only receives challenges from the active client.
+      nativeListen.call(session, 'message', (event) => {
+        if (!forwardedMessages.has(event)) event.stopImmediatePropagation();
+      });
+      session.generateRequest = (initDataType, data) => {
+        if (ready || closed)
+          return Promise.reject(
+            new DOMException('Session already initialized or closed', 'InvalidStateError'),
+          );
+        ready = (async () => {
+          if (initDataType !== 'cenc')
+            throw unsupported('Playback requires cenc initialization data');
+          const source = toBytes(data);
+          const kids = parsePsshBoxes(source)
+            .filter((box) => box.systemId === systemId)
+            .flatMap(getPsshKeyIds);
+          if (!kids.length)
+            throw unsupported('Playback requires key IDs in the DRM initialization data');
+          initData = fromBuffer(source).toBase64();
+          await nativeGenerate.call(
+            session,
+            'keyids',
+            encodeJsonUtf8({ kids: kids.map(hexToBase64Url) }),
+          );
+          await sendSessionRequest({ action: 'generateRequest' });
+          const challenge = await sendSessionRequest({ action: 'license-request' });
+          if (typeof challenge !== 'string' || !challenge.length) {
+            throw new DOMException(
+              'The active client could not create a license request. Check Okova for details.',
+              'OperationError',
+            );
+          }
+          if (keySystem !== WIDEVINE) return encodePlayReadyMessage(challenge);
+          return fromBase64(challenge).toBuffer().buffer;
+        })();
+        return ready.then((challenge) => {
+          // Deliver the challenge as a task, after generateRequest has resolved.
+          setTimeout(() => {
+            if (closed) return;
+            const event = new MediaKeyMessageEvent('message', {
+              messageType: 'license-request',
+              message: challenge,
+            });
+            forwardedMessages.add(event);
+            session.dispatchEvent(event);
+          }, 0);
+        });
+      };
+      session.update = async (response) => {
+        if (!ready || closed) throw new DOMException('Session is not active', 'InvalidStateError');
+        const message = new Uint8Array(toBytes(response));
+        await ready;
+        const result = await sendSessionRequest({
+          action: 'update',
+          message,
+          messageBase64: fromBuffer(message).toBase64(),
+        });
+        const parsed = licenseKeys.safeParse(result);
+        if (!parsed.success)
+          throw new DOMException(
+            'The active client could not retrieve content keys. Check Okova for details.',
+            'OperationError',
+          );
+        const { keys } = parsed.data;
+        await nativeUpdate.call(
+          session,
+          encodeJsonUtf8({
+            keys: keys.map(({ id, value }) => ({
+              kty: 'oct',
+              kid: hexToBase64Url(id),
+              k: hexToBase64Url(value),
+            })),
+            type: 'temporary',
+          }),
+        );
+      };
+      session.close = async () => {
+        closed = true;
+        await nativeClose.call(session);
+      };
+      void session.closed.then(() => {
+        closed = true;
+        void sendSessionRequest({ action: 'close' }).catch(() => {});
+      });
+      return session;
+    };
+    return mediaKeys;
+  };
+
+  navigator.requestMediaKeySystemAccess = async (keySystem, configurations) => {
+    const isPlayReady = keySystem === PLAYREADY || keySystem === 'com.microsoft.playready';
+    if (
+      keySystem === 'com.microsoft.playready.recommendation.3000' ||
+      keySystem === 'com.microsoft.playready.hardware'
+    ) {
+      throw unsupported('Hardware DRM is unavailable during client playback');
+    }
+    if (keySystem !== WIDEVINE && !isPlayReady) return requestAccess(keySystem, configurations);
+    const activeSystem = await sendDrmMessage({ action: 'playback-config' });
+    if (activeSystem !== (isPlayReady ? PLAYREADY : WIDEVINE)) {
+      throw unsupported('Select a matching DRM client in Okova');
+    }
+    const supportsCapability = (capability: MediaKeySystemMediaCapability) =>
+      (!capability.encryptionScheme || capability.encryptionScheme === 'cenc') &&
+      (!capability.robustness ||
+        (isPlayReady
+          ? ['150', '2000'].includes(capability.robustness)
+          : ['SW_SECURE_CRYPTO', 'SW_SECURE_DECODE'].includes(capability.robustness)));
+
+    for (const configuration of configurations) {
+      if (
+        configuration.persistentState === 'required' ||
+        configuration.distinctiveIdentifier === 'required' ||
+        configuration.sessionTypes?.some((type) => type !== 'temporary') ||
+        (configuration.initDataTypes && !configuration.initDataTypes.includes('cenc'))
+      )
+        continue;
+      const translate = (capabilities: MediaKeySystemMediaCapability[] | undefined) =>
+        capabilities
+          ?.filter(supportsCapability)
+          .map((capability) => ({ ...capability, robustness: '', encryptionScheme: 'cenc' }));
+      const audioCapabilities = translate(configuration.audioCapabilities);
+      const videoCapabilities = translate(configuration.videoCapabilities);
+      if (
+        (configuration.audioCapabilities?.length && !audioCapabilities?.length) ||
+        (configuration.videoCapabilities?.length && !videoCapabilities?.length)
+      )
+        continue;
+      try {
+        const nativeAccess = await requestAccess(CLEARKEY, [
+          {
+            ...configuration,
+            initDataTypes: ['keyids'],
+            audioCapabilities,
+            videoCapabilities,
+            distinctiveIdentifier: 'not-allowed',
+            persistentState: 'not-allowed',
+            sessionTypes: ['temporary'],
+          },
+        ]);
+        const supported = nativeAccess.getConfiguration();
+        const restore = (
+          capabilities: MediaKeySystemMediaCapability[] | undefined,
+          requested: MediaKeySystemMediaCapability[] | undefined,
+        ) =>
+          capabilities?.map((capability) => ({
+            ...capability,
+            robustness:
+              requested?.find(
+                (candidate) =>
+                  candidate.contentType === capability.contentType && supportsCapability(candidate),
+              )?.robustness ?? '',
+          }));
+        return new Proxy(nativeAccess, {
+          get(target, property) {
+            if (property === 'keySystem') return keySystem;
+            if (property === 'getConfiguration')
+              return () => ({
+                ...supported,
+                initDataTypes: ['cenc'],
+                audioCapabilities: restore(
+                  supported.audioCapabilities,
+                  configuration.audioCapabilities,
+                ),
+                videoCapabilities: restore(
+                  supported.videoCapabilities,
+                  configuration.videoCapabilities,
+                ),
+              });
+            if (property === 'createMediaKeys')
+              return async () => adaptMediaKeys(await nativeCreateKeys.call(target), keySystem);
+            return Reflect.get(target, property, target);
+          },
+        });
+      } catch (error) {
+        if (!(error instanceof DOMException) || error.name !== 'NotSupportedError') throw error;
+      }
+    }
+    throw unsupported('No compatible ClearKey configuration for client playback');
+  };
+};

--- a/src/extension/utils/playback-sessions.ts
+++ b/src/extension/utils/playback-sessions.ts
@@ -1,0 +1,2 @@
+// Shared with normal EME interception so adapted sessions are captured only once.
+export const playbackSessions = new WeakSet<MediaKeySession>();

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -70,6 +70,7 @@ export const getRecentKeysForUrl = (
 
 export type Settings = {
   spoofing: boolean;
+  clientPlayback?: boolean;
   emeInterception: boolean;
   requestInterception: boolean;
   theme: ThemeMode;
@@ -104,8 +105,21 @@ const mutateKeyHistory = (mutation: () => Promise<void>) =>
 
 const recentKeys = asJson(storage.defineItem<KeyInfo[]>('local:recent-keys'));
 
+const storedSettings = asJson(
+  storage.defineItem<Settings & { clientPlayback?: boolean }>('local:settings'),
+);
+
 export const appStorage = {
-  settings: asJson(storage.defineItem<Settings>('local:settings')),
+  settings: {
+    ...storedSettings,
+    getValue: async (): Promise<Settings | null> => {
+      const settings = await storedSettings.getValue();
+      if (!settings) return null;
+      // Keep preferences saved by the initial playback prototype.
+      const { clientPlayback, ...current } = settings;
+      return { ...current, clientPlayback: clientPlayback ?? false };
+    },
+  },
 
   recentKeys: {
     ...recentKeys,

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -70,7 +70,7 @@ export const getRecentKeysForUrl = (
 
 export type Settings = {
   spoofing: boolean;
-  clientPlayback?: boolean;
+  clientPlayback: boolean;
   emeInterception: boolean;
   requestInterception: boolean;
   theme: ThemeMode;
@@ -106,19 +106,24 @@ const mutateKeyHistory = (mutation: () => Promise<void>) =>
 const recentKeys = asJson(storage.defineItem<KeyInfo[]>('local:recent-keys'));
 
 const storedSettings = asJson(
-  storage.defineItem<Settings & { clientPlayback?: boolean }>('local:settings'),
+  storage.defineItem<Omit<Settings, 'clientPlayback'> & { clientPlayback?: boolean }>(
+    'local:settings',
+  ),
 );
+
+const normalizeSettings = (
+  settings: Awaited<ReturnType<typeof storedSettings.getValue>>,
+): Settings | null =>
+  settings ? { ...settings, clientPlayback: settings.clientPlayback ?? false } : null;
 
 export const appStorage = {
   settings: {
     ...storedSettings,
-    getValue: async (): Promise<Settings | null> => {
-      const settings = await storedSettings.getValue();
-      if (!settings) return null;
-      // Keep preferences saved by the initial playback prototype.
-      const { clientPlayback, ...current } = settings;
-      return { ...current, clientPlayback: clientPlayback ?? false };
-    },
+    getValue: async () => normalizeSettings(await storedSettings.getValue()),
+    watch: (callback: (newValue: Settings | null, oldValue: Settings | null) => void) =>
+      storedSettings.watch((newValue, oldValue) =>
+        callback(normalizeSettings(newValue), normalizeSettings(oldValue)),
+      ),
   },
 
   recentKeys: {

--- a/src/lib/key-system.ts
+++ b/src/lib/key-system.ts
@@ -1,13 +1,20 @@
+export const CLIENT_KEY_SYSTEMS = {
+  widevine: 'com.widevine.alpha',
+  playready: 'com.microsoft.playready.recommendation',
+} as const;
+
+export type ClientKeySystem = (typeof CLIENT_KEY_SYSTEMS)[keyof typeof CLIENT_KEY_SYSTEMS];
+
 /** Normalize the supported EME names without accepting arbitrary vendor suffixes. */
 export const normalizeKeySystem = (keySystem: string) => {
   switch (keySystem) {
     case 'com.widevine.alpha':
-      return 'com.widevine.alpha';
+      return CLIENT_KEY_SYSTEMS.widevine;
     case 'com.microsoft.playready':
     case 'com.microsoft.playready.recommendation':
     case 'com.microsoft.playready.recommendation.3000':
     case 'com.microsoft.playready.hardware':
-      return 'com.microsoft.playready.recommendation';
+      return CLIENT_KEY_SYSTEMS.playready;
     default:
       throw new Error(`Unsupported DRM key system: ${keySystem}`);
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -145,9 +145,7 @@ export const bytesToString = (bytes: Uint8Array) => {
   return String.fromCharCode.apply(null, Array.from(bytes));
 };
 
-export const bytesToBase64 = (uint8array: Uint8Array) => {
-  return btoa(String.fromCharCode.apply(null, Array.from(uint8array)));
-};
+export const bytesToBase64 = (data: BytesLike) => fromBuffer(toBytes(data)).toBase64();
 
 export const stringToBytes = (string: string) => {
   return Uint8Array.from(string.split('').map((x) => x.charCodeAt(0)));

--- a/test/drm-bridge.test.ts
+++ b/test/drm-bridge.test.ts
@@ -2,16 +2,18 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import content from '../src/extension/entrypoints/content';
+import { appStorage, type Settings } from '../src/extension/utils/storage';
 import { sendDrmMessage } from '../src/extension/utils/drm-bridge';
 
 vi.mock('../src/extension/utils/storage', () => ({
-  appStorage: { settings: { getValue: async () => ({}) } },
+  appStorage: { settings: { getValue: vi.fn<() => Promise<Partial<Settings>>>() } },
 }));
 
 const postMessage = vi.fn<(message: { requestId: string }, origin: string) => void>();
 const sendMessage = vi.fn<(message: unknown) => Promise<unknown>>();
 
 beforeEach(() => {
+  vi.mocked(appStorage.settings.getValue).mockResolvedValue(null);
   vi.useFakeTimers();
   vi.stubGlobal(
     'window',
@@ -109,8 +111,8 @@ const startContentBridge = async () => {
   vi.spyOn(browser.runtime, 'sendMessage').mockImplementation(sendMessage);
   vi.spyOn(browser.runtime, 'getURL').mockImplementation((path) => path);
   vi.stubGlobal('document', {
-    createElement: () => ({}),
-    head: { appendChild: vi.fn() },
+    createElement: () => ({ remove: vi.fn() }),
+    head: { appendChild: (element: { onload: () => void }) => element.onload() },
   });
   await content.main({} as ContentScriptContext);
   postMessage.mockImplementation((data) => {
@@ -170,3 +172,54 @@ test.each([undefined, 'license challenge', { keys: [{ id: 'key-id', value: 'key-
     expect(vi.getTimerCount()).toBe(0);
   },
 );
+
+test('registers the bridge before loading scripts and waits for manifest initialization', async () => {
+  vi.mocked(appStorage.settings.getValue).mockResolvedValue({
+    emeInterception: true,
+    spoofing: true,
+    clientPlayback: true,
+    requestInterception: true,
+    theme: 'auto',
+  });
+  vi.spyOn(browser.runtime, 'getURL').mockImplementation((path) => path);
+  const listen = vi.spyOn(window, 'addEventListener');
+  const scripts: { src: string; onload: () => void; remove: () => void }[] = [];
+  vi.stubGlobal('document', {
+    createElement: () => ({ remove: vi.fn() }),
+    head: {
+      appendChild: (element: (typeof scripts)[number]) => {
+        expect(listen).toHaveBeenCalledWith('message', expect.any(Function), false);
+        scripts.push(element);
+      },
+    },
+  });
+  const starting = content.main({} as ContentScriptContext);
+  await vi.waitFor(() => expect(scripts).toHaveLength(1));
+  expect(scripts[0]?.src).toBe('/manifest.js');
+  scripts[0]?.onload();
+  await vi.waitFor(() => expect(scripts).toHaveLength(3));
+  expect(scripts.map((script) => script.src)).toEqual([
+    '/manifest.js',
+    '/network.js',
+    '/eme-playback.js',
+  ]);
+  scripts[1]?.onload();
+  scripts[2]?.onload();
+  await starting;
+  for (const script of scripts) expect(script.remove).toHaveBeenCalledOnce();
+});
+
+test('reports script load failures and removes the failed element', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const remove = vi.fn();
+  vi.stubGlobal('document', {
+    createElement: () => ({ remove }),
+    head: { appendChild: (element: { onerror: () => void }) => element.onerror() },
+  });
+  await content.main({} as ContentScriptContext);
+  expect(warn).toHaveBeenCalledWith(
+    '[okova] Script injection failed',
+    expect.objectContaining({ message: 'Failed to inject /manifest.js' }),
+  );
+  expect(remove).toHaveBeenCalledOnce();
+});

--- a/test/drm-playback.test.ts
+++ b/test/drm-playback.test.ts
@@ -342,7 +342,7 @@ test.for(['com.microsoft.playready.recommendation.3000', 'com.microsoft.playread
       name: 'NotSupportedError',
     });
     expect(nativeRequest).not.toHaveBeenCalled();
-    expect(sendDrmMessage).not.toHaveBeenCalled();
+    expect(sendDrmMessage).toHaveBeenCalledExactlyOnceWith({ action: 'playback-config' });
   },
 );
 
@@ -356,4 +356,70 @@ test('rejects empty server certificates', async () => {
   const access = await navigator.requestMediaKeySystemAccess('com.widevine.alpha', [{}]);
   const mediaKeys = await access.createMediaKeys();
   await expect(mediaKeys.setServerCertificate(new Uint8Array())).rejects.toBeInstanceOf(TypeError);
+});
+
+test.for([
+  'com.widevine.alpha',
+  'com.microsoft.playready',
+  'com.microsoft.playready.recommendation',
+  'com.microsoft.playready.hardware',
+  'com.microsoft.playready.recommendation.3000',
+])('uses native %s when the active client has been removed', async (keySystem) => {
+  vi.mocked(sendDrmMessage).mockResolvedValueOnce(null);
+  const configurations = [{ videoCapabilities: [{ contentType }] }];
+  const nativeAccess = new NativeAccess(configurations[0]!);
+  nativeRequest.mockResolvedValueOnce(nativeAccess);
+  const access = await navigator.requestMediaKeySystemAccess(keySystem, configurations);
+  expect(access).toBe(nativeAccess);
+  expect(nativeRequest).toHaveBeenCalledExactlyOnceWith(keySystem, configurations);
+});
+
+test('delivers the regenerated challenge after a service certificate, then installs license keys', async () => {
+  const session = await createSession();
+  const messages: string[] = [];
+  session.addEventListener('message', (event) => {
+    if (event instanceof NativeMessageEvent) messages.push(new TextDecoder().decode(event.message));
+  });
+  await session.generateRequest('cenc', createInitData());
+  await vi.runAllTimersAsync();
+  messages.length = 0;
+  vi.mocked(sendDrmMessage).mockResolvedValueOnce({ challenge: btoa('private challenge') });
+  await session.update(new Uint8Array([8, 5]));
+  expect(messages).toEqual([]);
+  expect(nativeUpdate).not.toHaveBeenCalled();
+  await vi.runAllTimersAsync();
+  expect(messages).toEqual(['private challenge']);
+  await session.update(new Uint8Array([8, 2]));
+  expect(nativeUpdate).toHaveBeenCalledOnce();
+});
+
+test.for([undefined, { challenge: '' }])(
+  'rejects unsuccessful certificate updates: %j',
+  async (result) => {
+    const session = await createSession();
+    await session.generateRequest('cenc', createInitData());
+    await vi.runAllTimersAsync();
+    const listener = vi.fn();
+    session.addEventListener('message', listener);
+    vi.mocked(sendDrmMessage).mockResolvedValueOnce(result);
+    await expect(session.update(new Uint8Array([8, 5]))).rejects.toMatchObject({
+      name: 'OperationError',
+    });
+    await vi.runAllTimersAsync();
+    expect(listener).not.toHaveBeenCalled();
+    expect(nativeUpdate).not.toHaveBeenCalled();
+  },
+);
+
+test('does not deliver a regenerated challenge after close', async () => {
+  const session = await createSession();
+  await session.generateRequest('cenc', createInitData());
+  await vi.runAllTimersAsync();
+  const listener = vi.fn();
+  session.addEventListener('message', listener);
+  vi.mocked(sendDrmMessage).mockResolvedValueOnce({ challenge: btoa('private challenge') });
+  await session.update(new Uint8Array([8, 5]));
+  await session.close();
+  await vi.runAllTimersAsync();
+  expect(listener).not.toHaveBeenCalled();
 });

--- a/test/drm-playback.test.ts
+++ b/test/drm-playback.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { installDrmPlayback } from '../src/extension/utils/drm-playback';
+import { sendDrmMessage } from '../src/extension/utils/drm-bridge';
+import { createPsshBox, serializePsshBox, PSSH_SYSTEM_IDS } from '../src/lib/pssh';
+
+vi.mock('../src/extension/utils/drm-bridge', () => ({ sendDrmMessage: vi.fn() }));
+
+const kid = '00112233445566778899aabbccddeeff';
+const key = 'ffeeddccbbaa99887766554433221100';
+const contentType = 'video/mp4; codecs="avc1.42E01E"';
+const nativeUpdate = vi.fn<(response: BufferSource) => Promise<void>>();
+const nativeGenerate = vi.fn<(type: string, data: BufferSource) => Promise<void>>();
+
+class NativeMessageEvent extends Event {
+  readonly message: ArrayBuffer;
+  readonly messageType: MediaKeyMessageType;
+  constructor(type: string, init: MediaKeyMessageEventInit) {
+    super(type, init);
+    this.message = init.message;
+    this.messageType = init.messageType;
+  }
+}
+
+class NativeSession extends EventTarget {
+  sessionId = '';
+  closedResult = Promise.withResolvers<MediaKeySessionClosedReason>();
+  closed = this.closedResult.promise;
+  async generateRequest(type: string, data: BufferSource) {
+    await nativeGenerate(type, data);
+    this.sessionId = 'native-clearkey-session';
+    this.dispatchEvent(
+      new NativeMessageEvent('message', {
+        messageType: 'license-request',
+        message: new TextEncoder().encode('native ClearKey request').buffer,
+      }),
+    );
+  }
+  update(response: BufferSource) {
+    return nativeUpdate(response);
+  }
+  async close() {
+    this.closedResult.resolve('closed-by-application');
+  }
+}
+class NativeKeys {
+  createSession() {
+    return new NativeSession();
+  }
+}
+class NativeAccess {
+  keySystem = 'org.w3.clearkey';
+  constructor(readonly configuration: MediaKeySystemConfiguration) {}
+  getConfiguration() {
+    return structuredClone(this.configuration);
+  }
+  async createMediaKeys() {
+    return new NativeKeys();
+  }
+}
+const nativeRequest = vi.fn(
+  async (keySystem: string, configurations: MediaKeySystemConfiguration[]) => {
+    if (keySystem !== 'org.w3.clearkey') throw new DOMException('Unavailable', 'NotSupportedError');
+    return new NativeAccess(configurations[0]!);
+  },
+);
+
+const mockSessionBridge = ({
+  keySystem = 'com.widevine.alpha',
+  challenge = 'Widevine challenge',
+  keys = [{ id: kid, value: key }],
+} = {}) => {
+  vi.mocked(sendDrmMessage).mockImplementation(async (message) => {
+    if (message.action === 'playback-config') return keySystem;
+    if (message.action === 'license-request') return btoa(challenge);
+    if (message.action === 'update') return { keys };
+  });
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('navigator', { requestMediaKeySystemAccess: nativeRequest });
+  vi.stubGlobal('window', { MPD_LIST: new Map() });
+  vi.stubGlobal('MediaKeySystemAccess', NativeAccess);
+  vi.stubGlobal('MediaKeys', NativeKeys);
+  vi.stubGlobal('MediaKeySession', NativeSession);
+  vi.stubGlobal('MediaKeyMessageEvent', NativeMessageEvent);
+  nativeGenerate.mockResolvedValue();
+  nativeUpdate.mockResolvedValue();
+  mockSessionBridge();
+  installDrmPlayback();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+const createSession = async () => {
+  const access = await navigator.requestMediaKeySystemAccess('com.widevine.alpha', [
+    {
+      initDataTypes: ['cenc'],
+      videoCapabilities: [{ contentType, robustness: 'SW_SECURE_CRYPTO' }],
+    },
+  ]);
+  expect(access.keySystem).toBe('com.widevine.alpha');
+  expect(access.getConfiguration().videoCapabilities?.[0]?.robustness).toBe('SW_SECURE_CRYPTO');
+  const mediaKeys = await access.createMediaKeys();
+  expect(mediaKeys).toBeInstanceOf(NativeKeys);
+  return mediaKeys.createSession();
+};
+
+const createInitData = (
+  systemId: (typeof PSSH_SYSTEM_IDS)[keyof typeof PSSH_SYSTEM_IDS] = PSSH_SYSTEM_IDS.widevine,
+) =>
+  new Uint8Array(
+    serializePsshBox(
+      createPsshBox({
+        systemId,
+        version: 1,
+        keyIds: [kid],
+      }),
+    ),
+  );
+
+test('uses real ClearKey objects, hides native messages, and installs extracted keys before update resolves', async () => {
+  const session = await createSession();
+  const messages: string[] = [];
+  session.addEventListener('message', (event) => {
+    if (event instanceof NativeMessageEvent) messages.push(new TextDecoder().decode(event.message));
+  });
+  await session.generateRequest('cenc', createInitData());
+  expect(messages).toEqual([]);
+  await vi.runAllTimersAsync();
+  expect(messages).toEqual(['Widevine challenge']);
+  expect(nativeRequest).toHaveBeenCalledWith('org.w3.clearkey', [
+    expect.objectContaining({
+      initDataTypes: ['keyids'],
+      videoCapabilities: [{ contentType, robustness: '', encryptionScheme: 'cenc' }],
+    }),
+  ]);
+  expect(nativeGenerate.mock.calls[0]?.[0]).toBe('keyids');
+  const installed = Promise.withResolvers<void>();
+  nativeUpdate.mockReturnValueOnce(installed.promise);
+  const updating = session.update(new Uint8Array([1, 2, 3]));
+  let resolved = false;
+  void updating.then(() => {
+    resolved = true;
+  });
+  await vi.waitFor(() => expect(nativeUpdate).toHaveBeenCalledOnce());
+  expect(resolved).toBe(false);
+  const response = nativeUpdate.mock.calls[0]?.[0];
+  expect(response).toBeInstanceOf(Uint8Array);
+  expect(JSON.parse(new TextDecoder().decode(response))).toEqual({
+    keys: [{ kty: 'oct', kid: 'ABEiM0RVZneImaq7zN3u_w', k: '_-7dzLuqmYh3ZlVEMyIRAA' }],
+    type: 'temporary',
+  });
+  installed.resolve();
+  await updating;
+  await session.close();
+  expect(sendDrmMessage).toHaveBeenCalledWith(expect.objectContaining({ action: 'close' }));
+});
+
+test('rejects an unsuccessful extraction without forwarding a Widevine license to ClearKey', async () => {
+  mockSessionBridge({ keys: [] });
+  const session = await createSession();
+  await session.generateRequest('cenc', createInitData());
+  await expect(session.update(new Uint8Array([1, 2, 3]))).rejects.toThrow();
+  expect(nativeUpdate).not.toHaveBeenCalled();
+});
+
+test.for([
+  { videoCapabilities: [{ contentType, robustness: 'HW_SECURE_ALL' }] },
+  { videoCapabilities: [{ contentType, encryptionScheme: 'cbcs' }] },
+  { videoCapabilities: [{ contentType }], sessionTypes: ['persistent-license'] },
+])('does not advertise unsupported configurations: %j', async (configuration) => {
+  await expect(
+    navigator.requestMediaKeySystemAccess('com.widevine.alpha', [configuration]),
+  ).rejects.toMatchObject({ name: 'NotSupportedError' });
+  expect(nativeRequest).not.toHaveBeenCalled();
+});
+
+test.for(['com.microsoft.playready', 'com.microsoft.playready.recommendation'])(
+  'adapts %s using PlayReady PSSH IDs and license messages',
+  async (keySystem) => {
+    mockSessionBridge({
+      keySystem: 'com.microsoft.playready.recommendation',
+      challenge: '<soap:Envelope/>',
+    });
+    const access = await navigator.requestMediaKeySystemAccess(keySystem, [
+      {
+        videoCapabilities: [{ contentType, robustness: '2000' }],
+      },
+    ]);
+    expect(access.keySystem).toBe(keySystem);
+    const mediaKeys = await access.createMediaKeys();
+    await expect(mediaKeys.setServerCertificate(new Uint8Array([1]))).resolves.toBe(false);
+    const session = mediaKeys.createSession();
+    let challengeXml = '';
+    session.addEventListener('message', (event) => {
+      if (event instanceof NativeMessageEvent) {
+        challengeXml = new TextDecoder('utf-16le').decode(event.message);
+      }
+    });
+    await session.generateRequest('cenc', createInitData(PSSH_SYSTEM_IDS.playready));
+    await vi.runAllTimersAsync();
+    expect(challengeXml).toContain('<PlayReadyKeyMessage type="LicenseAcquisition">');
+    expect(challengeXml).toContain(
+      `<Challenge encoding="base64encoded">${btoa('<soap:Envelope/>')}</Challenge>`,
+    );
+    expect(challengeXml).toContain('<name>Content-Type</name>');
+    await session.update(new TextEncoder().encode('<License/>'));
+    expect(sendDrmMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'update', keySystem }),
+    );
+    expect(JSON.parse(new TextDecoder().decode(nativeUpdate.mock.calls[0]?.[0])).keys[0].kid).toBe(
+      'ABEiM0RVZneImaq7zN3u_w',
+    );
+  },
+);
+
+test('does not advertise a DRM system that differs from the active client', async () => {
+  await expect(
+    navigator.requestMediaKeySystemAccess('com.microsoft.playready.recommendation', [
+      {
+        videoCapabilities: [{ contentType }],
+      },
+    ]),
+  ).rejects.toMatchObject({ name: 'NotSupportedError' });
+  expect(nativeRequest).not.toHaveBeenCalled();
+});
+
+test('encodes a large sliced response without including surrounding bytes or overflowing the call stack', async () => {
+  const session = await createSession();
+  await session.generateRequest('cenc', createInitData());
+  const length = 256 * 1024;
+  const backing = new Uint8Array(length + 2).fill(7);
+  backing[0] = 99;
+  backing[length + 1] = 99;
+  await session.update(new DataView(backing.buffer, 1, length));
+  const encoded = vi
+    .mocked(sendDrmMessage)
+    .mock.calls.find(([message]) => message.action === 'update')?.[0].messageBase64;
+  if (typeof encoded !== 'string') throw new Error('Expected an encoded response');
+  const decoded = Buffer.from(encoded, 'base64');
+  expect(decoded.length).toBe(length);
+  expect(decoded.every((byte) => byte === 7)).toBe(true);
+});

--- a/test/drm-playback.test.ts
+++ b/test/drm-playback.test.ts
@@ -245,3 +245,115 @@ test('encodes a large sliced response without including surrounding bytes or ove
   expect(decoded.length).toBe(length);
   expect(decoded.every((byte) => byte === 7)).toBe(true);
 });
+
+test('reinstalling playback leaves the installed adapter unchanged', async () => {
+  const installedRequest = navigator.requestMediaKeySystemAccess;
+  installDrmPlayback();
+  expect(navigator.requestMediaKeySystemAccess).toBe(installedRequest);
+  const session = await createSession();
+  await session.generateRequest('cenc', createInitData());
+  expect(nativeGenerate).toHaveBeenCalledOnce();
+  expect(
+    vi
+      .mocked(sendDrmMessage)
+      .mock.calls.filter(([message]) => message.action === 'playback-config'),
+  ).toHaveLength(1);
+});
+
+test('rejects updates before or during initialization and duplicate generation', async () => {
+  const session = await createSession();
+  await expect(session.update(new Uint8Array([1]))).rejects.toMatchObject({
+    name: 'InvalidStateError',
+  });
+  const generated = Promise.withResolvers<void>();
+  nativeGenerate.mockReturnValueOnce(generated.promise);
+  const generating = session.generateRequest('cenc', createInitData());
+  await expect(session.update(new Uint8Array([1]))).rejects.toMatchObject({
+    name: 'InvalidStateError',
+  });
+  await expect(session.generateRequest('cenc', createInitData())).rejects.toMatchObject({
+    name: 'InvalidStateError',
+  });
+  generated.resolve();
+  await generating;
+});
+
+test('failed generation leaves updates invalid without replaying its error', async () => {
+  nativeGenerate.mockRejectedValueOnce(new Error('Native generation failed'));
+  const session = await createSession();
+  await expect(session.generateRequest('cenc', createInitData())).rejects.toThrow(
+    'Native generation failed',
+  );
+  await expect(session.update(new Uint8Array([1]))).rejects.toMatchObject({
+    name: 'InvalidStateError',
+  });
+  await expect(session.generateRequest('cenc', createInitData())).rejects.toMatchObject({
+    name: 'InvalidStateError',
+  });
+  expect(nativeUpdate).not.toHaveBeenCalled();
+});
+
+test('closing before challenge delivery suppresses the message', async () => {
+  const session = await createSession();
+  const listener = vi.fn();
+  session.addEventListener('message', listener);
+  await session.generateRequest('cenc', createInitData());
+  await session.close();
+  await vi.runAllTimersAsync();
+  expect(listener).not.toHaveBeenCalled();
+  await expect(session.update(new Uint8Array([1]))).rejects.toMatchObject({
+    name: 'InvalidStateError',
+  });
+});
+
+test('closing during native generation prevents a background session from being created', async () => {
+  const session = await createSession();
+  const generated = Promise.withResolvers<void>();
+  nativeGenerate.mockReturnValueOnce(generated.promise);
+  const generating = session.generateRequest('cenc', createInitData());
+  await session.close();
+  generated.resolve();
+  await expect(generating).rejects.toMatchObject({ name: 'InvalidStateError' });
+  expect(sendDrmMessage).not.toHaveBeenCalledWith(
+    expect.objectContaining({ action: 'generateRequest' }),
+  );
+});
+
+test.for(['org.w3.clearkey', 'com.apple.fps'])(
+  'passes %s directly to the browser',
+  async (keySystem) => {
+    const configurations = [{ videoCapabilities: [{ contentType }] }];
+    if (keySystem === 'org.w3.clearkey') {
+      await navigator.requestMediaKeySystemAccess(keySystem, configurations);
+    } else {
+      await expect(
+        navigator.requestMediaKeySystemAccess(keySystem, configurations),
+      ).rejects.toMatchObject({ name: 'NotSupportedError' });
+    }
+    expect(nativeRequest).toHaveBeenCalledWith(keySystem, configurations);
+    expect(sendDrmMessage).not.toHaveBeenCalled();
+  },
+);
+
+test.for(['com.microsoft.playready.recommendation.3000', 'com.microsoft.playready.hardware'])(
+  'rejects hardware DRM %s',
+  async (keySystem) => {
+    await expect(navigator.requestMediaKeySystemAccess(keySystem, [{}])).rejects.toMatchObject({
+      name: 'NotSupportedError',
+    });
+    expect(nativeRequest).not.toHaveBeenCalled();
+    expect(sendDrmMessage).not.toHaveBeenCalled();
+  },
+);
+
+test('propagates playback configuration bridge failures', async () => {
+  vi.mocked(sendDrmMessage).mockRejectedValueOnce(new Error('Bridge unavailable'));
+  await expect(createSession()).rejects.toThrow('Bridge unavailable');
+  expect(nativeRequest).not.toHaveBeenCalled();
+});
+
+test('rejects empty server certificates', async () => {
+  const access = await navigator.requestMediaKeySystemAccess('com.widevine.alpha', [{}]);
+  const mediaKeys = await access.createMediaKeys();
+  await expect(mediaKeys.setServerCertificate(new Uint8Array())).rejects.toBeInstanceOf(TypeError);
+});

--- a/test/e2e/bitmovin.test.ts
+++ b/test/e2e/bitmovin.test.ts
@@ -6,6 +6,12 @@ import { chromium } from 'playwright';
 import { expect, test } from 'vitest';
 import { z } from 'zod';
 
+declare global {
+  interface Window {
+    okovaPlaybackProbe: { requestedKeySystems: string[]; attachedKeySystems: string[] };
+  }
+}
+
 declare const chrome: typeof import('wxt/browser').browser;
 
 const storedKeys = z.array(
@@ -18,12 +24,15 @@ const storedKeys = z.array(
   }),
 );
 
-test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabled', async ({
-  skip,
-}) => {
-  const clientPath = process.env.VITEST_WIDEVINE_CLIENT_PATH;
+test.for([
+  { drm: 'widevine', playback: false },
+  { drm: 'widevine', playback: true },
+  { drm: 'playready', playback: true },
+])('captures Bitmovin $drm keys with playback=$playback', async ({ drm, playback }, { skip }) => {
+  const clientPath =
+    drm === 'playready' ? process.env.VITEST_PRD_PATH : process.env.VITEST_WIDEVINE_CLIENT_PATH;
   if (!clientPath || !existsSync(resolve(clientPath))) {
-    skip('VITEST_WIDEVINE_CLIENT_PATH is unset or the .wvd file does not exist');
+    skip('Set VITEST_WIDEVINE_CLIENT_PATH or VITEST_PRD_PATH to a local client file');
     return;
   }
 
@@ -31,32 +40,54 @@ test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabl
   const profilePath = await mkdtemp(join(tmpdir(), 'okova-e2e-'));
   try {
     const context = await chromium.launchPersistentContext(profilePath, {
-      channel: 'chromium',
+      channel: process.env.VITEST_CHROMIUM_BINARY ? undefined : 'chromium',
+      executablePath: process.env.VITEST_CHROMIUM_BINARY,
       headless: true,
       // Disabling component updates also prevents native Widevine from registering.
-      ignoreDefaultArgs: ['--disable-component-update'],
+      ignoreDefaultArgs: playback ? [] : ['--disable-component-update'],
       args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
     });
     try {
       context.setDefaultTimeout(20_000);
       const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
       const popupUrl = `chrome-extension://${new URL(worker.url()).hostname}/popup.html`;
+      const pageErrors: string[] = [];
+      context.on('page', (page) =>
+        page.on('pageerror', (error) => {
+          // Website analytics and cookie scripts are outside this extension/player check.
+          if (
+            page.url().startsWith('chrome-extension://') ||
+            error.stack?.includes('chrome-extension://') ||
+            error.stack?.includes('bitmovinplayer.js')
+          ) {
+            pageErrors.push(`${page.url()}: ${error.stack ?? error.message}`);
+          }
+        }),
+      );
       const popup = await context.newPage();
-      await popup.goto(popupUrl);
-      await popup.getByRole('link', { name: 'Settings', exact: true }).click();
-      const spoofingRow = popup.locator('label').filter({ hasText: 'Spoofing' });
-      const spoofing = spoofingRow.getByRole('checkbox');
-      await spoofingRow.locator('label').click();
-      await expect.poll(() => spoofing.isChecked()).toBe(true);
-      await popup.goto(popupUrl);
-      await popup.getByRole('link', { name: 'Settings', exact: true }).click();
-      await expect.poll(() => spoofing.isChecked()).toBe(true);
-
+      await popup.setViewportSize({ width: 500, height: 600 });
       await popup.goto(popupUrl);
       await popup.getByRole('link', { name: 'Clients', exact: true }).click();
       await popup.getByLabel('Import client').setInputFiles(resolve(clientPath));
-      await expect.poll(() => popup.getByText(/^Widevine L\d$/).count()).toBe(1);
-      // The UI updates before the imported client has finished writing to storage.
+      await expect
+        .poll(() =>
+          popup.getByText(drm === 'widevine' ? /^Widevine L\d$/ : /^PlayReady SL\d+$/).count(),
+        )
+        .toBe(1);
+      await popup.getByText(drm === 'widevine' ? /^Widevine L\d$/ : /^PlayReady SL\d+$/).hover();
+      await popup.locator('svg').filter({ hasText: 'Client Settings' }).click();
+      await expect
+        .poll(() =>
+          popup
+            .getByText(drm === 'widevine' ? 'Google Widevine' : 'Microsoft PlayReady', {
+              exact: true,
+            })
+            .count(),
+        )
+        .toBe(1);
+      await popup.goto(popupUrl);
+      // Imports must finish persisting before navigating away.
+
       await expect
         .poll(() =>
           worker.evaluate(async () => {
@@ -66,7 +97,46 @@ test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabl
           }),
         )
         .toBe(true);
-      // Returning to the dashboard persists the sole imported client as active.
+      await popup.goto(popupUrl);
+      await popup.getByRole('link', { name: 'Settings', exact: true }).click();
+      const playbackRow = popup
+        .locator('label')
+        .filter({ hasText: 'Use the active client to play protected content' });
+      const spoofingRow = popup
+        .locator('label')
+        .filter({ hasText: 'Use the active client to obtain content keys' });
+      await expect.poll(() => spoofingRow.getByRole('checkbox').isChecked()).toBe(true);
+      await expect.poll(() => playbackRow.getByRole('checkbox').isChecked()).toBe(true);
+      expect(
+        await popup.evaluate(
+          () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+        ),
+        'Settings must fit the popup width',
+      ).toBe(true);
+      const interceptionRow = popup
+        .locator('label')
+        .filter({ hasText: 'Logging EME events and calls' });
+      await interceptionRow.locator('label').click();
+      await expect.poll(() => spoofingRow.getByRole('checkbox').isDisabled()).toBe(true);
+      await expect.poll(() => playbackRow.getByRole('checkbox').isDisabled()).toBe(true);
+      await interceptionRow.locator('label').click();
+      await expect.poll(() => spoofingRow.getByRole('checkbox').isDisabled()).toBe(false);
+      await expect.poll(() => playbackRow.getByRole('checkbox').isDisabled()).toBe(true);
+      await spoofingRow.locator('label').click();
+      await expect.poll(() => playbackRow.getByRole('checkbox').isDisabled()).toBe(false);
+      if (!playback) await playbackRow.locator('label').click();
+      await expect
+        .poll(() =>
+          worker.evaluate(async () => {
+            const raw: unknown = (await chrome.storage.local.get('settings')).settings;
+            const settings: unknown = typeof raw === 'string' ? JSON.parse(raw) : raw;
+            return typeof settings === 'object' && settings !== null && 'clientPlayback' in settings
+              ? settings.clientPlayback
+              : undefined;
+          }),
+        )
+        .toBe(playback);
+      // Import persists the first active client without requiring a dashboard visit.
       await popup.goto(popupUrl);
       await expect.poll(() => popup.getByText('Active', { exact: true }).count()).toBe(1);
       await expect
@@ -94,6 +164,38 @@ test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabl
           navigator.userAgent.replace('HeadlessChrome/', 'Chrome/'),
         ),
       });
+      if (playback) {
+        await demo.addInitScript(() => {
+          const probe: Window['okovaPlaybackProbe'] = {
+            requestedKeySystems: [],
+            attachedKeySystems: [],
+          };
+          window.okovaPlaybackProbe = probe;
+          const systems = new WeakMap<MediaKeys, string>();
+          const request = navigator.requestMediaKeySystemAccess.bind(navigator);
+          navigator.requestMediaKeySystemAccess = async (keySystem, configurations) => {
+            probe.requestedKeySystems.push(keySystem);
+            // Deterministically emulate a browser with no Widevine, even if installed globally.
+            if (
+              keySystem === 'com.widevine.alpha' ||
+              keySystem.startsWith('com.microsoft.playready')
+            )
+              throw new DOMException('Native DRM disabled by test', 'NotSupportedError');
+            return request(keySystem, configurations);
+          };
+          const create = MediaKeySystemAccess.prototype.createMediaKeys;
+          MediaKeySystemAccess.prototype.createMediaKeys = async function () {
+            const keys = await create.call(this);
+            systems.set(keys, this.keySystem);
+            return keys;
+          };
+          const attach = HTMLMediaElement.prototype.setMediaKeys;
+          HTMLMediaElement.prototype.setMediaKeys = async function (keys) {
+            await attach.call(this, keys);
+            if (keys) probe.attachedKeySystems.push(systems.get(keys) ?? 'unknown');
+          };
+        });
+      }
       const response = await demo.goto('https://bitmovin.com/demos/drm', {
         waitUntil: 'domcontentloaded',
       });
@@ -105,10 +207,10 @@ test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabl
       await expect
         .poll(() => demo.locator('#available-drm-systems').inputValue(), {
           timeout: 30_000,
-          message: 'The Bitmovin demo must detect native Widevine support in the test browser',
+          message: 'The Bitmovin demo must detect Widevine support through EME',
         })
-        .toBe('widevine');
-      // Native playback may reject the substituted license after Okova has captured its keys.
+        .toBe(drm);
+      // Start muted playback so autoplay policy cannot block the test.
       await demo.locator('#player-container video').evaluate((video: HTMLVideoElement) => {
         video.muted = true;
         void video.play().catch(() => {});
@@ -119,15 +221,56 @@ test('retrieves new Widevine keys from the Bitmovin DRM demo with Spoofing enabl
           async () =>
             (await readKeys()).some(
               (key) =>
-                key.drmSystem === 'W' &&
+                key.drmSystem === (drm === 'widevine' ? 'W' : 'P') &&
                 new URL(key.url).hostname === 'bitmovin.com' &&
                 key.createdAt >= startedAt &&
                 /^[0-9a-f]{32}$/i.test(key.id) &&
                 /^[0-9a-f]{32}$/i.test(key.value),
             ),
-          { timeout: 60_000, message: 'Expected a newly captured Widevine key from Bitmovin' },
+          { timeout: 60_000, message: `Expected a newly captured ${drm} key from Bitmovin` },
         )
         .toBe(true);
+
+      if (playback) {
+        const video = demo.locator('#player-container video');
+        const start = await video.evaluate((element: HTMLVideoElement) => {
+          const quality = element.getVideoPlaybackQuality();
+          return {
+            time: element.currentTime,
+            frames: quality.totalVideoFrames - quality.droppedVideoFrames,
+          };
+        });
+        await expect
+          .poll(
+            () =>
+              video.evaluate((element: HTMLVideoElement, initial) => {
+                const quality = element.getVideoPlaybackQuality();
+                return {
+                  advanced: element.currentTime > initial.time + 3,
+                  renderedFrames:
+                    quality.totalVideoFrames - quality.droppedVideoFrames > initial.frames + 5,
+                  error: element.error?.code ?? null,
+                  paused: element.paused,
+                };
+              }, start),
+            {
+              timeout: 30_000,
+              message: 'Native ClearKey must render frames and advance playback after key capture',
+            },
+          )
+          .toMatchObject({
+            advanced: true,
+            renderedFrames: true,
+            error: null,
+            paused: false,
+          });
+        const probe = await demo.evaluate(() => window.okovaPlaybackProbe);
+        expect(probe.requestedKeySystems).toContain('org.w3.clearkey');
+        expect(probe.attachedKeySystems).toContain('org.w3.clearkey');
+        expect(probe.attachedKeySystems).not.toContain('com.widevine.alpha');
+      }
+
+      expect(pageErrors, 'Popup and player should have no uncaught JavaScript errors').toEqual([]);
 
       // All Keys avoids changing the active website tab used by dashboard filtering.
       await popup.getByRole('link', { name: 'Keys', exact: true }).click();

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 test.each(
-  ['captured keys', 'rejected license', 'bridge failure'].flatMap((result) =>
+  ['captured keys', 'service certificate', 'rejected license', 'bridge failure'].flatMap((result) =>
     ['buffer', 'typed array slice', 'DataView slice'].map((input) => ({ result, input })),
   ),
 )(
@@ -79,6 +79,8 @@ test.each(
           { id: '00112233445566778899aabbccddeeff', value: 'ffeeddccbbaa99887766554433221100' },
         ],
       });
+    } else if (result === 'service certificate') {
+      capture.resolve({ challenge: btoa('private challenge') });
     } else if (result === 'bridge failure') {
       capture.reject(new Error('DRM bridge failed'));
     } else {

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -203,7 +203,8 @@ test('same-PSSH sessions keep their challenges and updates across tabs, frames a
 test('retains the session for a service certificate and cleans up failed license parsing', async () => {
   const send = startBackground();
   await send('generateRequest', 'one');
-  await send('update', 'one', {}, { message: { 0: 8, 1: 5 } });
+  const continuation = await send('update', 'one', {}, { message: { 0: 8, 1: 5 } });
+  expect(continuation).toEqual({ challenge: await send('license-request', 'one') });
   expect(Session.prototype.close).not.toHaveBeenCalled();
   expect(Session.prototype.waitForKeyStatusesChange).not.toHaveBeenCalled();
   await expect(send('license-request', 'one')).resolves.toEqual(expect.any(String));

--- a/test/playback-settings.test.ts
+++ b/test/playback-settings.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, test } from 'vitest';
+import { browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing';
+import { appStorage } from '../src/extension/utils/storage';
+
+beforeEach(() => fakeBrowser.reset());
+
+const preferences = {
+  spoofing: true,
+  emeInterception: true,
+  requestInterception: false,
+  theme: 'dark',
+};
+
+test.for([
+  { saved: { clientPlayback: true }, expected: true },
+  { saved: { clientPlayback: false }, expected: false },
+  { saved: { clientPlayback: true, clientPlayback: false }, expected: false },
+  { saved: {}, expected: false },
+])(
+  'reads playback preferences without losing existing choices: $saved',
+  async ({ saved, expected }) => {
+    await browser.storage.local.set({ settings: JSON.stringify({ ...preferences, ...saved }) });
+    const settings = await appStorage.settings.getValue();
+    expect(settings).toEqual({ ...preferences, clientPlayback: expected });
+    if (!settings) throw new Error('Expected saved settings');
+    await appStorage.settings.setValue(settings);
+    const stored = await browser.storage.local.get('settings');
+    if (typeof stored.settings !== 'string') throw new Error('Expected serialized settings');
+    expect(JSON.parse(stored.settings)).toEqual({ ...preferences, clientPlayback: expected });
+  },
+);

--- a/test/playback-settings.test.ts
+++ b/test/playback-settings.test.ts
@@ -15,7 +15,6 @@ const preferences = {
 test.for([
   { saved: { clientPlayback: true }, expected: true },
   { saved: { clientPlayback: false }, expected: false },
-  { saved: { clientPlayback: true, clientPlayback: false }, expected: false },
   { saved: {}, expected: false },
 ])(
   'reads playback preferences without losing existing choices: $saved',
@@ -30,3 +29,27 @@ test.for([
     expect(JSON.parse(stored.settings)).toEqual({ ...preferences, clientPlayback: expected });
   },
 );
+
+test('returns null when settings have never been saved', async () => {
+  await expect(appStorage.settings.getValue()).resolves.toBeNull();
+});
+
+test('normalizes playback defaults in watched settings too', async () => {
+  const changes: unknown[] = [];
+  const unwatch = appStorage.settings.watch((value, previous) => changes.push({ value, previous }));
+  try {
+    await browser.storage.local.set({ settings: JSON.stringify(preferences) });
+    await browser.storage.local.set({
+      settings: JSON.stringify({ ...preferences, clientPlayback: true }),
+    });
+    expect(changes).toEqual([
+      { value: { ...preferences, clientPlayback: false }, previous: null },
+      {
+        value: { ...preferences, clientPlayback: true },
+        previous: { ...preferences, clientPlayback: false },
+      },
+    ]);
+  } finally {
+    unwatch();
+  }
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,6 +1,9 @@
 import { dirname, resolve } from 'node:path';
+import { loadEnv } from 'vite';
 import { defineConfig } from 'wxt';
 import arraybuffer from 'vite-plugin-arraybuffer';
+
+const devEnv = loadEnv('development', process.cwd(), 'WXT_');
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
@@ -11,14 +14,24 @@ export default defineConfig({
     host_permissions: ['https://*/*'],
     web_accessible_resources: [
       {
-        resources: ['eme.js', 'network.js', 'manifest.js'],
+        resources: ['eme.js', 'eme-playback.js', 'network.js', 'manifest.js'],
         matches: ['<all_urls>'],
       },
     ],
   },
   webExt: {
     chromiumArgs: ['--user-data-dir=./.wxt/chrome-data'],
-    disabled: true,
+    disabled: devEnv.WXT_BROWSER_AUTOSTART === 'false',
+    binaries: devEnv.WXT_CHROMIUM_BINARY ? { chrome: devEnv.WXT_CHROMIUM_BINARY } : undefined,
+  },
+  imports: {
+    presets: [
+      // Adds SolidJS reactive primitives to WXT's global auto-imports
+      {
+        package: 'solid-js',
+        imports: ['createSignal', 'createEffect', 'createMemo', 'onMount', 'onCleanup'],
+      },
+    ],
   },
   modules: ['@wxt-dev/module-solid'],
   vite: () => ({


### PR DESCRIPTION
## Summary

- Add client-backed Widevine and PlayReady playback through EME interception.
- Add Playback settings and automatically enable DRM interception, spoofing, and playback when importing a client.
- Adapt DRM sessions to native ClearKey sessions and forward extracted keys to the browser.
- Document playback requirements and limitations.

## Testing

- Added unit coverage for Widevine and PlayReady playback flows, session lifecycle, key installation, configuration filtering, and large responses.
- Expanded Bitmovin DRM E2E coverage.
- Added playback settings tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791277249&installation_model_id=424872&pr_number=66&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F66&signature=6914fa546293492efe5abfea443715cfaaf1c05205ff049290d129ec1d58ae6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->