### PR TITLE
fix(extension): make client storage transactional and id-based

### DIFF
--- a/src/extension/entrypoints/content.ts
+++ b/src/extension/entrypoints/content.ts
@@ -3,9 +3,9 @@ import { appStorage } from '@/utils/storage';
 import type { PublicPath } from 'wxt/browser';
 
 const getActiveClientKeySystem = async () => {
-  const client = await appStorage.clients.active.raw.getValue();
+  const client = await appStorage.clients.active.getInfo();
   if (!client) return null;
-  if (typeof client === 'string' || client.type === 'wvd') return CLIENT_KEY_SYSTEMS.widevine;
+  if (client.type === 'wvd') return CLIENT_KEY_SYSTEMS.widevine;
   if (client.type === 'remote') return client.config.keySystem;
   return CLIENT_KEY_SYSTEMS.playready;
 };

--- a/src/extension/entrypoints/popup/components/cell-import-client.tsx
+++ b/src/extension/entrypoints/popup/components/cell-import-client.tsx
@@ -1,93 +1,21 @@
 import { Component, createSignal, Show } from 'solid-js';
 import { z } from 'zod';
-import { RemoteClient } from '@/utils/remote-client';
-import { usesPywidevineFallback } from '@okova/lib/remote/pywidevine';
 import { SectionFooter } from './section';
 import { TbOutlineShieldPlus as TbShieldPlus } from 'solid-icons/tb';
-import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credentials';
-import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
 import { Cell } from './cell';
-import { useActiveClient, useClientImportWarning, useClients, useSettings } from '../utils/state';
+import { syncClients, useClientImportWarning, useSettings } from '../utils/state';
 import { appStorage, Client } from '@/utils/storage';
+import { parseClientFiles } from '../utils/client-import';
 
 export const CellImportClient: Component<{
   disabled?: boolean;
   onChange?: (client: Client) => void;
 }> = (props) => {
-  const [activeClient, setActiveClient] = useActiveClient();
-  const [settings, setSettings] = useSettings();
-  const [clients, setClients] = useClients();
+  const [, setSettings] = useSettings();
 
   const [, setImportWarning] = useClientImportWarning();
   const [error, setError] = createSignal<string>();
   const [isImporting, setIsImporting] = createSignal(false);
-
-  const importClient = async (files: File[]) => {
-    const jsonFiles = files.filter((file) => file.name.toLowerCase().endsWith('.json'));
-    if (jsonFiles.length) {
-      if (files.length !== 1) throw new Error('Select one remote JSON file at a time');
-      const file = jsonFiles[0]!;
-      if (file.size > 64 * 1024) throw new Error('Remote configuration must be smaller than 64 KB');
-      const config: unknown = JSON.parse(await file.text());
-      const client = await RemoteClient.from(config);
-      if (usesPywidevineFallback(config)) {
-        setImportWarning(
-          'DRM system not specified. Imported as Widevine. Add "security_level" to the JSON for better detection.',
-        );
-      }
-      return client;
-    }
-    const findFile = (query: string) =>
-      files
-        .find((file) => file.name.includes(query))
-        ?.arrayBuffer()
-        .then((buffer) => new Uint8Array(buffer));
-
-    // Widevine
-    const wvd = await findFile('wvd');
-    const id = await findFile('client');
-    const key = await findFile('key');
-    if (wvd) {
-      return WidevineDeviceCredentials.from({ wvd });
-    } else if (id && key) {
-      return WidevineDeviceCredentials.from({ id, key });
-    }
-
-    // PlayReady
-    const prd = await findFile('prd');
-    const bgroupcert = await findFile('bgroupcert');
-    const zgpriv = await findFile('zgpriv');
-    if (prd) {
-      return PlayReadyDeviceCredentials.from({ prd });
-    } else if (bgroupcert && zgpriv) {
-      return PlayReadyDeviceCredentials.from({
-        groupKey: zgpriv,
-        groupCertificate: bgroupcert,
-      });
-    }
-  };
-
-  const completeClientImport = async (client: Client) => {
-    if (clients().some((existing) => existing.filename === client.filename))
-      throw new Error('This client is already imported');
-    const newClients = [...clients(), client];
-    await appStorage.clients.add(client);
-    if (!activeClient()) {
-      await appStorage.clients.active.setValue(client);
-      setActiveClient(client);
-    }
-    if (clients().length === 0) {
-      const nextSettings = {
-        ...settings,
-        emeInterception: true,
-        spoofing: true,
-        clientPlayback: true,
-      };
-      await appStorage.settings.setValue(nextSettings);
-      setSettings(nextSettings);
-    }
-    setClients(newClients);
-  };
 
   const handleFileChange = async (event: Event) => {
     if (!(event.target instanceof HTMLInputElement)) return;
@@ -98,11 +26,11 @@ export const CellImportClient: Component<{
     setImportWarning(undefined);
     setIsImporting(true);
     try {
-      if (clients().length >= 10) throw new Error('You can add a maximum of 10 clients');
-      const client = await importClient(files);
-      if (!client)
-        throw new Error('Select a WVD, PRD, device files, or JSON config for remote server');
-      await completeClientImport(client);
+      const { client, warning } = await parseClientFiles(files);
+      const snapshot = await appStorage.clients.import(client);
+      syncClients(snapshot);
+      if (snapshot.settings) setSettings(snapshot.settings);
+      setImportWarning(warning);
       props.onChange?.(client);
     } catch (error) {
       setImportWarning(undefined);

--- a/src/extension/entrypoints/popup/routes/client-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/client-settings.tsx
@@ -5,13 +5,15 @@ import { Client } from '@/utils/storage';
 import { Header } from '../components/header';
 import { Layout } from '../components/layout';
 import { List } from '../components/list';
-import { Section } from '../components/section';
+import { Section, SectionFooter } from '../components/section';
 import { Cell } from '../components/cell';
 import { WidevineDeviceCredentials } from '../../../../lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '../../../../lib/playready/device-credentials';
 
 type ClientSettingsProps = {
   client: Client;
+  error?: string;
+  disabled?: boolean;
   onExport: (client: Client) => void;
   onDelete: (client: Client) => void;
   onClose: () => void;
@@ -40,6 +42,11 @@ export const ClientSettings: Component<ClientSettingsProps> = (props) => {
   return (
     <Layout>
       <Header onClose={props.onClose}>Client Settings</Header>
+      <Show when={props.error}>
+        <SectionFooter>
+          <span role="alert">{props.error}</span>
+        </SectionFooter>
+      </Show>
       <List>
         <Section header="Details">
           <Cell class="capitalize group" subtitle={props.client.label}>
@@ -71,6 +78,7 @@ export const ClientSettings: Component<ClientSettingsProps> = (props) => {
           <Cell
             before={<TbOutlineTrash />}
             variant="danger"
+            disabled={props.disabled}
             onClick={() => props.onDelete(props.client)}
           >
             Delete

--- a/src/extension/entrypoints/popup/routes/clients.tsx
+++ b/src/extension/entrypoints/popup/routes/clients.tsx
@@ -1,8 +1,8 @@
 import { RemoteClient } from '@/utils/remote-client';
 import { BsCheckLg } from 'solid-icons/bs';
 import { TbOutlineSettings } from 'solid-icons/tb';
-import { appStorage, Client } from '@/utils/storage';
-import { useActiveClient, useClients } from '../utils/state';
+import { appStorage, Client, StoredClient } from '@/utils/storage';
+import { syncClients, useActiveClient, useClients } from '../utils/state';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
 import { Cell } from '../components/cell';
@@ -15,17 +15,30 @@ import { ClientSettings } from './client-settings';
 import { saveFile } from '../utils/file';
 
 export const Clients = () => {
-  const [activeClient, setActiveClient] = useActiveClient();
-  const [clients, setClients] = useClients();
+  const [activeClient] = useActiveClient();
+  const [clients] = useClients();
 
-  const setActive = async (client: Client) => {
-    setActiveClient(client);
-    await appStorage.clients.active.setValue(client);
+  const [error, setError] = createSignal<string>();
+  const [isSaving, setIsSaving] = createSignal(false);
+  const [openedClient, setOpenedClient] = createSignal<StoredClient | null>(null);
+
+  const changeClient = async (operation: () => Promise<void>) => {
+    if (isSaving()) return;
+    setIsSaving(true);
+    setError(undefined);
+    try {
+      await operation();
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to save client changes');
+    } finally {
+      setIsSaving(false);
+    }
   };
-
-  const isActive = (client: Client) => activeClient()?.filename === client.filename;
-
-  const [openedClient, setOpenedClient] = createSignal<Client | null>(null);
+  const setActive = (entry: StoredClient) =>
+    changeClient(async () => {
+      syncClients(await appStorage.clients.select(entry.id));
+    });
+  const isActive = (entry: StoredClient) => activeClient()?.id === entry.id;
 
   const exportClient = async (client: Client) => {
     const data = Uint8Array.from(await client.pack());
@@ -40,15 +53,11 @@ export const Clients = () => {
     await saveFile(data, filename);
   };
 
-  const removeClient = async (client: Client) => {
-    const newClients = clients().filter((c) => c.filename !== client.filename);
-    setClients(newClients);
-    await appStorage.clients.remove(client);
-    if (newClients.length === 0) setActiveClient(null);
-    if (isActive(client)) setActiveClient(newClients[0] ?? null);
-    await appStorage.clients.active.setValue(activeClient());
-    setOpenedClient(null);
-  };
+  const removeClient = (entry: StoredClient) =>
+    changeClient(async () => {
+      syncClients(await appStorage.clients.remove(entry.id));
+      setOpenedClient(null);
+    });
 
   const getClientLevel = (client: Client) => {
     if (client instanceof RemoteClient)
@@ -63,16 +72,23 @@ export const Clients = () => {
       when={!openedClient()}
       fallback={
         <ClientSettings
-          client={openedClient()!}
+          client={openedClient()!.client}
+          error={error()}
+          disabled={isSaving()}
           onExport={exportClient}
-          onDelete={removeClient}
+          onDelete={() => removeClient(openedClient()!)}
           onClose={() => setOpenedClient(null)}
         />
       }
     >
       <Layout>
         <Header backHref="/">Clients</Header>
-        <CellImportClient disabled={clients().length >= 10} />
+        <CellImportClient disabled={isSaving() || clients().length >= 10} />
+        <Show when={error()}>
+          <SectionFooter>
+            <span role="alert">{error()}</span>
+          </SectionFooter>
+        </Show>
         <Show when={clients().length === 0}>
           <SectionFooter>
             Import a WVD, PRD, raw device files, or JSON config for remote server
@@ -81,10 +97,11 @@ export const Clients = () => {
         <Show when={clients().length > 0}>
           <List class="mt-2">
             <Section header="Imported Clients" footer="You can add a maximum of 10 clients.">
-              {clients().map((client) => (
+              {clients().map((entry) => (
                 <Cell
                   class="capitalize group"
-                  subtitle={getClientLevel(client)}
+                  subtitle={getClientLevel(entry.client)}
+                  disabled={isSaving()}
                   after={
                     <div class="relative min-w-5 min-h-5">
                       <TbOutlineSettings
@@ -92,10 +109,11 @@ export const Clients = () => {
                         class="absolute top-0 text-blue-500 hover:text-blue-400 cursor-pointer w-5 h-5 transition-all translate-x-2 opacity-0 group-hover:opacity-100 group-hover:translate-x-0"
                         onClick={(event) => {
                           event.stopPropagation();
-                          setOpenedClient(client);
+                          setError(undefined);
+                          setOpenedClient(entry);
                         }}
                       />
-                      <Show when={isActive(client)}>
+                      <Show when={isActive(entry)}>
                         <BsCheckLg
                           title="Active Client"
                           class="text-blue-500 w-5 h-5 transition-transform group-hover:-translate-x-7"
@@ -103,9 +121,9 @@ export const Clients = () => {
                       </Show>
                     </div>
                   }
-                  onClick={() => setActive(client)}
+                  onClick={() => setActive(entry)}
                 >
-                  <div class="group-hover:w-[85%] truncate">{client.label}</div>
+                  <div class="group-hover:w-[85%] truncate">{entry.client.label}</div>
                 </Cell>
               ))}
             </Section>

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -15,7 +15,7 @@ import { Header } from '../components/header';
 import { CellImportClient } from '../components/cell-import-client';
 import { NoKeys } from '../components/no-keys';
 import { KeysList } from '../components/keys-list';
-import { appStorage, getRecentKeysForUrl, getWebsiteDomain, drmStages } from '@/utils/storage';
+import { getRecentKeysForUrl, getWebsiteDomain, drmStages } from '@/utils/storage';
 
 export const Dashboard = () => {
   const [failure] = useDrmFailure();
@@ -24,7 +24,7 @@ export const Dashboard = () => {
   const [recentKeys] = useRecentKeys();
   const [recentKeysByDomain] = useRecentKeysByDomain();
   const [activeTabUrl] = useActiveTabUrl();
-  const [activeClient, setActiveClient] = useActiveClient();
+  const [activeClient] = useActiveClient();
   const activeFailure = createMemo(() => failure()?.url === activeTabUrl() && failure());
   const activeDomain = createMemo(() => getWebsiteDomain(activeTabUrl()));
   const recentKeysHeader = createMemo(() =>
@@ -32,14 +32,6 @@ export const Dashboard = () => {
   );
   const activeDomainRecentKeys = createMemo(() => {
     return getRecentKeysForUrl(activeTabUrl(), recentKeysByDomain(), recentKeys());
-  });
-
-  createEffect(() => {
-    if (clients().length === 1) {
-      const client = clients()[0];
-      setActiveClient(client);
-      appStorage.clients.active.setValue(client);
-    }
   });
 
   return (
@@ -54,7 +46,7 @@ export const Dashboard = () => {
 
         <Show when={activeClient()}>
           <Cell class="capitalize" component="label" subtitle="Active">
-            {`${activeClient()?.label}`}
+            {`${activeClient()?.client.label}`}
           </Cell>
         </Show>
 

--- a/src/extension/entrypoints/popup/utils/client-import.ts
+++ b/src/extension/entrypoints/popup/utils/client-import.ts
@@ -1,0 +1,55 @@
+import { RemoteClient } from '@/utils/remote-client';
+import { usesPywidevineFallback } from '@okova/lib/remote/pywidevine';
+import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credentials';
+import { PlayReadyDeviceCredentials } from '@okova/lib/playready/device-credentials';
+import type { Client } from '@/utils/storage';
+
+// A selection is one packed device/configuration or one complete raw credential pair.
+export const parseClientFiles = async (
+  files: File[],
+): Promise<{ client: Client; warning?: string }> => {
+  const read = async (file: File) => new Uint8Array(await file.arrayBuffer());
+  const file = files[0];
+  if (files.length === 1 && file) {
+    const name = file.name.toLowerCase();
+    if (name.endsWith('.json')) {
+      if (file.size > 64 * 1024) throw new Error('Remote configuration must be smaller than 64 KB');
+      const config: unknown = JSON.parse(await file.text());
+      const client = await RemoteClient.from(config);
+      const warning = usesPywidevineFallback(config)
+        ? 'DRM system not specified. Imported as Widevine. Add "security_level" to the JSON for better detection.'
+        : undefined;
+      return { client, warning };
+    }
+    if (name.endsWith('.wvd')) {
+      return { client: await WidevineDeviceCredentials.from({ wvd: await read(file) }) };
+    }
+    if (name.endsWith('.prd')) {
+      return { client: await PlayReadyDeviceCredentials.from({ prd: await read(file) }) };
+    }
+  }
+  if (files.length === 2) {
+    const find = (...names: string[]) =>
+      files.find((file) => names.includes(file.name.toLowerCase()));
+    const id = find('device_client_id_blob');
+    const key = find('device_private_key');
+    if (id && key) {
+      return {
+        client: await WidevineDeviceCredentials.from({ id: await read(id), key: await read(key) }),
+      };
+    }
+    const groupCertificate = find('bgroupcert.dat', 'bgroupcert');
+    const groupKey = find('zgpriv.dat', 'zgpriv');
+    if (groupCertificate && groupKey) {
+      return {
+        client: await PlayReadyDeviceCredentials.from({
+          groupKey: await read(groupKey),
+          groupCertificate: await read(groupCertificate),
+        }),
+      };
+    }
+  }
+  throw new Error(
+    'Select one WVD, PRD, or remote JSON file, or a complete raw pair: device_client_id_blob + device_private_key, or bgroupcert.dat + zgpriv.dat',
+  );
+};

--- a/src/extension/entrypoints/popup/utils/state.ts
+++ b/src/extension/entrypoints/popup/utils/state.ts
@@ -1,4 +1,12 @@
-import { appStorage, Client, KeyInfo, RecentKeysByDomain, Settings } from '@/utils/storage';
+import {
+  appStorage,
+  StoredClient,
+  ClientSnapshot,
+  defaultSettings,
+  KeyInfo,
+  RecentKeysByDomain,
+  Settings,
+} from '@/utils/storage';
 import { getDrmFailureStorage, type DrmFailure } from '@/utils/storage';
 import { createSignal, onCleanup, onMount } from 'solid-js';
 import { createStore } from 'solid-js/store';
@@ -6,11 +14,18 @@ import { createStore } from 'solid-js/store';
 const clientImportWarningSignal = createSignal<string>();
 export const useClientImportWarning = () => clientImportWarningSignal;
 
-const clientsSignal = createSignal<Client[]>([]);
+const clientsSignal = createSignal<StoredClient[]>([]);
 export const useClients = () => clientsSignal;
 
-const activeClientSignal = createSignal<Client | null>(null);
+const activeClientSignal = createSignal<StoredClient | null>(null);
 export const useActiveClient = () => activeClientSignal;
+
+export const syncClients = (snapshot: ClientSnapshot) => {
+  clientsSignal[1](snapshot.clients);
+  activeClientSignal[1](
+    snapshot.clients.find((entry) => entry.id === snapshot.activeClientId) ?? null,
+  );
+};
 
 const recentKeysSignal = createSignal<KeyInfo[]>([]);
 export const useRecentKeys = () => recentKeysSignal;
@@ -24,20 +39,11 @@ export const useDrmFailure = () => drmFailureSignal;
 const activeTabUrlSignal = createSignal<string | null>(null);
 export const useActiveTabUrl = () => activeTabUrlSignal;
 
-const defaultSettings: Settings = {
-  emeInterception: true,
-  spoofing: false,
-  clientPlayback: false,
-  requestInterception: false,
-  theme: 'auto',
-};
 const settingsStore = createStore<Settings>(defaultSettings);
 export const useSettings = () => settingsStore;
 
 export const useSyncStateWithStorage = () => {
   const [, setSettings] = useSettings();
-  const [, setClients] = useClients();
-  const [, setActiveClient] = useActiveClient();
   const [, setRecentKeys] = useRecentKeys();
   const [, setRecentKeysByDomain] = useRecentKeysByDomain();
   const [, setActiveTabUrl] = useActiveTabUrl();
@@ -55,12 +61,12 @@ export const useSyncStateWithStorage = () => {
     if (settings) {
       const syncedSettings = { ...defaultSettings, ...settings };
       setSettings(syncedSettings);
-      if (!settings.theme) appStorage.settings.setValue(syncedSettings);
+      if (!settings.theme) await appStorage.settings.setValue(syncedSettings);
     } else {
-      appStorage.settings.setValue(defaultSettings);
+      await appStorage.settings.setValue(defaultSettings);
     }
 
-    appStorage.clients.getValue().then((clients) => setClients(clients));
+    appStorage.clients.getSnapshot().then(syncClients);
     browser.tabs.query({ active: true, currentWindow: true }).then(async ([tab]) => {
       if (isDisposed) return;
       setActiveTabUrl(tab?.url ?? null);
@@ -83,8 +89,5 @@ export const useSyncStateWithStorage = () => {
     appStorage.recentKeysByDomain.watch((newKeysByDomain) =>
       setRecentKeysByDomain(newKeysByDomain || {}),
     );
-    appStorage.clients.active
-      .getValue()
-      .then((activeClient) => activeClient && setActiveClient(activeClient));
   });
 };

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -96,9 +96,8 @@ export const fromInfoToClient = async (info: ClientInfo) => {
     return await PlayReadyDeviceCredentials.from({ prd: data });
   } else if (info.type === 'wvd') {
     return await WidevineDeviceCredentials.from({ wvd: data });
-  } else {
-    return null;
   }
+  throw new Error('Unsupported client type');
 };
 
 export const fromClientToInfo = async (client: Client): Promise<ClientInfo> => {
@@ -125,6 +124,162 @@ const normalizeSettings = (
   settings: Awaited<ReturnType<typeof storedSettings.getValue>>,
 ): Settings | null =>
   settings ? { ...settings, clientPlayback: settings.clientPlayback ?? false } : null;
+
+export const defaultSettings: Settings = {
+  emeInterception: true,
+  spoofing: false,
+  clientPlayback: false,
+  requestInterception: false,
+  theme: 'auto',
+};
+
+const clientRegistrySchema = z.object({
+  clients: z.array(z.object({ id: z.string(), info: clientInfoSchema })),
+  activeClientId: z.string().nullable(),
+});
+type ClientRegistry = z.infer<typeof clientRegistrySchema>;
+export type StoredClient = { id: string; client: Client };
+export type ClientSnapshot = { clients: StoredClient[]; activeClientId: string | null };
+const clientRegistry = storage.defineItem<ClientRegistry>('local:client-registry');
+const legacyClients = asJson(storage.defineItem<(string | ClientInfo)[]>('local:clients'));
+const legacyActiveClient = storage.defineItem<string | ClientInfo>('local:active-client');
+const withClientLock = <T>(operation: () => Promise<T>) =>
+  navigator.locks.request('okova:clients', operation);
+const sameClientInfo = (left: ClientInfo, right: ClientInfo) =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+// Keep legacy data as a backup. Once written, the registry is the only source of truth.
+const readClientRegistry = async (): Promise<ClientRegistry> => {
+  const stored = await clientRegistry.getValue();
+  if (stored) return clientRegistrySchema.parse(stored);
+  const registry: ClientRegistry = { clients: [], activeClientId: null };
+  const normalizeLegacy = async (value: string | ClientInfo) => {
+    const info = typeof value === 'string' ? { type: 'wvd' as const, data: value } : value;
+    return fromClientToInfo(await fromInfoToClient(clientInfoSchema.parse(info)));
+  };
+  for (const value of (await legacyClients.getValue()) ?? []) {
+    const info = await normalizeLegacy(value);
+    if (!registry.clients.some((entry) => sameClientInfo(entry.info, info))) {
+      registry.clients.push({ id: crypto.randomUUID(), info });
+    }
+  }
+  const active = await legacyActiveClient.getValue();
+  if (active) {
+    const info = await normalizeLegacy(active);
+    let entry = registry.clients.find((entry) => sameClientInfo(entry.info, info));
+    if (!entry) {
+      entry = { id: crypto.randomUUID(), info };
+      registry.clients.push(entry);
+    }
+    registry.activeClientId = entry.id;
+  } else {
+    registry.activeClientId = registry.clients[0]?.id ?? null;
+  }
+  return registry;
+};
+
+const decodeClientRegistry = async (registry: ClientRegistry): Promise<ClientSnapshot> => ({
+  clients: await Promise.all(
+    registry.clients.map(async (entry) => ({
+      id: entry.id,
+      client: await fromInfoToClient(entry.info),
+    })),
+  ),
+  activeClientId: registry.activeClientId,
+});
+
+const saveClientRegistry = async (registry: ClientRegistry, settings?: Settings) => {
+  // Parse before committing so a decoding failure cannot leave the popup behind storage.
+  const snapshot = await decodeClientRegistry(registry);
+  await storage.setItems([
+    { key: clientRegistry.key, value: registry },
+    ...(settings ? [{ key: storedSettings.key, value: JSON.stringify(settings) }] : []),
+  ]);
+  return snapshot;
+};
+
+const addClient = (client: Client, enablePlayback = false) =>
+  withClientLock(async () => {
+    const registry = await readClientRegistry();
+    const info = await fromClientToInfo(client);
+    if (registry.clients.some((entry) => sameClientInfo(entry.info, info))) {
+      throw new Error('This client is already imported');
+    }
+    if (registry.clients.length >= 10) throw new Error('You can add a maximum of 10 clients');
+    const isFirstClient = registry.clients.length === 0;
+    const entry = { id: crypto.randomUUID(), info };
+    registry.clients.push(entry);
+    registry.activeClientId ??= entry.id;
+    const settings =
+      enablePlayback && isFirstClient
+        ? {
+            ...defaultSettings,
+            ...(await storedSettings.getValue()),
+            emeInterception: true,
+            spoofing: true,
+            clientPlayback: true,
+          }
+        : undefined;
+    const snapshot = await saveClientRegistry(registry, settings);
+    return { ...snapshot, settings };
+  });
+
+const clientStorage = {
+  getSnapshot: () =>
+    withClientLock(async () => {
+      const registry = await readClientRegistry();
+      if (!(await clientRegistry.getValue())) return saveClientRegistry(registry);
+      return decodeClientRegistry(registry);
+    }),
+  getValue: async () => (await clientStorage.getSnapshot()).clients.map((entry) => entry.client),
+  add: (client: Client) => addClient(client),
+  import: (client: Client) => addClient(client, true),
+  select: (id: string | null) =>
+    withClientLock(async () => {
+      const registry = await readClientRegistry();
+      if (id !== null && !registry.clients.some((entry) => entry.id === id)) {
+        throw new Error('Client is no longer available');
+      }
+      return saveClientRegistry({ ...registry, activeClientId: id });
+    }),
+  remove: (client: string | Client) =>
+    withClientLock(async () => {
+      const registry = await readClientRegistry();
+      const info = typeof client === 'string' ? null : await fromClientToInfo(client);
+      const id =
+        typeof client === 'string'
+          ? client
+          : registry.clients.find((entry) => info && sameClientInfo(entry.info, info))?.id;
+      const clients = registry.clients.filter((entry) => entry.id !== id);
+      const activeClientId =
+        registry.activeClientId === id ? (clients[0]?.id ?? null) : registry.activeClientId;
+      return saveClientRegistry({ clients, activeClientId });
+    }),
+  active: {
+    getInfo: () =>
+      withClientLock(async () => {
+        const registry = await readClientRegistry();
+        return registry.clients.find((entry) => entry.id === registry.activeClientId)?.info ?? null;
+      }),
+    getValue: async (): Promise<Client | null> => {
+      const info = await clientStorage.active.getInfo();
+      return info ? fromInfoToClient(info) : null;
+    },
+    // Library-side callers may supply a client before adding it to the popup list.
+    setValue: (client: Client | null) =>
+      withClientLock(async () => {
+        const registry = await readClientRegistry();
+        if (!client) return saveClientRegistry({ ...registry, activeClientId: null });
+        const info = await fromClientToInfo(client);
+        let entry = registry.clients.find((entry) => sameClientInfo(entry.info, info));
+        if (!entry) {
+          entry = { id: crypto.randomUUID(), info };
+          registry.clients.push(entry);
+        }
+        return saveClientRegistry({ ...registry, activeClientId: entry.id });
+      }),
+  },
+};
 
 export const appStorage = {
   settings: {
@@ -210,63 +365,5 @@ export const appStorage = {
       }),
   },
 
-  clients: {
-    raw: asJson(storage.defineItem<string[] | ClientInfo[]>('local:clients')),
-    active: {
-      raw: storage.defineItem<string | ClientInfo>('local:active-client'),
-      setValue: async (client: Client | null) => {
-        if (!client) return appStorage.clients.active.raw.setValue(null);
-        const info = await fromClientToInfo(client);
-        return appStorage.clients.active.raw.setValue(info);
-      },
-      getValue: async () => {
-        const clientInfo = await appStorage.clients.active.raw.getValue();
-        if (!clientInfo) return null;
-        if (typeof clientInfo === 'string') {
-          // Deprecated
-          const client = await WidevineDeviceCredentials.from({
-            wvd: fromBase64(clientInfo).toBuffer(),
-          });
-          return client;
-        } else {
-          return fromInfoToClient(clientInfo);
-        }
-      },
-    },
-    setValue: async (clients: Client[]) => {
-      const values: ClientInfo[] = [];
-      for (const client of clients) {
-        values.push(await fromClientToInfo(client));
-      }
-      return appStorage.clients.raw.setValue(values);
-    },
-    getValue: async () => {
-      const values = await appStorage.clients.raw.getValue();
-      if (!values) return [];
-      const clients = [];
-      for (const value of values) {
-        if (typeof value === 'string') {
-          // Deprecated
-          const client = await WidevineDeviceCredentials.fromPacked(fromBase64(value).toBuffer());
-          clients.push(client);
-        } else {
-          const client = await fromInfoToClient(value);
-          if (client) clients.push(client);
-        }
-      }
-      return clients;
-    },
-    add: async (client: Client) => {
-      const clients = await appStorage.clients.getValue();
-      clients.push(client);
-      await appStorage.clients.setValue(clients);
-    },
-    remove: async (client: Client) => {
-      const clients = await appStorage.clients.getValue();
-      const index = clients.findIndex((c) => c.filename === client.filename);
-      if (index === -1) return;
-      clients.splice(index, 1);
-      await appStorage.clients.setValue(clients);
-    },
-  },
+  clients: clientStorage,
 };

--- a/test/e2e/bitmovin.test.ts
+++ b/test/e2e/bitmovin.test.ts
@@ -91,9 +91,16 @@ test.for([
       await expect
         .poll(() =>
           worker.evaluate(async () => {
-            const raw: unknown = (await chrome.storage.local.get('clients')).clients;
-            const clients: unknown = typeof raw === 'string' ? JSON.parse(raw) : raw;
-            return Array.isArray(clients) && clients.length === 1;
+            const raw: unknown = (await chrome.storage.local.get('client-registry'))[
+              'client-registry'
+            ];
+            return (
+              typeof raw === 'object' &&
+              raw !== null &&
+              'clients' in raw &&
+              Array.isArray(raw.clients) &&
+              raw.clients.length === 1
+            );
           }),
         )
         .toBe(true);
@@ -141,9 +148,17 @@ test.for([
       await expect.poll(() => popup.getByText('Active', { exact: true }).count()).toBe(1);
       await expect
         .poll(() =>
-          worker.evaluate(async () =>
-            Boolean((await chrome.storage.local.get('active-client'))['active-client']),
-          ),
+          worker.evaluate(async () => {
+            const raw: unknown = (await chrome.storage.local.get('client-registry'))[
+              'client-registry'
+            ];
+            return (
+              typeof raw === 'object' &&
+              raw !== null &&
+              'activeClientId' in raw &&
+              typeof raw.activeClientId === 'string'
+            );
+          }),
         )
         .toBe(true);
 

--- a/test/e2e/remote-client.test.ts
+++ b/test/e2e/remote-client.test.ts
@@ -3,6 +3,14 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { chromium } from 'playwright';
 import { expect, test } from 'vitest';
+import { z } from 'zod';
+
+declare const chrome: typeof import('wxt/browser').browser;
+
+const registrySchema = z.object({
+  clients: z.array(z.object({ id: z.string() })),
+  activeClientId: z.string().nullable(),
+});
 
 test('imports, selects, exports, and deletes remote clients in the popup', async () => {
   const profile = await mkdtemp(join(tmpdir(), 'okova-remote-ui-'));
@@ -105,6 +113,91 @@ test('imports, selects, exports, and deletes remote clients in the popup', async
     await popup.getByText('Local API', { exact: true }).waitFor();
     await expect.poll(() => popup.getByTitle('Active Client').count()).toBe(1);
     await popup.screenshot({ path: resolve('output/playwright/remote-client/clients.png') });
+  } finally {
+    await context.close();
+    await rm(profile, { recursive: true, force: true });
+  }
+});
+
+test('first import on Clients survives a failed write, repeated selection and duplicate labels', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-client-transaction-'));
+  const extension = resolve('.output/chrome-mv3');
+  const context = await chromium.launchPersistentContext(profile, {
+    channel: 'chromium',
+    headless: true,
+    args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+  });
+  try {
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+    const popup = await context.newPage();
+    const popupUrl = `chrome-extension://${new URL(worker.url()).hostname}/popup.html`;
+    await popup.goto(popupUrl);
+    await popup.getByRole('link', { name: 'Clients', exact: true }).click();
+    const input = popup.locator('input[type=file]');
+    const file = (device: string) => ({
+      name: 'REMOTE.JSON',
+      mimeType: 'application/json',
+      buffer: Buffer.from(
+        JSON.stringify({
+          baseUrl: 'https://cdm.test',
+          secret: 'test',
+          keySystem: 'com.widevine.alpha',
+          client: device,
+          label: 'Same label',
+        }),
+      ),
+    });
+    // Fail the actual popup write once, without changing another extension context.
+    await popup.evaluate(() => {
+      const set = chrome.storage.local.set.bind(chrome.storage.local);
+      chrome.storage.local.set = async () => {
+        chrome.storage.local.set = set;
+        throw new Error('Quota exceeded');
+      };
+    });
+    await input.setInputFiles(file('one'));
+    await expect.poll(() => popup.getByRole('alert').textContent()).toBe('Quota exceeded');
+    expect(await popup.getByText('Same label', { exact: true }).count()).toBe(0);
+    expect(await popup.getByTitle('Active Client').count()).toBe(0);
+    expect(await input.inputValue()).toBe('');
+    await input.setInputFiles(file('one'));
+    await popup.getByText('Same label', { exact: true }).waitFor();
+    await expect.poll(() => popup.getByTitle('Active Client').count()).toBe(1);
+    const stored = await worker.evaluate(() =>
+      chrome.storage.local.get(['client-registry', 'settings']),
+    );
+    const registry = registrySchema.parse(stored['client-registry']);
+    expect(registry.clients).toHaveLength(1);
+    expect(registry.activeClientId).toBe(registry.clients[0]!.id);
+    expect(
+      z
+        .object({ clientPlayback: z.literal(true) })
+        .parse(JSON.parse(z.string().parse(stored.settings))).clientPlayback,
+    ).toBe(true);
+    await input.setInputFiles(file('one'));
+    await expect
+      .poll(() => popup.getByRole('alert').textContent())
+      .toBe('This client is already imported');
+    await input.setInputFiles(file('two'));
+    await expect.poll(() => popup.getByText('Same label', { exact: true }).count()).toBe(2);
+    await popup.getByText('Same label', { exact: true }).last().click();
+    await expect
+      .poll(async () => {
+        const stored = await worker.evaluate(() => chrome.storage.local.get('client-registry'));
+        const registry = registrySchema.parse(stored['client-registry']);
+        return registry.activeClientId === registry.clients[1]!.id;
+      })
+      .toBe(true);
+    await popup.getByText('Same label', { exact: true }).last().hover();
+    await popup.getByTitle('Client Settings').last().click();
+    await popup.getByText('two', { exact: true }).waitFor();
+    await popup.getByText('Delete', { exact: true }).click();
+    await expect.poll(() => popup.getByTitle('Client Settings').count()).toBe(1);
+    await expect.poll(() => popup.getByText('Same label', { exact: true }).count()).toBe(1);
+    await popup.goto(popupUrl);
+    await popup.getByRole('link', { name: 'Clients', exact: true }).click();
+    await expect.poll(() => popup.getByText('Same label', { exact: true }).count()).toBe(1);
+    await expect.poll(() => popup.getByTitle('Active Client').count()).toBe(1);
   } finally {
     await context.close();
     await rm(profile, { recursive: true, force: true });

--- a/test/extension-clients.test.ts
+++ b/test/extension-clients.test.ts
@@ -1,0 +1,194 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { appStorage, defaultSettings, fromClientToInfo } from '../src/extension/utils/storage';
+import { RemoteClient } from '../src/extension/utils/remote-client';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+} from '../src/lib/widevine/proto';
+import { parseClientFiles } from '../src/extension/entrypoints/popup/utils/client-import';
+
+beforeEach(() => fakeBrowser.reset());
+afterEach(() => vi.restoreAllMocks());
+
+const remote = (device = 'one') =>
+  RemoteClient.from({
+    keySystem: 'com.widevine.alpha',
+    baseUrl: 'https://cdm.test',
+    secret: 'test-secret',
+    client: device,
+    label: 'Same label',
+  });
+
+const widevine = async (serial: number) => {
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+  const client = new WidevineDeviceCredentials(
+    ClientIdentification.create({
+      token: SignedDrmCertificate.encode(
+        SignedDrmCertificate.create({
+          drmCertificate: DrmCertificate.encode(
+            DrmCertificate.create({
+              systemId: 1,
+              serialNumber: new Uint8Array([serial]),
+            }),
+          ).finish(),
+        }),
+      ).finish(),
+      clientInfo: [
+        { name: 'company_name', value: 'Test' },
+        { name: 'model_name', value: 'Device' },
+      ],
+    }),
+  );
+  await client.importKey(privateKey);
+  return client;
+};
+
+test('same-model provisions retain distinct IDs across selection, export, reload and removal', async () => {
+  const first = await widevine(1);
+  const second = await widevine(2);
+  expect(first.filename).toBe(second.filename);
+  await appStorage.clients.import(first);
+  const imported = await appStorage.clients.import(second);
+  const [one, two] = imported.clients;
+  expect(one!.id).not.toBe(two!.id);
+  await appStorage.clients.select(two!.id);
+  const restored = await appStorage.clients.getSnapshot();
+  expect(restored.activeClientId).toBe(two!.id);
+  expect(await restored.clients[1]!.client.pack()).toEqual(await second.pack());
+  const remaining = await appStorage.clients.remove(two!.id);
+  expect(remaining.clients.map((entry) => entry.id)).toEqual([one!.id]);
+  expect(remaining.activeClientId).toBe(one!.id);
+  expect(await (await appStorage.clients.active.getValue())!.pack()).toEqual(await first.pack());
+  await appStorage.clients.remove(one!.id);
+  expect(await appStorage.clients.getSnapshot()).toEqual({ clients: [], activeClientId: null });
+  expect(await appStorage.clients.active.getValue()).toBeNull();
+});
+
+test('migrates mixed legacy formats and matches the active provision by content', async () => {
+  const first = await widevine(1);
+  const second = await widevine(2);
+  const firstInfo = await fromClientToInfo(first);
+  const secondInfo = await fromClientToInfo(second);
+  if (firstInfo.type !== 'wvd') throw new Error('Expected Widevine');
+  const legacy = JSON.stringify([firstInfo.data, secondInfo, secondInfo]);
+  await browser.storage.local.set({ clients: legacy, 'active-client': secondInfo });
+  const migrated = await appStorage.clients.getSnapshot();
+  expect(migrated.clients).toHaveLength(2);
+  expect(migrated.activeClientId).toBe(migrated.clients[1]!.id);
+  expect((await appStorage.clients.getSnapshot()).clients.map((entry) => entry.id)).toEqual(
+    migrated.clients.map((entry) => entry.id),
+  );
+  expect((await browser.storage.local.get('clients')).clients).toBe(legacy);
+  await appStorage.clients.remove(migrated.clients[0]!.id);
+  expect((await appStorage.clients.getSnapshot()).activeClientId).toBe(migrated.activeClientId);
+});
+
+test('preserves a legacy active client missing from the list', async () => {
+  await browser.storage.local.set({ 'active-client': await fromClientToInfo(await remote()) });
+  const snapshot = await appStorage.clients.getSnapshot();
+  expect(snapshot.clients).toHaveLength(1);
+  expect(snapshot.activeClientId).toBe(snapshot.clients[0]!.id);
+});
+
+test('commits first import, activation and playback settings in one write', async () => {
+  await appStorage.settings.setValue({ ...defaultSettings, theme: 'dark' });
+  const write = vi.spyOn(browser.storage.local, 'set');
+  const snapshot = await appStorage.clients.import(await remote());
+  expect(write).toHaveBeenCalledTimes(1);
+  expect(snapshot.activeClientId).toBe(snapshot.clients[0]!.id);
+  expect(await appStorage.settings.getValue()).toMatchObject({
+    theme: 'dark',
+    spoofing: true,
+    clientPlayback: true,
+    emeInterception: true,
+  });
+  expect(await appStorage.clients.active.getInfo()).toMatchObject({ type: 'remote' });
+});
+
+test('failed imports leave both settings and selection unchanged and can be retried', async () => {
+  await appStorage.settings.setValue(defaultSettings);
+  const before = await appStorage.clients.getSnapshot();
+  vi.spyOn(browser.storage.local, 'set').mockRejectedValueOnce(new Error('Quota exceeded'));
+  const client = await remote();
+  await expect(appStorage.clients.import(client)).rejects.toThrow('Quota exceeded');
+  expect(await appStorage.clients.getSnapshot()).toEqual(before);
+  expect(await appStorage.settings.getValue()).toEqual(defaultSettings);
+  await appStorage.clients.import(client);
+  await expect(appStorage.clients.import(await remote())).rejects.toThrow('already imported');
+  expect((await appStorage.clients.getSnapshot()).clients).toHaveLength(1);
+});
+
+test('serializes concurrent imports and active-client removal without losing devices', async () => {
+  const [one, two, three] = await Promise.all([remote('one'), remote('two'), remote('three')]);
+  await Promise.all([appStorage.clients.import(one), appStorage.clients.import(two)]);
+  const initial = await appStorage.clients.getSnapshot();
+  await Promise.all([
+    appStorage.clients.remove(initial.activeClientId!),
+    appStorage.clients.import(three),
+  ]);
+  const snapshot = await appStorage.clients.getSnapshot();
+  expect(snapshot.clients).toHaveLength(2);
+  expect(snapshot.clients.some((entry) => entry.id === snapshot.activeClientId)).toBe(true);
+  await expect(appStorage.clients.select(initial.activeClientId!)).rejects.toThrow(
+    'no longer available',
+  );
+});
+
+test('failed selection and deletion preserve the saved client list and active ID', async () => {
+  await appStorage.clients.import(await remote('one'));
+  await appStorage.clients.import(await remote('two'));
+  const initial = await appStorage.clients.getSnapshot();
+  const write = vi.spyOn(browser.storage.local, 'set');
+  write.mockRejectedValueOnce(new Error('Storage unavailable'));
+  await expect(appStorage.clients.select(initial.clients[1]!.id)).rejects.toThrow(
+    'Storage unavailable',
+  );
+  write.mockRejectedValueOnce(new Error('Storage unavailable'));
+  await expect(appStorage.clients.remove(initial.activeClientId!)).rejects.toThrow(
+    'Storage unavailable',
+  );
+  expect((await appStorage.clients.getSnapshot()).activeClientId).toBe(initial.activeClientId);
+  expect((await appStorage.clients.getSnapshot()).clients.map((entry) => entry.id)).toEqual(
+    initial.clients.map((entry) => entry.id),
+  );
+});
+
+test('recognizes uppercase packed extensions and exact raw Widevine pairs', async () => {
+  const client = await widevine(1);
+  const bytes = Uint8Array.from(await client.pack());
+  const packed = await parseClientFiles([new File([bytes], 'DEVICE.WVD')]);
+  const raw = await client.unpack();
+  const unpacked = await parseClientFiles(
+    Object.entries(raw).map(
+      ([name, bytes]) => new File([Uint8Array.from(bytes)], name.toUpperCase()),
+    ),
+  );
+  expect(await packed.client.pack()).toEqual(bytes);
+  expect(await unpacked.client.pack()).toEqual(bytes);
+});
+
+test.each([
+  ['first.wvd', 'second.wvd'],
+  ['client.wvd.backup'],
+  ['device_client_id_blob'],
+  ['device_client_id_blob', 'device_private_key', 'extra.txt'],
+  ['one.json', 'two.json'],
+])('rejects ambiguous or incomplete file selections: %j', async (...names) => {
+  await expect(parseClientFiles(names.map((name) => new File([], name)))).rejects.toThrow(
+    'Select one WVD',
+  );
+});
+
+test('malformed device files reject before touching storage', async () => {
+  await expect(parseClientFiles([new File(['invalid'], 'client.wvd')])).rejects.toThrow();
+  expect(await browser.storage.local.get(null)).toEqual({});
+});


### PR DESCRIPTION
## Summary
- Replace legacy client storage with an ID-based registry and transactional updates.
- Preserve legacy client data through migration and prevent duplicate imports.
- Centralize client import parsing and improve popup error handling.
- Add coverage for client storage, import failures, selection, duplicate labels, and deletion.

## Testing
- Added unit coverage in `test/extension-clients.test.ts`.
- Added end-to-end coverage for remote client lifecycle and transactional imports.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791290938&installation_model_id=424872&pr_number=70&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F70&signature=d771b802e7dbc53f17e762c13fff83b155b5e552b41616cc9885b6393531a5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->