### PR TITLE
fix(cli): harden command parsing and credential format handling

### DIFF
--- a/src/cli/commands/client/help.ts
+++ b/src/cli/commands/client/help.ts
@@ -1,25 +1,19 @@
 import { col } from '../../utils';
 
 export const help = () => {
-  console.log(`okova client: Widevine client utilities\n`);
-  console.log(`Usage: okova client <subcommand> [...flags]\n`);
-  console.log(`Commands:`);
+  console.log('okova client: Widevine and PlayReady client utilities\n');
+  console.log('Usage: okova client <subcommand> [...flags]\n');
+  console.log('Commands:');
+  console.log(col('info [input]') + 'Print device metadata');
+  console.log(col('pack [input] [output]') + 'Pack credentials into a .wvd or .prd file');
+  console.log(col('unpack [input] [output]') + 'Export raw credential files into a directory');
+  console.log('\nInput is a .wvd/.prd file or a directory containing credential files.');
   console.log(
-    col(`info <input>`) +
-      'print info about client that is on <input> path (*.wvd filepath or directory with id and private key)',
+    'Input defaults to the current directory. Default pack names use the device name and format.',
   );
-  console.log(
-    col(`pack <input> <output>`) +
-      'pack client id and private key from <input> directory into single file with <output> path',
-  );
-  console.log(
-    col(`unpack <input> <output>`) +
-      'unpack from <input> path to separate client id and private key placed in <output> directory',
-  );
-  console.log('');
+  console.log('Default unpack output is the current directory. PRD v2 cannot export group files.');
   console.log('Exports create output directories and refuse to overwrite existing paths.');
-  console.log('');
-  console.log(`Flags:`);
-  console.log(col(`-f, --format`) + 'Specify format for pack command (wvd/okova)');
-  console.log(col(`-h, --help`) + 'Display this menu and exit');
+  console.log('\nFlags:');
+  console.log(col('-f, --format <wvd|prd>') + 'Pack format; must match the device type');
+  console.log(col('-h, --help') + 'Display this menu and exit');
 };

--- a/src/cli/commands/client/info.ts
+++ b/src/cli/commands/client/info.ts
@@ -1,8 +1,14 @@
 import { importClient } from '../../utils';
 
-export const info = async (input: string) => {
+export const info = async (input = process.cwd()) => {
   const client = await importClient(input);
-  if (!('info' in client)) return;
+  if (!('info' in client)) {
+    console.log('DRM: PlayReady');
+    console.log(`Name: ${client.label}`);
+    console.log(`Security level: ${client.securityLevel}`);
+    console.log(`PRD version: ${client.groupKey ? 3 : 2}`);
+    return;
+  }
   for (const [key, value] of client.info.entries()) {
     console.log(`${key}: ${value}`);
   }

--- a/src/cli/commands/client/pack.ts
+++ b/src/cli/commands/client/pack.ts
@@ -1,14 +1,21 @@
 import { basename, dirname, extname, join } from 'node:path';
 import { importClient } from '../../utils';
+import { WidevineDeviceCredentials } from '../../../lib/widevine/device-credentials';
 import { exportFiles } from './export-files';
 
-export const pack = async (input = process.cwd(), format?: string, output?: string) => {
-  const client = await importClient(input, output);
-  const ext = format || (output ? extname(output) : '');
+export const pack = async (input = process.cwd(), format?: 'wvd' | 'prd', output?: string) => {
+  const client = await importClient(input, format ? `client.${format}` : output);
+  const ext = client instanceof WidevineDeviceCredentials ? 'wvd' : 'prd';
+  if (format && format !== ext) {
+    throw new Error(`Cannot pack ${ext} credentials as ${format}`);
+  }
+  const outputExtension = output ? extname(output).toLowerCase() : '';
+  if (['.wvd', '.prd'].includes(outputExtension) && outputExtension !== `.${ext}`) {
+    throw new Error(`Output extension must match credential format: .${ext}`);
+  }
   const data = await client.pack();
   const filename = `${client.getName()}`.replaceAll(' ', '-').toLowerCase();
   const outputPath = output || join(process.cwd(), `${filename}.${ext}`);
   await exportFiles(dirname(outputPath), { [basename(outputPath)]: data });
   console.log(`Client packed: ${outputPath}`);
-  // Convert to Base64: `base64 -i /Users/.../client.wvd | tr -d '\n' | pbcopy`
 };

--- a/src/cli/commands/license/help.ts
+++ b/src/cli/commands/license/help.ts
@@ -13,10 +13,9 @@ export const help = () => {
     col(`-H, --header`) +
       'headers to send with license request, compatible with curl (e.g. -H "Authorization: Bearer ...")',
   );
-  console.log(col(`-p, --pssh`) + 'widevine PSSH data in Base64');
+  console.log(col(`-p, --pssh`) + 'Widevine or PlayReady PSSH data in Base64');
   console.log(
-    col(`-c, --client`) +
-      'path to client (directory with id and private key or path to *.wvd file)',
+    col(`-c, --client`) + 'path to client (.wvd/.prd file or directory with credential files)',
   );
   console.log(
     col(`-e, --encrypt`) +

--- a/src/cli/commands/serve/help.ts
+++ b/src/cli/commands/serve/help.ts
@@ -8,8 +8,7 @@ export const help = () => {
   console.log(col(`--port`) + 'server port (default: 4000)');
   console.log(col(`--config`) + 'path to config file (default: okova.config.json)');
   console.log(
-    col(`-c, --client`) +
-      'path to client (directory with id and private key or path to *.wvd file)',
+    col(`-c, --client`) + 'path to client (.wvd/.prd file or directory with credential files)',
   );
   console.log(col(`-s, --secret`) + 'secret key to access API endpoints');
   console.log(col(`-h, --help`) + 'display this menu and exit');

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,127 +1,132 @@
 #!/usr/bin/env node
 
-import { parseArgs } from 'node:util';
+import { parseArgs, type ParseArgsOptionsConfig } from 'node:util';
 import { client } from './commands/client';
 import { license } from './commands/license';
 import pkg from '../../package.json' with { type: 'json' };
 import { col } from './utils';
 import { serve } from './commands/serve/serve';
 
-const args = parseArgs({
-  args: process.argv.slice(2),
-  options: {
-    pssh: { type: 'string', short: 'p' },
-    client: { type: 'string', short: 'c' },
-    encrypt: { type: 'boolean', short: 'e', default: false },
-    header: { type: 'string', short: 'H', multiple: true },
-    help: { type: 'boolean', short: 'h' },
-    version: { type: 'boolean', short: 'v' },
-    debug: { type: 'boolean', short: 'd' },
-    format: { type: 'boolean', short: 'f' },
+const helpOption = { help: { type: 'boolean', short: 'h' } } satisfies ParseArgsOptionsConfig;
+const parse = <T extends ParseArgsOptionsConfig>(args: string[], options: T) =>
+  parseArgs({ args, options, strict: true, allowPositionals: true });
 
-    host: { type: 'string' },
-    port: { type: 'string' },
-    secret: { type: 'string', short: 's' },
-    config: { type: 'string' },
-  },
-  strict: false,
-  allowPositionals: true,
-});
-
-const help = () => {
-  console.log(`Okova – advanced DRM inspection toolkit. (${pkg.version})\n`);
-  console.log(`Usage: okova <command> [...flags]\n`);
-  console.log(`Commands:`);
-  console.log(col(`serve`) + 'Run your API instance');
-  console.log(col(`license <url>`) + 'Make a license request');
-  console.log(col(`client <subcommand>`) + 'Additional Widevine client utilities');
-  console.log('');
-  console.log(`Flags:`);
-  console.log(col(`-d, --debug`) + 'Enable debug level logging');
-  console.log(col(`-v, --version`) + 'Print version and exit');
-  console.log(col(`-h, --help`) + 'Display this menu and exit');
-  console.log('');
-  console.log(`(more flags in okova license --help and okova client --help)`);
+const checkPositionals = (positionals: string[], maximum: number) => {
+  if (positionals.length > maximum) throw new Error('Too many positional arguments');
 };
 
-(async () => {
-  if (args.values.version) {
-    console.log(pkg.version);
-    process.exit(0);
-  }
+const help = () => {
+  console.log(`Okova: advanced DRM inspection toolkit. (${pkg.version})\n`);
+  console.log('Usage: okova <command> [...flags]\n');
+  console.log('Commands:');
+  console.log(col('serve') + 'Run your API instance');
+  console.log(col('license <url>') + 'Make a license request');
+  console.log(col('client <subcommand>') + 'Widevine and PlayReady client utilities');
+  console.log('\nFlags:');
+  console.log(col('-v, --version') + 'Print version and exit');
+  console.log(col('-h, --help') + 'Display this menu and exit');
+  console.log('\nUse okova <command> --help for command options.');
+};
 
-  const [command, ...positionals] = args.positionals;
+const main = async () => {
+  const [command, ...argv] = process.argv.slice(2);
+  if (!command || command.startsWith('-')) {
+    const args = parse(process.argv.slice(2), {
+      ...helpOption,
+      version: { type: 'boolean', short: 'v' },
+    });
+    checkPositionals(args.positionals, 0);
+    if (args.values.version) console.log(pkg.version);
+    else help();
+    return;
+  }
 
   switch (command) {
     case 'serve': {
-      if (args.values.help) {
-        serve.help();
-        process.exit(0);
-      }
-      serve({
-        host: args.values.host as string | undefined,
-        port: args.values.port ? parseInt(args.values.port as string) : undefined,
-        config: args.values.config as string | undefined,
-        client: args.values.client as string | undefined,
-        secret: args.values.secret as string | undefined,
+      const { values, positionals } = parse(argv, {
+        ...helpOption,
+        host: { type: 'string' },
+        port: { type: 'string' },
+        secret: { type: 'string', short: 's' },
+        config: { type: 'string' },
+        client: { type: 'string', short: 'c' },
       });
-      break;
+      if (values.help) return serve.help();
+      checkPositionals(positionals, 0);
+      const port = values.port === undefined ? undefined : Number(values.port);
+      if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) {
+        throw new Error('Port must be an integer between 1 and 65535');
+      }
+      await serve({ ...values, port });
+      return;
     }
     case 'client': {
-      const subcommand = positionals.shift();
+      const [subcommand, ...rest] = argv;
+      if (!subcommand || subcommand.startsWith('-')) {
+        const { values, positionals } = parse(argv, helpOption);
+        checkPositionals(positionals, 0);
+        if (values.help) return client.help();
+        throw new Error('Client subcommand required: pack, unpack, info');
+      }
+      if (!['pack', 'unpack', 'info'].includes(subcommand)) {
+        throw new Error(`Unknown client subcommand: ${subcommand}`);
+      }
+      const { values, positionals } = parse(rest, {
+        ...helpOption,
+        ...(subcommand === 'pack' ? { format: { type: 'string', short: 'f' } } : {}),
+      } satisfies ParseArgsOptionsConfig);
+      if (values.help) return client.help();
+      checkPositionals(positionals, subcommand === 'info' ? 1 : 2);
       const [input, output] = positionals;
       switch (subcommand) {
-        case 'pack':
-          await client.pack(input, args.values.format as string | undefined, output);
-          break;
+        case 'pack': {
+          const format = values.format;
+          if (format !== undefined && format !== 'wvd' && format !== 'prd') {
+            throw new Error('Format must be wvd or prd');
+          }
+          await client.pack(input, format, output);
+          return;
+        }
         case 'unpack':
           await client.unpack(input, output);
-          break;
+          return;
         case 'info':
-          client.info(input);
-          break;
-        default: {
-          if (args.values.help) {
-            client.help();
-            process.exit(0);
-          } else {
-            console.log('Client subcommand required: pack, unpack, info');
-            process.exit(1);
-          }
-        }
+          await client.info(input);
+          return;
       }
-      break;
+      return;
     }
     case 'license': {
-      if (args.values.help) {
-        license.help();
-        process.exit(0);
-      }
-      const url = positionals.shift();
+      const { values, positionals } = parse(argv, {
+        ...helpOption,
+        pssh: { type: 'string', short: 'p' },
+        client: { type: 'string', short: 'c' },
+        encrypt: { type: 'boolean', short: 'e', default: false },
+        header: { type: 'string', short: 'H', multiple: true },
+      });
+      if (values.help) return license.help();
+      checkPositionals(positionals, 1);
+      const [url] = positionals;
       if (!url) throw new Error('License URL required');
-      const pssh = args.values.pssh as string;
-      if (!pssh) throw new Error('PSSH required');
-      const clientPath = args.values.client as string;
-      const encrypt = args.values.encrypt as boolean;
-      const headers = args.values.header as string[];
-      await license({ url, pssh, clientPath, encrypt, headers });
-      break;
+      if (!values.pssh) throw new Error('PSSH required');
+      await license({
+        url,
+        pssh: values.pssh,
+        clientPath: values.client,
+        encrypt: values.encrypt,
+        headers: values.header,
+      });
+      return;
     }
     case 'pssh':
-      break;
     case 'test':
-      break;
-    default: {
-      if (args.values.help) {
-        help();
-        process.exit(0);
-      } else {
-        console.log('Command not found');
-        process.exit(1);
-      }
-    }
+      throw new Error(`Command not implemented: ${command}`);
+    default:
+      throw new Error(`Unknown command: ${command}`);
   }
-})().catch((error: unknown) => {
+};
+
+main().catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -7,9 +7,6 @@ export const importClient = async (input: string, output?: string) => {
   const inputStat = await stat(input);
   const isDir = inputStat.isDirectory();
 
-  const outputInfo = output ? await stat(output).catch(() => null) : null;
-  const importForUnpack =
-    !outputInfo || outputInfo?.isDirectory() || input.endsWith('.wvd') || input.endsWith('.prd');
   if (isDir) {
     const entries = isDir ? await readdir(input) : [];
 
@@ -31,7 +28,7 @@ export const importClient = async (input: string, output?: string) => {
       (!!(playreadyCertificateFile && playreadyKeyFile) || !!prdFile) && !output?.endsWith('.wvd');
 
     if (isWidevine) {
-      if (importForUnpack && wvdFile) {
+      if (wvdFile) {
         const wvd = await readFile(join(input, wvdFile));
         return await WidevineDeviceCredentials.from({ wvd });
       } else {
@@ -40,7 +37,7 @@ export const importClient = async (input: string, output?: string) => {
         return WidevineDeviceCredentials.from({ id, key });
       }
     } else if (isPlayReady) {
-      if (importForUnpack && prdFile) {
+      if (prdFile) {
         const prd = await readFile(join(input, prdFile));
         return await PlayReadyDeviceCredentials.from({ prd });
       } else {
@@ -52,8 +49,7 @@ export const importClient = async (input: string, output?: string) => {
         });
       }
     } else {
-      console.log(`Unable to find client files in ${input}`);
-      process.exit(1);
+      throw new Error(`Unable to find client files in ${input}`);
     }
   } else if (input.endsWith('.wvd')) {
     const wvd = await readFile(input);
@@ -62,8 +58,7 @@ export const importClient = async (input: string, output?: string) => {
     const prd = await readFile(input);
     return await PlayReadyDeviceCredentials.from({ prd });
   } else {
-    console.log(`Unable to find client files in ${input}`);
-    process.exit(1);
+    throw new Error(`Unable to find client files in ${input}`);
   }
 };
 

--- a/src/extension/entrypoints/popup/routes/settings.tsx
+++ b/src/extension/entrypoints/popup/routes/settings.tsx
@@ -44,7 +44,8 @@ export const Settings = () => {
     { value: 'dark', label: 'Dark' },
   ];
 
-  const { allowUpdateCheck, checkForUpdates, isCheckingForUpdates } = useUpdater();
+  const { allowUpdateCheck, checkForUpdates, isCheckingForUpdates, updateCheckError } =
+    useUpdater();
   const { hasUpdate, updateInfo } = useUpdateInfo();
 
   return (
@@ -142,10 +143,15 @@ export const Settings = () => {
                 <Cell
                   component="button"
                   variant="primary"
+                  subtitle={updateCheckError() ?? undefined}
                   disabled={isCheckingForUpdates()}
                   onClick={() => checkForUpdates()}
                 >
-                  Check for Updates
+                  {isCheckingForUpdates()
+                    ? 'Checking for Updates…'
+                    : updateCheckError()
+                      ? 'Retry Update Check'
+                      : 'Check for Updates'}
                 </Cell>
               ) : (
                 <Cell disabled>Up to Date</Cell>

--- a/src/extension/entrypoints/popup/utils/date.ts
+++ b/src/extension/entrypoints/popup/utils/date.ts
@@ -7,7 +7,9 @@ export const formatRelativeTime = (
   } = {},
 ): string => {
   const { locale = 'en', numeric = 'auto', timeZone = 'UTC' } = options;
-  if (!Temporal) return new Date(input).toLocaleString().slice(0, -3);
+  if (typeof Temporal === 'undefined') {
+    return new Date(input).toLocaleString(locale, { timeZone });
+  }
   const past = Temporal.Instant.from(input).toZonedDateTimeISO(timeZone);
   const now = Temporal.Now.instant().toZonedDateTimeISO(timeZone);
   const duration = past.until(now, { largestUnit: 'year' });

--- a/src/extension/entrypoints/popup/utils/updater.ts
+++ b/src/extension/entrypoints/popup/utils/updater.ts
@@ -1,5 +1,13 @@
+import { createMemo, createSignal } from 'solid-js';
+import { z } from 'zod';
 import { compare } from 'semver';
 import { formatRelativeTime } from './date';
+
+const releaseSchema = z.object({
+  tag_name: z.string(),
+  published_at: z.iso.datetime(),
+  assets: z.array(z.object({ name: z.string(), browser_download_url: z.url() })),
+});
 
 const [updateInfo, setUpdateInfo] = createSignal<{
   version: string;
@@ -10,6 +18,7 @@ const hasUpdate = createMemo(
   () => updateInfo() !== null && updateInfo()?.version !== browser.runtime.getManifest().version,
 );
 const [allowUpdateCheck, setAllowUpdateCheck] = createSignal(true);
+const [updateCheckError, setUpdateCheckError] = createSignal<string | null>(null);
 const [isCheckingForUpdates, setIsCheckingForUpdates] = createSignal(false);
 
 export const useUpdateInfo = () => {
@@ -20,39 +29,48 @@ export const useUpdater = () => {
   const { updateInfo, setUpdateInfo, hasUpdate } = useUpdateInfo();
 
   const checkForUpdates = async () => {
+    if (!allowUpdateCheck() || isCheckingForUpdates()) return;
+    setIsCheckingForUpdates(true);
+    setUpdateCheckError(null);
     try {
-      if (!allowUpdateCheck() || isCheckingForUpdates()) return;
-      setIsCheckingForUpdates(true);
       const owner = 'azot-labs';
       const repo = 'okova';
       const link = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
       const isFirefox = browser.runtime.getURL('').startsWith('moz-extension://');
       const response = await fetch(link);
       if (!response.ok) throw new Error('Release not found or API limit reached');
-      const data = await response.json();
+      const data = releaseSchema.parse(await response.json());
       const manifest = browser.runtime.getManifest();
       const currentVersion = manifest.version;
-      const latestVersion = data.tag_name?.replace('v', '');
+      const latestVersion = data.tag_name.replace(/^v/, '');
       const isCurrentVersionOutdated = compare(latestVersion, currentVersion) > 0;
       if (isCurrentVersionOutdated) {
-        const asset = data.assets?.find((asset: any) =>
+        const asset = data.assets.find((asset) =>
           asset.name.includes(isFirefox ? 'firefox' : 'chrome'),
         );
-        const url = asset?.browser_download_url;
-        const publishedAt = new Date(data.published_at).toLocaleString();
-        const timeSinceRelease = Temporal ? formatRelativeTime(data.published_at) : publishedAt;
+        if (!asset) throw new Error('Release has no download for this browser');
+        const url = asset.browser_download_url;
+        const timeSinceRelease = formatRelativeTime(data.published_at);
         setUpdateInfo({ version: latestVersion, url, timeSinceRelease });
+      } else {
+        setUpdateInfo(null);
       }
+      setAllowUpdateCheck(false);
+      setTimeout(() => setAllowUpdateCheck(true), 30_000);
     } catch (error) {
       console.error('Error fetching release:', error);
+      setUpdateCheckError('Update check failed. Please try again.');
+    } finally {
+      setIsCheckingForUpdates(false);
     }
-    setIsCheckingForUpdates(false);
-    setAllowUpdateCheck(false);
-    setTimeout(
-      () => setAllowUpdateCheck(true),
-      1000 * 30, // 30 seconds
-    );
   };
 
-  return { hasUpdate, updateInfo, checkForUpdates, allowUpdateCheck, isCheckingForUpdates };
+  return {
+    hasUpdate,
+    updateInfo,
+    checkForUpdates,
+    allowUpdateCheck,
+    isCheckingForUpdates,
+    updateCheckError,
+  };
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+} from '../src/lib/widevine/proto';
+import { buildWvd, parseWvd } from '../src/lib/widevine/wvd';
+
+let directory: string;
+let executable: string;
+let input: string;
+let wvd: Uint8Array;
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(process.cwd(), 'node_modules/.okova-cli-test-'));
+  const output = join(directory, 'build');
+  execFileSync(
+    process.execPath,
+    [
+      fileURLToPath(import.meta.resolve('tsdown/run')),
+      '--config',
+      'tsdown.cli.config.ts',
+      '--out-dir',
+      output,
+    ],
+    { timeout: 60_000, stdio: 'pipe' },
+  );
+  executable = join(output, 'main.cjs');
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const clientId = ClientIdentification.encode(
+    ClientIdentification.create({
+      token: SignedDrmCertificate.encode(
+        SignedDrmCertificate.create({
+          drmCertificate: DrmCertificate.encode(DrmCertificate.create({ systemId: 123 })).finish(),
+        }),
+      ).finish(),
+      clientInfo: [
+        { name: 'company_name', value: 'Test' },
+        { name: 'model_name', value: 'Device' },
+      ],
+    }),
+  ).finish();
+  wvd = buildWvd({
+    deviceType: 2,
+    securityLevel: 3,
+    clientId,
+    privateKey: privateKey.export({ type: 'pkcs1', format: 'der' }),
+  });
+  input = join(directory, 'input.wvd');
+  await writeFile(input, wvd);
+  await writeFile(join(directory, 'invalid-config.json'), JSON.stringify({ sessionLimits: false }));
+}, 60_000);
+
+afterAll(async () => {
+  if (directory) await rm(directory, { recursive: true, force: true });
+});
+
+const run = (args: string[], cwd = directory) =>
+  spawnSync(process.execPath, [executable, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+
+test.each([
+  ['--help'],
+  ['--version'],
+  ['serve', '--help'],
+  ['license', '--help'],
+  ['client', '--help'],
+  ['client', 'pack', '--help'],
+  ['client', 'unpack', '--help'],
+  ['client', 'info', '--help'],
+])('prints help/version without executing %j', (...args) => {
+  const result = run(args);
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stdout.trim()).not.toBe('');
+  expect(result.stderr).toBe('');
+});
+
+test.each([
+  ['client', 'pack', '--format'],
+  ['client', 'pack', '--format', 'okova'],
+  ['client', 'info', '--format', 'wvd'],
+  ['license', '--port', '4000'],
+  ['serve', '--port', '4000oops'],
+  ['--debug'],
+  ['--unknown'],
+  ['pssh'],
+  ['test'],
+  ['unknown'],
+  ['client', 'unknown'],
+  ['client', 'info', 'a', 'b'],
+  ['license'],
+  ['client', 'info', 'missing.wvd'],
+  ['serve', '--config', 'invalid-config.json'],
+])('rejects invalid or unimplemented invocation %j', (...args) => {
+  const result = run(args);
+  expect(result.status, result.stdout).toBe(1);
+  expect(result.stderr.trim()).not.toBe('');
+  expect(result.stderr).not.toContain('UnhandledPromiseRejection');
+});
+
+test.each([[], ['--format', 'wvd'], ['-f', 'wvd']])(
+  'packs with the correct default extension %j',
+  async (...flags) => {
+    const cwd = await mkdtemp(join(directory, 'pack-'));
+    const result = run(['client', 'pack', input, ...flags], cwd);
+    expect(result.status, result.stderr).toBe(0);
+    expect(await readdir(cwd)).toEqual(['test_device.wvd']);
+    expect(parseWvd(new Uint8Array(await readFile(join(cwd, 'test_device.wvd'))))).toEqual(
+      parseWvd(wvd),
+    );
+  },
+);
+
+test('packs raw credentials, honors output paths, and refuses overwrites or format mismatches', async () => {
+  const cwd = await mkdtemp(join(directory, 'raw-'));
+  const raw = join(cwd, 'raw');
+  const unpack = run(['client', 'unpack', input, raw], cwd);
+  expect(unpack.status, unpack.stderr).toBe(0);
+  const output = join(cwd, 'nested', 'export.wvd');
+  const pack = run(['client', 'pack', raw, output, '--format', 'wvd'], cwd);
+  expect(pack.status, pack.stderr).toBe(0);
+  expect(parseWvd(new Uint8Array(await readFile(output)))).toEqual(parseWvd(wvd));
+  expect(run(['client', 'pack', raw, output], cwd).status).toBe(1);
+  expect(parseWvd(new Uint8Array(await readFile(output)))).toEqual(parseWvd(wvd));
+  expect(run(['client', 'pack', input, '--format', 'prd'], cwd).status).toBe(1);
+  expect(run(['client', 'pack', input, join(cwd, 'wrong.prd')], cwd).status).toBe(1);
+  const info = run(['client', 'info', input]);
+  expect(info.status, info.stderr).toBe(0);
+  expect(info.stdout).toContain('company_name: Test');
+});
+
+test.skipIf(!process.env.VITEST_PRD_PATH)(
+  'prints PRD metadata and packs with a .prd default filename',
+  async () => {
+    const prdPath = process.env.VITEST_PRD_PATH;
+    if (!prdPath) throw new Error('VITEST_PRD_PATH is required');
+    const cwd = await mkdtemp(join(directory, 'prd-'));
+    const info = run(['client', 'info', prdPath], cwd);
+    expect(info.status, info.stderr).toBe(0);
+    expect(info.stdout).toContain('DRM: PlayReady');
+    expect(info.stdout).toMatch(/Security level: \d+/);
+    expect(info.stdout).toMatch(/PRD version: [23]/);
+    const result = run(['client', 'pack', prdPath, '--format', 'prd'], cwd);
+    expect(result.status, result.stderr).toBe(0);
+    const files = await readdir(cwd);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/\.prd$/);
+    expect(await readFile(join(cwd, files[0]))).toEqual(await readFile(prdPath));
+    // A directory containing both device types must honor the requested pack format.
+    const mixed = join(cwd, 'mixed');
+    await mkdir(mixed);
+    await writeFile(join(mixed, 'client.wvd'), wvd);
+    await writeFile(join(mixed, 'client.prd'), await readFile(prdPath));
+    const output = join(cwd, 'selected.prd');
+    expect(run(['client', 'pack', mixed, output, '-f', 'prd'], cwd).status).toBe(0);
+    expect(await readFile(output)).toEqual(await readFile(prdPath));
+  },
+);

--- a/test/e2e/popup-updater.test.ts
+++ b/test/e2e/popup-updater.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { expect, test } from 'vitest';
+
+test('popup displays update failure, retries, and renders a release without Temporal', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-popup-updater-'));
+  const extension = resolve('.output/chrome-mv3');
+  try {
+    const context = await chromium.launchPersistentContext(profile, {
+      channel: 'chromium',
+      headless: true,
+      viewport: { width: 500, height: 650 },
+      args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+    });
+    try {
+      const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      const popup = await context.newPage();
+      await popup.addInitScript(() => {
+        Reflect.deleteProperty(globalThis, 'Temporal');
+      });
+      let shouldFail = true;
+      await popup.route(
+        'https://api.github.com/repos/azot-labs/okova/releases/latest',
+        async (route) => {
+          if (shouldFail) {
+            await route.fulfill({ status: 503, body: 'Unavailable' });
+            return;
+          }
+          await route.fulfill({
+            json: {
+              tag_name: 'v99.0.0',
+              published_at: '2026-09-01T00:00:00Z',
+              assets: [
+                {
+                  name: 'okova-chrome.zip',
+                  browser_download_url: 'https://example.com/chrome.zip',
+                },
+              ],
+            },
+          });
+        },
+      );
+      const pageErrors: string[] = [];
+      popup.on('pageerror', (error) => pageErrors.push(error.message));
+      await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
+      await popup.getByRole('link', { name: 'Settings', exact: true }).click();
+      await popup.getByRole('button', { name: 'Check for Updates', exact: true }).click();
+      const retry = popup.getByRole('button', { name: /Retry Update Check/ });
+      await expect.poll(() => retry.isVisible()).toBe(true);
+      expect(await popup.getByText('Up to Date', { exact: true }).count()).toBe(0);
+      expect(await popup.getByText('Update check failed. Please try again.').isVisible()).toBe(
+        true,
+      );
+      shouldFail = false;
+      await retry.click();
+      await expect.poll(() => popup.getByText(/Version 99.0.0 \(published/).isVisible()).toBe(true);
+      expect(pageErrors).toEqual([]);
+      await mkdir(resolve('output/playwright/popup-updater'), { recursive: true });
+      await popup.screenshot({ path: resolve('output/playwright/popup-updater/success.png') });
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await rm(profile, { recursive: true, force: true });
+  }
+});

--- a/test/popup-updater.test.ts
+++ b/test/popup-updater.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { formatRelativeTime } from '../src/extension/entrypoints/popup/utils/date';
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      getManifest: () => ({ version: '0.13.0' }),
+      getURL: () => 'chrome-extension://test/',
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  vi.stubGlobal('Temporal', undefined);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const release = {
+  tag_name: 'v0.14.0',
+  published_at: '2026-09-01T00:00:00Z',
+  assets: [{ name: 'okova-chrome.zip', browser_download_url: 'https://example.com/chrome.zip' }],
+};
+
+test('formats dates without Temporal and respects the requested locale and time zone', () => {
+  const options = { locale: 'en-GB', timeZone: 'Asia/Tokyo' };
+  expect(formatRelativeTime(release.published_at, options)).toBe(
+    new Date(release.published_at).toLocaleString(options.locale, { timeZone: options.timeZone }),
+  );
+});
+
+test('loads a release without Temporal and prevents overlapping checks', async () => {
+  const fetchMock = vi.fn(async () => Response.json(release));
+  vi.stubGlobal('fetch', fetchMock);
+  const { useUpdater } = await import('../src/extension/entrypoints/popup/utils/updater');
+  const updater = useUpdater();
+  const checking = updater.checkForUpdates();
+  expect(updater.isCheckingForUpdates()).toBe(true);
+  await updater.checkForUpdates();
+  await checking;
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(updater.isCheckingForUpdates()).toBe(false);
+  expect(updater.updateCheckError()).toBeNull();
+  expect(updater.updateInfo()).toMatchObject({
+    version: '0.14.0',
+    url: release.assets[0].browser_download_url,
+  });
+  expect(updater.allowUpdateCheck()).toBe(false);
+  vi.advanceTimersByTime(30_000);
+  expect(updater.allowUpdateCheck()).toBe(true);
+});
+
+test.each(['http', 'network', 'invalid', 'missing asset'])(
+  'allows retry after %s failure and clears the error on success',
+  async (failure) => {
+    const fetchMock = vi.fn(async () => {
+      if (failure === 'network') throw new Error('Offline');
+      if (failure === 'http') return new Response(null, { status: 503 });
+      return Response.json(failure === 'invalid' ? {} : { ...release, assets: [] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { useUpdater } = await import('../src/extension/entrypoints/popup/utils/updater');
+    const updater = useUpdater();
+    await updater.checkForUpdates();
+    expect(updater.updateCheckError()).toContain('Update check failed');
+    expect(updater.allowUpdateCheck()).toBe(true);
+    expect(updater.isCheckingForUpdates()).toBe(false);
+    expect(updater.updateInfo()).toBeNull();
+    fetchMock.mockResolvedValueOnce(Response.json({ ...release, tag_name: 'v0.13.0' }));
+    await updater.checkForUpdates();
+    expect(updater.updateCheckError()).toBeNull();
+    expect(updater.allowUpdateCheck()).toBe(false);
+    expect(updater.updateInfo()).toBeNull();
+  },
+);


### PR DESCRIPTION
## Summary

- Enforce strict CLI command, option, positional, port, and credential format validation.
- Improve Widevine and PlayReady credential import, packing, unpacking, and metadata output.
- Harden extension client storage, importing, selection, deletion, update retries, and Temporal fallback handling.
- Add CLI and popup updater coverage while removing obsolete client storage tests.

## Testing

- Added and updated CLI tests for parsing and credential format validation.
- Added popup updater tests and Bitmovin DRM E2E coverage updates.
- Not run: full test suite and production extension build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791291714&installation_model_id=424872&pr_number=71&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F71&signature=a97768bd24dfaa450f1afecc1fa31a73083a93a3e378b999bce98ee27db2a382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->