### PR TITLE
fix: harden config loading, network inspection, and session cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ client must match the requested system.
 Wait for each session mutation to finish before starting another; overlapping
 requests return HTTP 409. Requests for different sessions can run concurrently.
 
+`okova serve` reads `okova.config.json` in the current directory and uses defaults
+if that file is absent. An explicit `--config <path>` must be readable. Malformed
+JSON or invalid settings stop startup before the server opens a listening socket.
+
 The server limits sessions and concurrent requests across all users and devices.
 In `okova.config.json`, optional `sessionLimits` fields override these defaults:
 

--- a/src/cli/commands/serve/serve.ts
+++ b/src/cli/commands/serve/serve.ts
@@ -18,8 +18,7 @@ type ServeOptions = {
 };
 
 export const serve = async (options: ServeOptions = {}) => {
-  const configPath = options.config || 'okova.config.json';
-  await loadConfig(configPath);
+  await loadConfig(options.config);
   if (options.client) config.clients.push(options.client);
   if (!config.clients.length) {
     const files = await readdir(process.cwd());

--- a/src/cli/commands/serve/state.ts
+++ b/src/cli/commands/serve/state.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { readFile } from 'node:fs/promises';
 import { basename, extname, resolve } from 'node:path';
 import { WidevineDeviceCredentials } from '../../../lib/widevine/device-credentials';
@@ -6,25 +7,18 @@ import { SessionRegistry, sessionLimitsSchema } from './session-registry';
 
 export const clients = new Map<string, WidevineDeviceCredentials | PlayReadyDeviceCredentials>();
 
-type Config = {
-  host: string;
-  port: number;
-  clients: string[];
-  users: { [secretKey: string]: { name: string; clients: string[] } };
-  forcePrivacyMode: boolean;
-  sessionLimits: ReturnType<typeof sessionLimitsSchema.parse>;
-};
+const configSchema = z.object({
+  host: z.string().min(1).default('0.0.0.0'),
+  port: z.number().int().min(0).max(65535).default(4000),
+  clients: z.array(z.string().min(1)).default([]),
+  users: z
+    .record(z.string(), z.object({ name: z.string(), clients: z.array(z.string()) }))
+    .default({}),
+  forcePrivacyMode: z.boolean().default(true),
+  sessionLimits: sessionLimitsSchema.prefault({}),
+});
 
-const defaultConfig = {
-  host: '0.0.0.0',
-  port: 4000,
-  clients: [],
-  users: {},
-  forcePrivacyMode: true,
-  sessionLimits: sessionLimitsSchema.parse({}),
-};
-
-export const config: Config = structuredClone(defaultConfig);
+export const config = configSchema.parse({});
 export const sessions = new SessionRegistry(() => config.sessionLimits);
 
 // Aliases must identify exactly one configured device, regardless of list order.
@@ -43,10 +37,31 @@ export const resolveClient = (identifier: string) => {
   return paths.size === 1 ? paths.values().next().value : undefined;
 };
 
-export const loadConfig = async (configPath: string) => {
-  const data = await readFile(configPath, { encoding: 'utf-8' })
-    .then((data) => JSON.parse(data))
-    .catch(() => defaultConfig);
-  const sessionLimits = sessionLimitsSchema.parse(data.sessionLimits ?? {});
-  Object.assign(config, data, { sessionLimits });
+// Only an absent implicit config permits starting with defaults.
+export const loadConfig = async (configPath?: string) => {
+  const path = configPath ?? 'okova.config.json';
+  let text: string;
+  try {
+    text = await readFile(path, 'utf-8');
+  } catch (error) {
+    if (
+      configPath === undefined &&
+      error instanceof Error &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      Object.assign(config, configSchema.parse({}));
+      return;
+    }
+    throw new Error(`Cannot read server config "${path}"`, { cause: error });
+  }
+  try {
+    const data: unknown = JSON.parse(text);
+    Object.assign(config, configSchema.parse(data));
+  } catch (error) {
+    throw new Error(
+      `Invalid server config "${path}": ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
 };

--- a/src/cli/commands/serve/state.ts
+++ b/src/cli/commands/serve/state.ts
@@ -7,15 +7,15 @@ import { SessionRegistry, sessionLimitsSchema } from './session-registry';
 
 export const clients = new Map<string, WidevineDeviceCredentials | PlayReadyDeviceCredentials>();
 
-const configSchema = z.object({
+const configSchema = z.strictObject({
   host: z.string().min(1).default('0.0.0.0'),
   port: z.number().int().min(0).max(65535).default(4000),
   clients: z.array(z.string().min(1)).default([]),
   users: z
-    .record(z.string(), z.object({ name: z.string(), clients: z.array(z.string()) }))
+    .record(z.string(), z.strictObject({ name: z.string(), clients: z.array(z.string()) }))
     .default({}),
   forcePrivacyMode: z.boolean().default(true),
-  sessionLimits: sessionLimitsSchema.prefault({}),
+  sessionLimits: sessionLimitsSchema.strict().prefault({}),
 });
 
 export const config = configSchema.parse({});

--- a/src/extension/entrypoints/network.tsx
+++ b/src/extension/entrypoints/network.tsx
@@ -34,7 +34,27 @@ export default defineUnlistedScript(() => {
     const headers = Object.fromEntries(response.headers.entries());
     if (!filterHead(url, headers)) return;
 
-    const text = await response.clone().text();
+    const reader = response.clone().body?.getReader();
+    if (!reader) return;
+    const decoder = new TextDecoder();
+    let sizeBytes = 0;
+    let text = '';
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        sizeBytes += value.byteLength;
+        if (sizeBytes >= MAX_SIZE) {
+          // A tee's cancellation can wait for the page to consume its branch.
+          void reader.cancel().catch(() => {});
+          return;
+        }
+        text += decoder.decode(value, { stream: true });
+      }
+      text += decoder.decode();
+    } finally {
+      reader.releaseLock();
+    }
     if (filterData(url, text)) postMessage(url, headers, text);
   };
 
@@ -83,7 +103,7 @@ export default defineUnlistedScript(() => {
           const header = parts.shift();
           if (!header) continue;
           const value = parts.join(': ');
-          headers[header] = value;
+          headers[header.toLowerCase()] = value;
         }
         if (!filterHead(url, headers)) return;
 
@@ -101,7 +121,7 @@ export default defineUnlistedScript(() => {
             text = new TextDecoder().decode(response);
             break;
           case 'blob':
-            if (!(response instanceof Blob)) return;
+            if (!(response instanceof Blob) || response.size >= MAX_SIZE) return;
             text = await response.text();
             break;
           case 'document':
@@ -111,6 +131,9 @@ export default defineUnlistedScript(() => {
           default:
             return;
         }
+        // Reject long strings before allocating a UTF-8 copy for the byte check.
+        if (text.length >= MAX_SIZE || new TextEncoder().encode(text).byteLength >= MAX_SIZE)
+          return;
         if (filterData(url, text)) postMessage(url, headers, text);
       }
     }

--- a/src/lib/remote/engine.ts
+++ b/src/lib/remote/engine.ts
@@ -115,21 +115,16 @@ class RemoteSession extends BaseMediaKeysEngineSession {
     this.#removeRequested ||= remove;
     // Both routes release the server session; concurrent calls share that cleanup.
     if (!this.#closePromise) {
-      this.#closePromise = this.#api
-        .close(this.sessionId, remove)
-        .then(() => {
-          this.isClosed = true;
-          this.keys.clear();
-          this.keyStatuses.clear();
-          this.#engine.sessions.delete(this.sessionId);
-          this.dispatchEvent(new Event('closed'));
-          if (this.#removeRequested) this.dispatchEvent(new Event('removed'));
-        })
-        .catch((error: unknown) => {
-          this.#closePromise = null;
-          this.#removeRequested = false;
-          throw error;
-        });
+      this.#closePromise = this.#api.close(this.sessionId, remove).finally(() => {
+        this.isClosed = true;
+        this.#initData = undefined;
+        this.#serviceCertificate = undefined;
+        this.keys.clear();
+        this.keyStatuses.clear();
+        this.#engine.sessions.delete(this.sessionId);
+        this.dispatchEvent(new Event('closed'));
+        if (this.#removeRequested) this.dispatchEvent(new Event('removed'));
+      });
     }
     return this.#closePromise;
   }

--- a/src/lib/remote/engine.ts
+++ b/src/lib/remote/engine.ts
@@ -115,16 +115,20 @@ class RemoteSession extends BaseMediaKeysEngineSession {
     this.#removeRequested ||= remove;
     // Both routes release the server session; concurrent calls share that cleanup.
     if (!this.#closePromise) {
-      this.#closePromise = this.#api.close(this.sessionId, remove).finally(() => {
-        this.isClosed = true;
-        this.#initData = undefined;
-        this.#serviceCertificate = undefined;
-        this.keys.clear();
-        this.keyStatuses.clear();
-        this.#engine.sessions.delete(this.sessionId);
-        this.dispatchEvent(new Event('closed'));
-        if (this.#removeRequested) this.dispatchEvent(new Event('removed'));
-      });
+      this.#closePromise = this.#api
+        .close(this.sessionId, remove)
+        .finally(() => {
+          this.isClosed = true;
+          this.#initData = undefined;
+          this.#serviceCertificate = undefined;
+          this.keys.clear();
+          this.keyStatuses.clear();
+          this.#engine.sessions.delete(this.sessionId);
+          this.dispatchEvent(new Event('closed'));
+        })
+        .then(() => {
+          if (this.#removeRequested) this.dispatchEvent(new Event('removed'));
+        });
     }
     return this.#closePromise;
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -99,6 +99,8 @@ test.each([
   ['license'],
   ['client', 'info', 'missing.wvd'],
   ['serve', '--config', 'invalid-config.json'],
+  ['serve', '--config', 'missing-config.json'],
+  ['serve', '--config', 'input.wvd'],
 ])('rejects invalid or unimplemented invocation %j', (...args) => {
   const result = run(args);
   expect(result.status, result.stdout).toBe(1);

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -152,9 +152,15 @@ const makeResponse = () =>
 
 test('page fetch returns before inspection finishes', async () => {
   const response = makeResponse();
-  const inspection = Promise.withResolvers<string>();
-  const clone = response.clone();
-  vi.spyOn(clone, 'text').mockReturnValue(inspection.promise);
+  const inspection = Promise.withResolvers<Uint8Array>();
+  const clone = new Response(
+    new ReadableStream({
+      async start(controller) {
+        controller.enqueue(await inspection.promise);
+        controller.close();
+      },
+    }),
+  );
   vi.spyOn(response, 'clone').mockReturnValue(clone);
   nativeFetch.mockResolvedValue(response);
   const options = { credentials: 'include' } satisfies RequestInit;
@@ -162,7 +168,7 @@ test('page fetch returns before inspection finishes', async () => {
   expect(nativeFetch).toHaveBeenCalledWith(url, options);
   expect(postMessage).not.toHaveBeenCalled();
   expect(await response.text()).toBe(manifest);
-  inspection.resolve(manifest);
+  inspection.resolve(new TextEncoder().encode(manifest));
   await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce());
 });
 
@@ -176,8 +182,13 @@ test.each(['clone', 'body', 'message'])(
         throw error;
       });
     } else if (failure === 'body') {
-      const clone = response.clone();
-      vi.spyOn(clone, 'text').mockRejectedValue(error);
+      const clone = new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(error);
+          },
+        }),
+      );
       vi.spyOn(response, 'clone').mockReturnValue(clone);
     } else {
       postMessage.mockImplementation(() => {
@@ -197,3 +208,41 @@ test('page fetch preserves network failures', async () => {
   await expect(fetch(url)).rejects.toBe(error);
   expect(console.warn).not.toHaveBeenCalled();
 });
+
+test.each(['', '1'])(
+  'bounds headerless or understated fetch bodies, Content-Length %j',
+  async (contentLength) => {
+    const body = manifest + ' '.repeat(2 * 1024 * 1024);
+    const response = new Response(body, {
+      headers: {
+        'content-type': 'application/octet-stream',
+        ...(contentLength ? { 'content-length': contentLength } : {}),
+      },
+    });
+    const clone = response.clone();
+    const reader = clone.body!.getReader();
+    const cancel = vi.spyOn(reader, 'cancel');
+    vi.spyOn(clone.body!, 'getReader').mockReturnValue(reader);
+    vi.spyOn(response, 'clone').mockReturnValue(clone);
+    nativeFetch.mockResolvedValue(response);
+    expect(await fetch(url)).toBe(response);
+    expect(await response.text()).toBe(body);
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    expect(postMessage).not.toHaveBeenCalled();
+  },
+);
+
+test.each(['text', 'blob'] as const)(
+  'rejects oversized XHR %s before posting or reading blobs',
+  async (responseType) => {
+    const body = manifest + 'é'.repeat(600_000);
+    const blob = new Blob([body]);
+    const read = vi.spyOn(blob, 'text');
+    const xhr = new XMLHttpRequest();
+    Object.assign(xhr, { responseType, response: responseType === 'blob' ? blob : body });
+    xhr.dispatchEvent(new Event('load'));
+    await Promise.resolve();
+    expect(read).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+  },
+);

--- a/test/remote-protocol.test.ts
+++ b/test/remote-protocol.test.ts
@@ -496,7 +496,10 @@ test.each(['close', 'remove'] as const)(
     const native = await engine.createSession();
     const session = new Session('temporary', engine, native);
     const closed = vi.fn();
+    const removed = vi.fn();
     native.addEventListener('closed', closed);
+    native.addEventListener('removed', removed);
+    session.addEventListener('removed', removed);
     const waiting = expect(native.waitForKeys()).rejects.toThrow('Session closed');
     native.keys.set(keyId, key);
     native.keyStatuses.set(keyId, 'usable');
@@ -510,12 +513,13 @@ test.each(['close', 'remove'] as const)(
     await expect(native.update(new Uint8Array())).rejects.toThrow('Session closed');
     await native.close();
     expect(closed).toHaveBeenCalledOnce();
+    expect(removed).not.toHaveBeenCalled();
     expect(fetch).toHaveBeenCalledTimes(2);
   },
 );
 
-test.each(['timeout', 'restart'] as const)(
-  'remote cleanup releases waiters after a server %s',
+test.each(['timeout', 'restart', 'server error'] as const)(
+  'remote cleanup releases waiters after %s',
   async (failure) => {
     const fetch = vi
       .fn<typeof globalThis.fetch>()
@@ -527,6 +531,8 @@ test.each(['timeout', 'restart'] as const)(
       requestTimeoutMs: 50,
     });
     const session = await engine.createSession();
+    const removed = vi.fn();
+    session.addEventListener('removed', removed);
     const waiting = expect(session.waitForKeys()).rejects.toThrow('Session closed');
     if (failure === 'timeout') {
       vi.useFakeTimers();
@@ -543,12 +549,15 @@ test.each(['timeout', 'restart'] as const)(
           ),
       );
     } else {
-      fetch.mockResolvedValueOnce(Response.json({ error: 'Session not found' }, { status: 404 }));
+      fetch.mockResolvedValueOnce(
+        Response.json({ error: 'Cleanup failed' }, { status: failure === 'restart' ? 404 : 500 }),
+      );
     }
-    const closing = expect(session.close()).rejects.toThrow();
+    const closing = expect(session.remove()).rejects.toThrow();
     if (failure === 'timeout') await vi.advanceTimersByTimeAsync(50);
     await closing;
     await waiting;
+    expect(removed).not.toHaveBeenCalled();
     expect(engine.sessions.size).toBe(0);
     await session.close();
     expect(fetch).toHaveBeenCalledTimes(2);

--- a/test/remote-protocol.test.ts
+++ b/test/remote-protocol.test.ts
@@ -484,3 +484,73 @@ test('resume identity uses effective headers regardless of casing, order, or ove
   });
   expect(engine.resumeSession(state).sessionId).toBe('session');
 });
+
+test.each(['close', 'remove'] as const)(
+  '%s disposes local state when remote cleanup fails',
+  async (operation) => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(Response.json({ id: 'session' }));
+    vi.stubGlobal('fetch', fetch);
+    const engine = new Remote({ keySystem: 'com.widevine.alpha', baseUrl: 'https://cdm.test' });
+    const native = await engine.createSession();
+    const session = new Session('temporary', engine, native);
+    const closed = vi.fn();
+    native.addEventListener('closed', closed);
+    const waiting = expect(native.waitForKeys()).rejects.toThrow('Session closed');
+    native.keys.set(keyId, key);
+    native.keyStatuses.set(keyId, 'usable');
+    fetch.mockRejectedValueOnce(new Error('Server unavailable'));
+    await expect(session[operation]()).rejects.toThrow('Server unavailable');
+    await waiting;
+    expect(native.keys.size).toBe(0);
+    expect(native.keyStatuses.size).toBe(0);
+    expect(engine.sessions.size).toBe(0);
+    expect(() => session.pause()).toThrow('Session closed');
+    await expect(native.update(new Uint8Array())).rejects.toThrow('Session closed');
+    await native.close();
+    expect(closed).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  },
+);
+
+test.each(['timeout', 'restart'] as const)(
+  'remote cleanup releases waiters after a server %s',
+  async (failure) => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(Response.json({ id: 'session' }));
+    vi.stubGlobal('fetch', fetch);
+    const engine = new Remote({
+      keySystem: 'com.widevine.alpha',
+      baseUrl: 'https://cdm.test',
+      requestTimeoutMs: 50,
+    });
+    const session = await engine.createSession();
+    const waiting = expect(session.waitForKeys()).rejects.toThrow('Session closed');
+    if (failure === 'timeout') {
+      vi.useFakeTimers();
+      fetch.mockImplementationOnce(
+        async (_url, init) =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                init?.signal?.addEventListener('abort', () =>
+                  controller.error(init.signal?.reason),
+                );
+              },
+            }),
+          ),
+      );
+    } else {
+      fetch.mockResolvedValueOnce(Response.json({ error: 'Session not found' }, { status: 404 }));
+    }
+    const closing = expect(session.close()).rejects.toThrow();
+    if (failure === 'timeout') await vi.advanceTimersByTimeAsync(50);
+    await closing;
+    await waiting;
+    expect(engine.sessions.size).toBe(0);
+    await session.close();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  },
+);

--- a/test/serve-config.test.ts
+++ b/test/serve-config.test.ts
@@ -54,3 +54,15 @@ test('loading a new config resets omitted settings to defaults', async () => {
   expect(config.port).toBe(4000);
   expect(config.clients).toEqual([]);
 });
+
+test.each([
+  { porrt: 8080 },
+  { users: { secret: { name: 'test', clients: [], clietns: ['test.wvd'] } } },
+  { sessionLimits: { maxSession: 1 } },
+])('rejects unknown configuration fields in %j', async (data) => {
+  const path = await setup();
+  const before = structuredClone(config);
+  await writeFile(path, JSON.stringify(data));
+  await expect(loadConfig(path)).rejects.toThrow('Unrecognized key');
+  expect(config).toEqual(before);
+});

--- a/test/serve-config.test.ts
+++ b/test/serve-config.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+import { config, loadConfig } from '../src/cli/commands/serve/state';
+
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+const setup = async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'okova-config-'));
+  directories.push(directory);
+  return join(directory, 'config.json');
+};
+
+test('only a missing implicit configuration uses defaults', async () => {
+  const path = await setup();
+  await expect(loadConfig(path)).rejects.toThrow('Cannot read server config');
+  const originalDirectory = process.cwd();
+  try {
+    process.chdir(directories[0]!);
+    await loadConfig();
+    expect(config.port).toBe(4000);
+    expect(config.clients).toEqual([]);
+    await writeFile('okova.config.json', '{');
+    await expect(loadConfig()).rejects.toThrow('Invalid server config');
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test.each(['{', 'null', '[]', '{"port":"4000"}', '{"clients":false}'])(
+  'rejects malformed or invalid config %s without changing current settings',
+  async (text) => {
+    const path = await setup();
+    const before = structuredClone(config);
+    await writeFile(path, text);
+    await expect(loadConfig(path)).rejects.toThrow('Invalid server config');
+    expect(config).toEqual(before);
+  },
+);
+
+test('loading a new config resets omitted settings to defaults', async () => {
+  const path = await setup();
+  await writeFile(path, JSON.stringify({ port: 1234, clients: ['test.wvd'] }));
+  await loadConfig(path);
+  expect(config.port).toBe(1234);
+  await writeFile(path, '{}');
+  await loadConfig(path);
+  expect(config.port).toBe(4000);
+  expect(config.clients).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- Validate server configuration and fail clearly for unreadable or invalid explicit files.
- Bound network response inspection by size, normalize XHR headers, and avoid oversized blobs.
- Always dispose remote session state after cleanup failures.
- Add regression coverage and document server configuration behavior.

## Testing

- Added CLI coverage for missing, invalid, and unsupported serve configurations.
- Added server config tests for defaults, validation, and reset behavior.
- Added extension network tests for oversized fetch and XHR responses.
- Added remote protocol tests for cleanup failures, timeouts, and server restarts.
- Not run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791293102&installation_model_id=424872&pr_number=72&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F72&signature=08cc3226428a6c68ffcdebd0c6f0dadf3f5a914992c79e33416c90c271d699d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->