### PR TITLE
fix(extension): handle playready during manifest interception and reduce content script bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Import a Widevine or PlayReady client in **Clients**. Okova automatically enable
 
 Playback depends on the website, browser, and client. Offline licenses and hardware-protected playback are not supported.
 
-Experimental request interception detects streaming manifests in page fetch and XMLHttpRequest responses. Requests made inside workers are not inspected.
+Experimental request interception associates Widevine and PlayReady DASH manifests with captured sessions using their `cenc:pssh` boxes. It supports page fetch and XMLHttpRequest responses, including alternate XML prefixes and concatenated initialization data. HLS playlists and requests made inside workers are not inspected.
 
 The toolbar badge shows a count capped at `99+`, followed by `W`, `P`, or `C` for Widevine, PlayReady, or ClearKey, such as `3W` or `99+W`:
 

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -30,7 +30,7 @@ import { SignedDrmCertificate, SignedMessage } from '@okova/lib/widevine/proto';
 import { isServiceCertificate as isWidevineServiceCertificate } from '@okova/lib/widevine/message';
 import { WidevineDeviceCredentials } from '@okova/lib/widevine/device-credentials';
 import { withAbort } from '@okova/lib/abort';
-import { normalizeKeySystem } from '@okova/lib/key-system';
+import { CLIENT_KEY_SYSTEMS, normalizeKeySystem } from '@okova/lib/key-system';
 import { Session } from '@okova/lib/api';
 import { RemoteClient } from '@/utils/remote-client';
 import type { Client } from '@/utils/storage';
@@ -396,6 +396,16 @@ export default defineBackground({
         }
       };
       const handleMessage = async () => {
+        if (message.action === 'playback-config') {
+          const client = await run(appStorage.clients.active.getInfo());
+          if (!client) respond(null);
+          else if (client.type === 'remote') respond(client.config.keySystem);
+          else
+            respond(
+              client.type === 'wvd' ? CLIENT_KEY_SYSTEMS.widevine : CLIENT_KEY_SYSTEMS.playready,
+            );
+          return;
+        }
         if (message.action === 'close') {
           stage = 'close';
           if (sessionKey) await closeSession(sessionKey);

--- a/src/extension/entrypoints/content.ts
+++ b/src/extension/entrypoints/content.ts
@@ -1,14 +1,5 @@
-import { CLIENT_KEY_SYSTEMS } from '@okova/lib/key-system';
-import { appStorage } from '@/utils/storage';
+import { settingsStorage } from '@/utils/storage/settings';
 import type { PublicPath } from 'wxt/browser';
-
-const getActiveClientKeySystem = async () => {
-  const client = await appStorage.clients.active.getInfo();
-  if (!client) return null;
-  if (client.type === 'wvd') return CLIENT_KEY_SYSTEMS.widevine;
-  if (client.type === 'remote') return client.config.keySystem;
-  return CLIENT_KEY_SYSTEMS.playready;
-};
 
 const inject = (script: PublicPath) => {
   return new Promise<void>((resolve, reject) => {
@@ -33,7 +24,7 @@ export default defineContentScript({
   allFrames: true,
   async main() {
     // Checking if interception enabled
-    const settings = await appStorage.settings.getValue();
+    const settings = await settingsStorage.getValue();
 
     // Listen for event from injected script
     window.addEventListener(
@@ -46,10 +37,7 @@ export default defineContentScript({
         const { requestId, log } = event.data;
         const message = { ...log, url: window.location.href };
         try {
-          const body =
-            log.action === 'playback-config'
-              ? await getActiveClientKeySystem()
-              : await browser.runtime.sendMessage(message);
+          const body = await browser.runtime.sendMessage(message);
           // Firefox blocks page scripts from reading object detail created in a content script.
           window.dispatchEvent(
             new CustomEvent('drm-message-response', {

--- a/src/extension/entrypoints/eme.tsx
+++ b/src/extension/entrypoints/eme.tsx
@@ -1,3 +1,4 @@
+import { findManifest } from '@/utils/manifest';
 import { toBytes, bytesToBase64, fromBase64 } from '@okova/lib/utils';
 import { sendDrmMessage } from '@/utils/drm-bridge';
 import { playbackSessions } from '@/utils/playback-sessions';
@@ -98,7 +99,7 @@ export const installEmeInterception = () => {
         keySystem: getKeySystem(session),
         initData: session.initData,
         initDataType: session.initDataType,
-        mpd: window.MPD_LIST.get(session.initData!),
+        mpd: findManifest(session.initData),
         keyStatuses,
       });
       return;
@@ -175,7 +176,7 @@ export const installEmeInterception = () => {
         initDataType: session.initDataType,
         message,
         messageBase64,
-        mpd: window.MPD_LIST.get(session.initData!),
+        mpd: findManifest(session.initData),
       });
 
       if (result?.keys) {

--- a/src/extension/entrypoints/manifest.tsx
+++ b/src/extension/entrypoints/manifest.tsx
@@ -16,7 +16,7 @@ declare global {
 }
 
 export default defineUnlistedScript(() => {
-  window.MPD_LIST ??= new Map();
+  if (!(window.MPD_LIST instanceof Map)) window.MPD_LIST = new Map();
 
   window.addEventListener('message', (event: MessageEvent<unknown>) => {
     if (event.source !== window) return;

--- a/src/extension/entrypoints/manifest.tsx
+++ b/src/extension/entrypoints/manifest.tsx
@@ -1,3 +1,14 @@
+import { z } from 'zod/mini';
+import { splitPssh } from '@/utils/manifest';
+
+const DASH_NAMESPACE = 'urn:mpeg:dash:schema:mpd:2011';
+const CENC_NAMESPACE = 'urn:mpeg:cenc:2013';
+const responseSchema = z.object({
+  namespace: z.literal('okova:network'),
+  method: z.literal('response'),
+  params: z.object({ url: z.string(), text: z.string().check(z.maxLength(1024 * 1024)) }),
+});
+
 declare global {
   interface Window {
     MPD_LIST: Map<string, string>;
@@ -5,30 +16,31 @@ declare global {
 }
 
 export default defineUnlistedScript(() => {
-  window.MPD_LIST = new Map();
+  window.MPD_LIST ??= new Map();
 
-  const parsePssh = (text: string, url: string) => {
-    const parser = new DOMParser();
-    const mpd = parser.parseFromString(text, 'text/xml');
-    const contentProtectionList = mpd.querySelectorAll(
-      'ContentProtection[schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"]',
-    );
-    for (const contentProtection of contentProtectionList) {
-      const children = Array.from(contentProtection.children);
-      for (const child of children) {
-        if (child.nodeName === 'cenc:pssh') {
-          const pssh = child.textContent;
-          if (!pssh) continue;
-          window.MPD_LIST.set(pssh, url);
+  window.addEventListener('message', (event: MessageEvent<unknown>) => {
+    if (event.source !== window) return;
+    const parsed = responseSchema.safeParse(event.data);
+    if (!parsed.success) return;
+    const { url, text } = parsed.data.params;
+    try {
+      const mpd = new DOMParser().parseFromString(text, 'text/xml');
+      if (mpd.getElementsByTagNameNS('*', 'parsererror').length) return;
+      if (
+        mpd.documentElement?.localName !== 'MPD' ||
+        mpd.documentElement.namespaceURI !== DASH_NAMESPACE
+      )
+        return;
+      for (const protection of Array.from(
+        mpd.getElementsByTagNameNS(DASH_NAMESPACE, 'ContentProtection'),
+      )) {
+        for (const child of Array.from(protection.getElementsByTagNameNS(CENC_NAMESPACE, 'pssh'))) {
+          if (child.parentNode !== protection) continue;
+          for (const pssh of splitPssh(child.textContent ?? '')) window.MPD_LIST.set(pssh, url);
         }
       }
+    } catch {
+      // An unrelated or malformed response must not break page message dispatch.
     }
-  };
-
-  window.addEventListener('message', (event) => {
-    const isResponse = event.data.method === 'response';
-    if (!isResponse) return;
-    const { url, headers, text } = event.data.params;
-    parsePssh(text, url);
   });
 });

--- a/src/extension/entrypoints/network.tsx
+++ b/src/extension/entrypoints/network.tsx
@@ -15,13 +15,13 @@ export default defineUnlistedScript(() => {
   };
 
   const filterData = (url: string, text: string) => {
-    const isManifest = text.startsWith('<?xml') || text.startsWith('<MPD');
+    const isManifest = text.trimStart().startsWith('<');
     return isManifest;
   };
 
   const postMessage = (url: string, headers: Record<string, string>, text: string) => {
     const message = {
-      jsonrpc: '2.0',
+      namespace: 'okova:network',
       method: 'response',
       params: { url, text, headers },
       id: Date.now(),

--- a/src/extension/utils/drm-playback.ts
+++ b/src/extension/utils/drm-playback.ts
@@ -1,3 +1,4 @@
+import { findManifest } from '@/utils/manifest';
 import { z } from 'zod';
 import { CLIENT_KEY_SYSTEMS, type ClientKeySystem } from '@okova/lib/key-system';
 import { toBytes, bytesToBase64, fromHex, fromBase64 } from '@okova/lib/utils';
@@ -71,7 +72,7 @@ export const installDrmPlayback = () => {
           initDataType: 'cenc',
           initData,
           serverCertificate,
-          mpd: initData ? window.MPD_LIST?.get(initData) : undefined,
+          mpd: findManifest(initData),
         });
       const dispatchChallenge = (challenge: ArrayBuffer) => {
         // Deliver as a task, after generateRequest or update has resolved.

--- a/src/extension/utils/manifest.ts
+++ b/src/extension/utils/manifest.ts
@@ -1,0 +1,40 @@
+// Match the original box bytes without decoding DRM-specific payloads.
+export const splitPssh = (initData: string): string[] => {
+  try {
+    const binary = atob(initData.replace(/\s/g, ''));
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    const view = new DataView(bytes.buffer);
+    const boxes: string[] = [];
+    let offset = 0;
+    while (offset < bytes.length) {
+      if (bytes.length - offset < 8 || view.getUint32(offset + 4) !== 0x70737368) return [];
+      const size = view.getUint32(offset);
+      let length = size || bytes.length - offset;
+      let headerLength = 8;
+      if (size === 1) {
+        if (bytes.length - offset < 16) return [];
+        const extendedSize = view.getBigUint64(offset + 8);
+        if (extendedSize > BigInt(bytes.length - offset)) return [];
+        length = Number(extendedSize);
+        headerLength = 16;
+      }
+      if (length < headerLength + 24 || length > bytes.length - offset) return [];
+      boxes.push(btoa(binary.slice(offset, offset + length)));
+      offset += length;
+    }
+    return boxes;
+  } catch {
+    return [];
+  }
+};
+
+export const findManifest = (initData: string | undefined) => {
+  if (!initData || !window.MPD_LIST) return undefined;
+  const exact = window.MPD_LIST.get(initData);
+  if (exact) return exact;
+  for (const pssh of splitPssh(initData)) {
+    const url = window.MPD_LIST.get(pssh);
+    if (url) return url;
+  }
+  return undefined;
+};

--- a/src/extension/utils/manifest.ts
+++ b/src/extension/utils/manifest.ts
@@ -29,7 +29,7 @@ export const splitPssh = (initData: string): string[] => {
 };
 
 export const findManifest = (initData: string | undefined) => {
-  if (!initData || !window.MPD_LIST) return undefined;
+  if (!initData || !(window.MPD_LIST instanceof Map)) return undefined;
   const exact = window.MPD_LIST.get(initData);
   if (exact) return exact;
   for (const pssh of splitPssh(initData)) {

--- a/src/extension/utils/storage/json.ts
+++ b/src/extension/utils/storage/json.ts
@@ -1,0 +1,27 @@
+import type { WxtStorageItem } from '#imports';
+
+type WatchCallback<T> = (newValue: T, oldValue: T) => void;
+
+export const asJson = <K, T extends WxtStorageItem<K | null, {}> = WxtStorageItem<K | null, {}>>(
+  item: T,
+): T => ({
+  ...item,
+  getValue: async () => {
+    const value = await item.getValue();
+    if (!value) return value;
+    return JSON.parse(value as unknown as string) as K;
+  },
+  setValue: async (value: Uint8Array) => {
+    const data = JSON.stringify(value) as unknown as K;
+    return item.setValue(data);
+  },
+  watch: (callback: WatchCallback<K>) => {
+    return item.watch((newValue, oldValue) => {
+      if (!newValue) return;
+      callback(
+        JSON.parse(newValue as unknown as string) as K,
+        JSON.parse(oldValue as unknown as string) as K,
+      );
+    });
+  },
+});

--- a/src/extension/utils/storage/settings.ts
+++ b/src/extension/utils/storage/settings.ts
@@ -1,0 +1,40 @@
+import { storage } from '#imports';
+import { asJson } from './json';
+
+export type Settings = {
+  spoofing: boolean;
+  clientPlayback: boolean;
+  emeInterception: boolean;
+  requestInterception: boolean;
+  theme: ThemeMode;
+};
+
+export type ThemeMode = 'light' | 'dark' | 'auto';
+
+export const storedSettings = asJson(
+  storage.defineItem<Omit<Settings, 'clientPlayback'> & { clientPlayback?: boolean }>(
+    'local:settings',
+  ),
+);
+
+const normalizeSettings = (
+  settings: Awaited<ReturnType<typeof storedSettings.getValue>>,
+): Settings | null =>
+  settings ? { ...settings, clientPlayback: settings.clientPlayback ?? false } : null;
+
+export const defaultSettings: Settings = {
+  emeInterception: true,
+  spoofing: false,
+  clientPlayback: false,
+  requestInterception: false,
+  theme: 'auto',
+};
+
+export const settingsStorage = {
+  ...storedSettings,
+  getValue: async () => normalizeSettings(await storedSettings.getValue()),
+  watch: (callback: (newValue: Settings | null, oldValue: Settings | null) => void) =>
+    storedSettings.watch((newValue, oldValue) =>
+      callback(normalizeSettings(newValue), normalizeSettings(oldValue)),
+    ),
+};

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -5,7 +5,10 @@ import { RemoteClient } from '../remote-client';
 import { WidevineDeviceCredentials } from '../../../lib/widevine/device-credentials';
 import { PlayReadyDeviceCredentials } from '../../../lib/playready/device-credentials';
 import { fromBase64, fromBuffer } from '../../../lib';
-import { asJson } from './utils';
+import { asJson } from './json';
+import { defaultSettings, settingsStorage, storedSettings, type Settings } from './settings';
+
+export { defaultSettings, type Settings, type ThemeMode } from './settings';
 
 export type BadgeDrmSystem = 'W' | 'P' | 'C';
 
@@ -71,16 +74,6 @@ export const getRecentKeysForUrl = (
   return legacyDomain === domain ? legacyKeys : [];
 };
 
-export type Settings = {
-  spoofing: boolean;
-  clientPlayback: boolean;
-  emeInterception: boolean;
-  requestInterception: boolean;
-  theme: ThemeMode;
-};
-
-export type ThemeMode = 'light' | 'dark' | 'auto';
-
 export type Client = WidevineDeviceCredentials | PlayReadyDeviceCredentials | RemoteClient;
 export const clientInfoSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('wvd'), data: z.string() }),
@@ -113,25 +106,6 @@ const mutateKeyHistory = (mutation: () => Promise<void>) =>
   navigator.locks.request('okova:key-history', mutation);
 
 const recentKeys = asJson(storage.defineItem<KeyInfo[]>('local:recent-keys'));
-
-const storedSettings = asJson(
-  storage.defineItem<Omit<Settings, 'clientPlayback'> & { clientPlayback?: boolean }>(
-    'local:settings',
-  ),
-);
-
-const normalizeSettings = (
-  settings: Awaited<ReturnType<typeof storedSettings.getValue>>,
-): Settings | null =>
-  settings ? { ...settings, clientPlayback: settings.clientPlayback ?? false } : null;
-
-export const defaultSettings: Settings = {
-  emeInterception: true,
-  spoofing: false,
-  clientPlayback: false,
-  requestInterception: false,
-  theme: 'auto',
-};
 
 const clientRegistrySchema = z.object({
   clients: z.array(z.object({ id: z.string(), info: clientInfoSchema })),
@@ -282,14 +256,7 @@ const clientStorage = {
 };
 
 export const appStorage = {
-  settings: {
-    ...storedSettings,
-    getValue: async () => normalizeSettings(await storedSettings.getValue()),
-    watch: (callback: (newValue: Settings | null, oldValue: Settings | null) => void) =>
-      storedSettings.watch((newValue, oldValue) =>
-        callback(normalizeSettings(newValue), normalizeSettings(oldValue)),
-      ),
-  },
+  settings: settingsStorage,
 
   recentKeys: {
     ...recentKeys,

--- a/src/extension/utils/storage/utils.ts
+++ b/src/extension/utils/storage/utils.ts
@@ -1,7 +1,7 @@
 import { WxtStorageItem } from '#imports';
 import { fromBase64, fromBuffer } from '../../../lib';
 
-type WatchCallback<T> = (newValue: T, oldValue: T) => void;
+export { asJson } from './json';
 
 export const asBytes = <T extends WxtStorageItem<Uint8Array | null, {}>>(item: T): T => ({
   ...item,
@@ -13,29 +13,5 @@ export const asBytes = <T extends WxtStorageItem<Uint8Array | null, {}>>(item: T
   setValue: async (value: Uint8Array) => {
     const data = fromBuffer(value).toBase64() as unknown as Uint8Array;
     return item.setValue(data);
-  },
-});
-
-export const asJson = <K, T extends WxtStorageItem<K | null, {}> = WxtStorageItem<K | null, {}>>(
-  item: T,
-): T => ({
-  ...item,
-  getValue: async () => {
-    const value = await item.getValue();
-    if (!value) return value;
-    return JSON.parse(value as unknown as string) as K;
-  },
-  setValue: async (value: Uint8Array) => {
-    const data = JSON.stringify(value) as unknown as K;
-    return item.setValue(data);
-  },
-  watch: (callback: WatchCallback<K>) => {
-    return item.watch((newValue, oldValue) => {
-      if (!newValue) return;
-      callback(
-        JSON.parse(newValue as unknown as string) as K,
-        JSON.parse(oldValue as unknown as string) as K,
-      );
-    });
   },
 });

--- a/test/drm-bridge.test.ts
+++ b/test/drm-bridge.test.ts
@@ -2,18 +2,18 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import content from '../src/extension/entrypoints/content';
-import { appStorage, type Settings } from '../src/extension/utils/storage';
+import { settingsStorage, type Settings } from '../src/extension/utils/storage/settings';
 import { sendDrmMessage } from '../src/extension/utils/drm-bridge';
 
-vi.mock('../src/extension/utils/storage', () => ({
-  appStorage: { settings: { getValue: vi.fn<() => Promise<Partial<Settings>>>() } },
+vi.mock('../src/extension/utils/storage/settings', () => ({
+  settingsStorage: { getValue: vi.fn<() => Promise<Settings | null>>() },
 }));
 
 const postMessage = vi.fn<(message: { requestId: string }, origin: string) => void>();
 const sendMessage = vi.fn<(message: unknown) => Promise<unknown>>();
 
 beforeEach(() => {
-  vi.mocked(appStorage.settings.getValue).mockResolvedValue(null);
+  vi.mocked(settingsStorage.getValue).mockResolvedValue(null);
   vi.useFakeTimers();
   vi.stubGlobal(
     'window',
@@ -174,7 +174,7 @@ test.each([undefined, 'license challenge', { keys: [{ id: 'key-id', value: 'key-
 );
 
 test('registers the bridge before loading scripts and waits for manifest initialization', async () => {
-  vi.mocked(appStorage.settings.getValue).mockResolvedValue({
+  vi.mocked(settingsStorage.getValue).mockResolvedValue({
     emeInterception: true,
     spoofing: true,
     clientPlayback: true,

--- a/test/e2e/manifest.test.ts
+++ b/test/e2e/manifest.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { expect, test } from 'vitest';
+
+// Empty, structurally valid PSSH boxes. No provision or license service is needed.
+const pssh = (systemId: string) => {
+  const box = Buffer.alloc(32);
+  box.writeUInt32BE(32);
+  box.write('pssh', 4);
+  Buffer.from(systemId, 'hex').copy(box, 12);
+  return box.toString('base64');
+};
+const widevine = pssh('edef8ba979d64acea3c827dcd51d21ed');
+const playready = pssh('9a04f07998404286ab92e65be0885f95');
+const manifestUrl = 'https://okova.test/manifest.mpd';
+
+test('built content bridge associates DASH and reads playback configuration through the worker', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-manifest-'));
+  const extension = resolve('.output/chrome-mv3');
+  try {
+    const context = await chromium.launchPersistentContext(profile, {
+      channel: 'chromium',
+      headless: true,
+      args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+    });
+    try {
+      const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      await worker.evaluate(async () => {
+        await browser.storage.local.set({
+          settings: JSON.stringify({
+            spoofing: false,
+            clientPlayback: false,
+            emeInterception: false,
+            requestInterception: true,
+            theme: 'auto',
+          }),
+          'client-registry': {
+            clients: [
+              {
+                id: 'synthetic',
+                info: {
+                  type: 'remote',
+                  config: {
+                    protocol: 'okova',
+                    keySystem: 'com.widevine.alpha',
+                    baseUrl: 'https://unused.test',
+                  },
+                },
+              },
+            ],
+            activeClientId: 'synthetic',
+          },
+        });
+      });
+      await context.route('https://okova.test/**', async (route) => {
+        if (route.request().url() === manifestUrl) {
+          await route.fulfill({
+            contentType: 'application/dash+xml',
+            body: `
+            <d:MPD xmlns:d="urn:mpeg:dash:schema:mpd:2011" xmlns:p="urn:mpeg:cenc:2013">
+              <d:Period><d:AdaptationSet>
+                <d:ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"><p:pssh>${widevine}</p:pssh></d:ContentProtection>
+                <d:ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"><p:pssh>\n${playready.slice(0, 16)}\n${playready.slice(16)}\n</p:pssh></d:ContentProtection>
+              </d:AdaptationSet></d:Period>
+            </d:MPD>`,
+          });
+        } else {
+          await route.fulfill({
+            contentType: 'text/html',
+            body: '<!doctype html><title>Okova manifest check</title>',
+          });
+        }
+      });
+      const page = await context.newPage();
+      const errors: string[] = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      const readinessMs: number[] = [];
+      for (let index = 0; index < 5; index++) {
+        const ready = page.waitForEvent('console', {
+          predicate: (message) => message.text() === '[okova] Response interception added',
+        });
+        await page.goto(`https://okova.test/page-${index}`);
+        await ready;
+        // Resource timing covers loading the content script's dependent page script.
+        readinessMs.push(
+          await page.evaluate(() => {
+            const entry = performance
+              .getEntriesByType('resource')
+              .find((item) => item.name.endsWith('/manifest.js'));
+            return entry ? entry.startTime + entry.duration : performance.now();
+          }),
+        );
+        await page.evaluate(async (url) => {
+          window.postMessage(null, '*');
+          window.postMessage({ method: 'response', params: null }, '*');
+          await fetch(url);
+        }, manifestUrl);
+        await expect.poll(() => page.evaluate(() => window.MPD_LIST.size)).toBe(2);
+        expect(
+          await page.evaluate(
+            (keys) => keys.map((key) => window.MPD_LIST.get(key)),
+            [widevine, playready],
+          ),
+        ).toEqual([manifestUrl, manifestUrl]);
+      }
+      const activeSystem = await page.evaluate(
+        () =>
+          new Promise((resolve) => {
+            const requestId = 'browser-config-check';
+            const onResponse = (event: Event) => {
+              if (!(event instanceof CustomEvent) || typeof event.detail !== 'string') return;
+              const response = JSON.parse(event.detail);
+              if (response.requestId !== requestId) return;
+              window.removeEventListener('drm-message-response', onResponse);
+              resolve(response.body);
+            };
+            window.addEventListener('drm-message-response', onResponse);
+            window.postMessage(
+              { type: 'drm-message', requestId, log: { action: 'playback-config' } },
+              '*',
+            );
+          }),
+      );
+      expect(activeSystem).toBe('com.widevine.alpha');
+      expect(errors).toEqual([]);
+      const artifacts = resolve('output/playwright/manifest');
+      await mkdir(artifacts, { recursive: true });
+      await writeFile(
+        join(artifacts, 'timing.json'),
+        JSON.stringify({ manifestLoadedMs: readinessMs }, null, 2),
+      );
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await rm(profile, { recursive: true, force: true });
+  }
+});

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -1,0 +1,98 @@
+import { DOMParser } from '@xmldom/xmldom';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import manifest from '../src/extension/entrypoints/manifest';
+import { findManifest, splitPssh } from '../src/extension/utils/manifest';
+import { createPsshBox, psshBoxToBase64, PSSH_SYSTEM_IDS } from '../src/lib/pssh';
+
+const widevine = psshBoxToBase64(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine }));
+const playready = psshBoxToBase64(createPsshBox({ systemId: PSSH_SYSTEM_IDS.playready }));
+const combined = btoa(atob(widevine) + atob(playready));
+const url = 'https://example.test/manifest.mpd';
+let receive: (event: { source: unknown; data: unknown }) => void;
+
+const mpd = (pssh: string, scheme: string = PSSH_SYSTEM_IDS.widevine) => `
+  <dash:MPD xmlns:dash="urn:mpeg:dash:schema:mpd:2011" xmlns:other="urn:mpeg:cenc:2013">
+    <dash:Period><dash:AdaptationSet><dash:ContentProtection schemeIdUri="urn:uuid:${scheme}">
+      <other:pssh>\n ${pssh.slice(0, 16)}\n ${pssh.slice(16)} \n</other:pssh>
+    </dash:ContentProtection></dash:AdaptationSet></dash:Period>
+  </dash:MPD>`;
+const post = (text: string) =>
+  receive({
+    source: window,
+    data: { namespace: 'okova:network', method: 'response', params: { url, text } },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal('DOMParser', DOMParser);
+  vi.stubGlobal('window', {
+    addEventListener: (_name: string, callback: typeof receive) => {
+      receive = callback;
+    },
+  });
+  manifest.main();
+});
+afterEach(() => vi.unstubAllGlobals());
+
+test.each([
+  { pssh: widevine, scheme: PSSH_SYSTEM_IDS.widevine },
+  { pssh: playready, scheme: PSSH_SYSTEM_IDS.playready },
+])('associates prefixed DASH and normalized PSSH for $scheme', ({ pssh, scheme }) => {
+  post(mpd(pssh, scheme));
+  expect(findManifest(pssh)).toBe(url);
+  expect(findManifest(combined)).toBe(url);
+});
+
+test('indexes each PSSH when a descriptor carries concatenated boxes', () => {
+  post(mpd(combined));
+  expect(findManifest(widevine)).toBe(url);
+  expect(findManifest(playready)).toBe(url);
+});
+
+test('ignores unrelated page messages, foreign frames, and invalid response shapes', () => {
+  const valid = {
+    namespace: 'okova:network',
+    method: 'response',
+    params: { url, text: mpd(widevine) },
+  };
+  for (const data of [
+    null,
+    undefined,
+    3,
+    'response',
+    {},
+    { method: 'response', params: valid.params },
+    { ...valid, params: null },
+    { ...valid, params: { url: 42, text: mpd(widevine) } },
+    { ...valid, params: { url, text: null } },
+  ]) {
+    expect(() => receive({ source: window, data })).not.toThrow();
+  }
+  receive({ source: {}, data: valid });
+  expect(window.MPD_LIST.size).toBe(0);
+});
+
+test('ignores non-DASH XML, wrong namespaces, malformed XML and invalid base64', () => {
+  post(mpd(widevine).replaceAll('urn:mpeg:dash:schema:mpd:2011', 'urn:other'));
+  post(mpd(widevine).replaceAll('urn:mpeg:cenc:2013', 'urn:other'));
+  post(mpd('%%%'));
+  post('<MPD');
+  expect(window.MPD_LIST.size).toBe(0);
+});
+
+test('rejects truncated sequences and handles extended and terminal box sizes', () => {
+  const raw = Buffer.from(widevine, 'base64');
+  const extended = Buffer.alloc(raw.length + 8);
+  extended.writeUInt32BE(1);
+  raw.copy(extended, 4, 4, 8);
+  extended.writeBigUInt64BE(BigInt(extended.length), 8);
+  raw.copy(extended, 16, 8);
+  expect(splitPssh(extended.toString('base64'))).toEqual([extended.toString('base64')]);
+  const terminal = Buffer.from(raw);
+  terminal.writeUInt32BE(0);
+  expect(splitPssh(terminal.toString('base64'))).toEqual([terminal.toString('base64')]);
+  expect(splitPssh(btoa(atob(widevine) + 'x'))).toEqual([]);
+  expect(splitPssh(raw.subarray(0, -1).toString('base64'))).toEqual([]);
+  extended.writeBigUInt64BE(0xffffffffffffffffn, 8);
+  expect(splitPssh(extended.toString('base64'))).toEqual([]);
+  expect(findManifest(undefined)).toBeUndefined();
+});

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -33,6 +33,26 @@ beforeEach(() => {
 });
 afterEach(() => vi.unstubAllGlobals());
 
+test.each([null, undefined, false, 42, 'page-owned', {}, []])(
+  'replaces an incompatible page-owned manifest cache: %j',
+  (value) => {
+    Reflect.set(window, 'MPD_LIST', value);
+    expect(findManifest(widevine)).toBeUndefined();
+    manifest.main();
+    post(mpd(combined));
+    expect(findManifest(widevine)).toBe(url);
+    expect(findManifest(playready)).toBe(url);
+  },
+);
+
+test('preserves existing manifest associations when initialized again', () => {
+  post(mpd(widevine));
+  const cache = window.MPD_LIST;
+  manifest.main();
+  expect(window.MPD_LIST).toBe(cache);
+  expect(findManifest(widevine)).toBe(url);
+});
+
 test.each([
   { pssh: widevine, scheme: PSSH_SYSTEM_IDS.widevine },
   { pssh: playready, scheme: PSSH_SYSTEM_IDS.playready },

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -70,6 +70,7 @@ test.each(['', 'text', 'arraybuffer', 'blob', 'document'] satisfies XMLHttpReque
     await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
+        namespace: 'okova:network',
         method: 'response',
         params: { url, text: manifest, headers: { 'content-type': 'application/dash+xml' } },
       }),

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -949,3 +949,27 @@ test('sets the badge text and tooltip when text-color control is unavailable', a
     Object.defineProperty(browser.action, 'setBadgeTextColor', descriptor);
   }
 });
+
+test.each([
+  { info: null, expected: null },
+  { info: { type: 'wvd', data: '' } as const, expected: 'com.widevine.alpha' },
+  { info: { type: 'prd', data: '' } as const, expected: 'com.microsoft.playready.recommendation' },
+  {
+    info: {
+      type: 'remote',
+      config: {
+        protocol: 'okova',
+        keySystem: 'com.widevine.alpha',
+        baseUrl: 'https://cdm.test',
+        secret: 'test',
+        client: 'device',
+      },
+    } as const,
+    expected: 'com.widevine.alpha',
+  },
+])('answers playback configuration in the background: $expected', async ({ info, expected }) => {
+  vi.spyOn(appStorage.clients.active, 'getInfo').mockResolvedValue(info);
+  const send = startBackground();
+  await expect(send('playback-config', '')).resolves.toBe(expected);
+  expect(appStorage.clients.active.getValue).not.toHaveBeenCalled();
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,3 +1,4 @@
+import { stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { loadEnv } from 'vite';
 import { defineConfig } from 'wxt';
@@ -8,6 +9,17 @@ const devEnv = loadEnv('development', process.cwd(), 'WXT_');
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   srcDir: './src/extension',
+  hooks: {
+    'build:done': async (wxt) => {
+      if (wxt.config.mode !== 'production') return;
+      // Every matching frame pays this cost. Keep device parsing out of the bridge.
+      const budgetBytes = 20 * 1024;
+      const { size } = await stat(resolve(wxt.config.outDir, 'content-scripts/content.js'));
+      if (size > budgetBytes) {
+        throw new Error(`Content script is ${size} bytes; budget is ${budgetBytes} bytes`);
+      }
+    },
+  },
   manifest: {
     name: 'Okova',
     permissions: ['storage', 'tabs', 'activeTab', 'clipboardWrite'],


### PR DESCRIPTION
## Summary

- Validate network messages before indexing DASH manifests.
- Support namespaced XML, normalized and concatenated PSSH boxes.
- Move playback configuration lookup to the background worker.
- Content bundle reduced from **681.14 kB to 13.53 kB**, with a 20 KiB build limit
- Add safer JSON-backed settings storage and enforce content-script size limits.
- Expand unit and end-to-end coverage for manifest handling and playback configuration.

## Testing

- Added extension manifest, network, session, and DRM bridge tests.
- Added Playwright end-to-end coverage for DASH manifest association.
- Not run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791294560&installation_model_id=424872&pr_number=73&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F73&signature=5a24b932e14fee9a740e25ccb06c5b9f321d3ed5f5489dbe6c995ab44c9a871a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->