### PR TITLE
feat(extension): add key history export as JSON or TXT

### DIFF
--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -31,6 +31,7 @@ export const Cell: Component<CellProps> = (props) => {
         props.class,
       )}
       title={props.title}
+      disabled={cellProps.component === 'button' ? props.disabled : undefined}
       onClick={props.onClick}
     >
       {props.before && <div class="[&>svg]:w-[18px] [&>svg]:h-[18px] mr-3">{props.before}</div>}

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -6,9 +6,31 @@ import { appStorage, KeyInfo } from '@/utils/storage';
 import { KeysList } from '../components/keys-list';
 import { NoKeys } from '../components/no-keys';
 import { Section } from '../components/section';
+import { serializeHistory, type HistoryExportFormat } from '../utils/history-export';
+import { saveFile } from '../utils/file';
 
 export const Keys = () => {
   const [keys, setKeys] = createSignal<KeyInfo[]>([]);
+  const [isExporting, setIsExporting] = createSignal(false);
+  const [exportError, setExportError] = createSignal<string>();
+
+  const exportKeys = async (format: HistoryExportFormat) => {
+    if (isExporting()) return;
+    setIsExporting(true);
+    setExportError(undefined);
+    try {
+      const records = (await appStorage.allKeys.getValue()) ?? [];
+      const content = serializeHistory(records, format);
+      const filename = format === 'json' ? 'okova-history.json' : 'okova-keys.txt';
+      await saveFile(new TextEncoder().encode(content), filename);
+    } catch (error) {
+      if (!(error instanceof Error && error.name === 'AbortError')) {
+        setExportError('Export failed. Please try again.');
+      }
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   onMount(async () => {
     const keys = await appStorage.allKeys.getValue();
@@ -24,10 +46,33 @@ export const Keys = () => {
     <Layout>
       <Header backHref="/">Keys</Header>
       <div class="flex flex-col gap-3">
-        <Section header="Actions">
-          {/* TODO: Implement */}
-          <Cell before={<TbOutlineDownload />} variant="primary" disabled>
-            Export All
+        <Section
+          header="Actions"
+          footer={
+            <Show when={exportError()}>
+              <span role="alert">{exportError()}</span>
+            </Show>
+          }
+        >
+          <Cell
+            component="button"
+            before={<TbOutlineDownload />}
+            variant="primary"
+            subtitle="All records, including statuses and metadata"
+            disabled={isExporting()}
+            onClick={() => exportKeys('json')}
+          >
+            Export All as JSON
+          </Cell>
+          <Cell
+            component="button"
+            before={<TbOutlineDownload />}
+            variant="primary"
+            subtitle="Unique KID:KEY pairs, one per line"
+            disabled={isExporting()}
+            onClick={() => exportKeys('txt')}
+          >
+            Export All as TXT
           </Cell>
           <Cell before={<TbTrash />} variant="danger" onClick={clearKeys}>
             Delete All

--- a/src/extension/entrypoints/popup/utils/history-export.ts
+++ b/src/extension/entrypoints/popup/utils/history-export.ts
@@ -1,0 +1,14 @@
+import { isCapturedKey, type KeyInfo } from '@/utils/storage';
+
+export type HistoryExportFormat = 'json' | 'txt';
+
+export const serializeHistory = (records: readonly KeyInfo[], format: HistoryExportFormat) => {
+  if (format === 'json') return `${JSON.stringify({ version: 1, records }, null, 2)}\n`;
+
+  const pairs = new Set(
+    records
+      .filter(isCapturedKey)
+      .map((record) => `${record.id.toLowerCase()}:${record.value.toLowerCase()}`),
+  );
+  return pairs.size ? `${[...pairs].join('\n')}\n` : '';
+};

--- a/test/extension-history-export.test.ts
+++ b/test/extension-history-export.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest';
+import { serializeHistory } from '../src/extension/entrypoints/popup/utils/history-export';
+import type { KeyInfo } from '../src/extension/utils/storage';
+
+const key: KeyInfo = {
+  drmSystem: 'W',
+  id: '00112233445566778899aabbccddeeff',
+  value: 'ffeeddccbbaa99887766554433221100',
+  url: 'https://example.com/watch/1',
+  pssh: 'cHNzaA==',
+  mpd: 'https://example.com/manifest.mpd',
+  createdAt: 1,
+};
+
+test('JSON preserves individual records, metadata, and status-only entries', () => {
+  const records = [
+    key,
+    { ...key, url: 'https://example.com/watch/2' },
+    {
+      ...key,
+      value: 'expired',
+      mpd: undefined,
+      pssh: '',
+    },
+  ];
+
+  expect(JSON.parse(serializeHistory(records, 'json'))).toEqual({ version: 1, records });
+  expect(records[0]).toEqual(key);
+});
+
+test('TXT deduplicates pairs across records and hex casing but retains different keys for a KID', () => {
+  const otherValue = '11223344556677889900aabbccddeeff';
+  const records = [
+    key,
+    { ...key, url: 'https://example.com/watch/2' },
+    { ...key, id: key.id.toUpperCase(), value: key.value.toUpperCase() },
+    { ...key, value: otherValue },
+    ...['usable', 'expired', 'output-restricted', 'status-pending', ''].map((value) => ({
+      ...key,
+      value,
+    })),
+  ];
+
+  expect(serializeHistory(records, 'txt')).toBe(
+    `${key.id}:${key.value}\n${key.id}:${otherValue}\n`,
+  );
+});
+
+test('empty history produces an empty JSON collection or empty text', () => {
+  expect(JSON.parse(serializeHistory([], 'json'))).toEqual({ version: 1, records: [] });
+  expect(serializeHistory([], 'txt')).toBe('');
+  expect(serializeHistory([{ ...key, value: 'usable' }], 'txt')).toBe('');
+});


### PR DESCRIPTION
## Summary

- Add JSON export for complete key history, including metadata and status-only records.
- Add TXT export for deduplicated KID:key pairs.
- Disable export actions while saving and show export errors in the popup.
- Add serialization and export coverage.

## Testing

- Added Vitest coverage for JSON preservation, TXT deduplication, casing normalization, and empty histories.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305232&installation_model_id=424872&pr_number=76&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F76&signature=06ca953568eeb03f004f85fb6303e7a497cf2284168cef34e19538597de50cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->