### PR TITLE
feat(extension): add key search by KID and site

### DIFF
--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -9,6 +9,19 @@ import { Section } from '../components/section';
 
 export const Keys = () => {
   const [keys, setKeys] = createSignal<KeyInfo[]>([]);
+  const [search, setSearch] = createSignal('');
+  const filteredKeys = createMemo(() => {
+    const query = search().trim().toLowerCase();
+    if (!query) return keys();
+
+    const kidQuery = query.replaceAll('-', '');
+    return keys().filter(
+      (key) =>
+        (kidQuery.length > 0 && key.id.toLowerCase().replaceAll('-', '').includes(kidQuery)) ||
+        key.url.toLowerCase().includes(query) ||
+        key.mpd?.toLowerCase().includes(query),
+    );
+  });
 
   onMount(async () => {
     const keys = await appStorage.allKeys.getValue();
@@ -33,9 +46,39 @@ export const Keys = () => {
             Delete All
           </Cell>
         </Section>
-        <KeysList keys={keys} header="All Keys" />
-        <Show when={!keys().length}>
-          <NoKeys />
+        <div class="flex flex-col gap-1.5">
+          <label for="key-search" class="px-2 text-[13px] font-medium">
+            Search by KID or site
+          </label>
+          <input
+            id="key-search"
+            type="search"
+            placeholder="KID, page URL, or manifest URL"
+            value={search()}
+            onInput={(event) => setSearch(event.currentTarget.value)}
+            class="w-full rounded-lg bg-white px-3 py-2 text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-neutral-800"
+          />
+          <p role="status" class="px-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+            {filteredKeys().length} / {keys().length} keys
+          </p>
+        </div>
+        <KeysList keys={filteredKeys} header="All Keys" />
+        <Show when={!filteredKeys().length}>
+          <Show when={keys().length} fallback={<NoKeys />}>
+            <div class="flex flex-col items-center gap-1 py-4 text-center">
+              <h1 class="text-[16px] font-semibold">No matching keys</h1>
+              <p class="text-[13px] text-neutral-800 dark:text-neutral-300">
+                Try another KID, page URL, or manifest URL.
+              </p>
+              <button
+                type="button"
+                onClick={() => setSearch('')}
+                class="rounded px-3 py-2 text-[13px] text-blue-600 hover:underline focus-visible:outline-2 dark:text-blue-400"
+              >
+                Clear search
+              </button>
+            </div>
+          </Show>
         </Show>
       </div>
     </Layout>

--- a/test/e2e/key-search.test.ts
+++ b/test/e2e/key-search.test.ts
@@ -1,0 +1,92 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { expect, test } from 'vitest';
+import type { KeyInfo } from '../../src/extension/utils/storage';
+
+test('saved keys filter immediately by KID, page URL, and manifest URL', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-key-search-'));
+  const extension = resolve('.output/chrome-mv3');
+  try {
+    const context = await chromium.launchPersistentContext(profile, {
+      channel: 'chromium',
+      headless: true,
+      viewport: { width: 500, height: 600 },
+      args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+    });
+    try {
+      const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      const keys: KeyInfo[] = [
+        {
+          id: 'AABBCCDD11223344556677889900AABB',
+          value: '00112233445566778899aabbccddeeff',
+          url: 'https://Watch.Example/Some-Show',
+          mpd: 'https://CDN.Example/Video/Manifest.mpd',
+          pssh: '',
+          createdAt: Date.now(),
+        },
+        {
+          id: '12345678-abcd-ef90-1234-567890abcdef',
+          value: 'ffeeddccbbaa99887766554433221100',
+          url: 'https://other.example/watch',
+          pssh: '',
+          createdAt: Date.now(),
+        },
+      ];
+      await worker.evaluate(async (keys) => {
+        await browser.storage.local.set({ 'all-keys': JSON.stringify(keys) });
+      }, keys);
+      const popup = await context.newPage();
+      await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html#/keys`);
+      const search = popup.getByRole('searchbox', { name: 'Search by KID or site' });
+      const count = popup.getByRole('status');
+      await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
+      for (const query of [
+        'aabbccdd-1122-3344-5566-77889900aabb',
+        ' DD-1122 ',
+        'WATCH.EXAMPLE',
+        'some-show',
+        'cdn.example/video',
+        'MANIFEST.MPD',
+      ]) {
+        await search.fill(query);
+        await expect.poll(() => count.textContent()).toBe('1 / 2 keys');
+        expect(await popup.locator('code').allTextContents()).toEqual([
+          `${keys[0]!.id}:${keys[0]!.value}`,
+        ]);
+      }
+      await search.fill('5678ABCDEF90');
+      await expect.poll(() => count.textContent()).toBe('1 / 2 keys');
+      expect(await popup.locator('code').allTextContents()).toEqual([
+        `${keys[1]!.id}:${keys[1]!.value}`,
+      ]);
+      for (const query of ['missing.example', '---', keys[0]!.value]) {
+        await search.fill(query);
+        await expect.poll(() => count.textContent()).toBe('0 / 2 keys');
+        expect(await popup.getByRole('heading', { name: 'No matching keys' }).isVisible()).toBe(
+          true,
+        );
+        expect(await popup.locator('code').count()).toBe(0);
+      }
+      await mkdir(resolve('output/playwright/key-search'), { recursive: true });
+      await popup.screenshot({ path: resolve('output/playwright/key-search/no-matches.png') });
+      await popup.getByRole('button', { name: 'Clear search', exact: true }).click();
+      await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
+      expect(await search.inputValue()).toBe('');
+      await search.fill('   ');
+      await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
+      await search.fill('');
+      await popup.screenshot({ path: resolve('output/playwright/key-search/all-keys.png') });
+      await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
+      await expect.poll(() => count.textContent()).toBe('0 / 0 keys');
+      expect(await popup.getByRole('heading', { name: 'Keys will appear here' }).isVisible()).toBe(
+        true,
+      );
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await rm(profile, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add case-insensitive key search by KID, page URL, and manifest URL.
- Show matching-key counts and an empty-state message with a clear-search action.
- Replace the key export actions with a disabled placeholder.

## Testing

- Added Playwright E2E coverage for KID, page URL, manifest URL, empty results, clearing search, and deleting all keys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305574&installation_model_id=424872&pr_number=77&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F77&signature=880cda80911d2f6bbf17ab3fdcb97479ca75b0a3ec4fe2b0f8a617116c4c1bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->