### PR TITLE
fix(extension): keep key history live without losing popup state

### DIFF
--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -1,13 +1,16 @@
-import { Accessor, Component, JSX } from 'solid-js';
+import { Accessor, Component, JSX, batch, createComputed, untrack } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
 import { Cell } from './cell';
 import { KeyInfo } from '@/utils/storage';
 import { List } from './list';
 import { Section } from './section';
 import { KeySettings } from '../routes/key-settings';
 import { formatRelativeTime } from '../utils/date';
+import { captureHistoryScroll, reconcileHistoryRows, type HistoryRow } from '../utils/history-rows';
 
 type KeysListProps = {
   keys: Accessor<KeyInfo[]>;
+  allKeys?: Accessor<KeyInfo[]>;
   header?: JSX.Element;
   footer?: JSX.Element;
 };
@@ -15,46 +18,67 @@ type KeysListProps = {
 const shorten = (url?: string) => url?.replace('https://', '');
 
 export const KeysList: Component<KeysListProps> = (props) => {
-  const [openedKey, setOpenedKey] = createSignal<KeyInfo | null>(null);
+  const [rows, setRows] = createStore<HistoryRow[]>([]);
+  const [openedIdentity, setOpenedIdentity] = createSignal<number | null>(null);
+  const openedKey = createMemo(() => rows.find((row) => row.identity === openedIdentity())?.key);
+  let nextIdentity = 0;
+  let list: HTMLDivElement | undefined;
+
+  createComputed(() => {
+    const visible = props.keys();
+    const records = props.allKeys?.() ?? visible;
+    untrack(() => {
+      const restoreScroll = captureHistoryScroll(list);
+      const next = reconcileHistoryRows(rows, records, visible, () => nextIdentity++);
+      batch(() => {
+        setRows(reconcile(next, { key: 'identity' }));
+        if (!next.some((row) => row.identity === openedIdentity())) setOpenedIdentity(null);
+      });
+      queueMicrotask(restoreScroll);
+    });
+  });
 
   return (
-    <Show when={props.keys().length > 0}>
-      <Show
-        when={!openedKey()}
-        fallback={
+    <>
+      <div ref={list}>
+        <Show when={props.keys().length > 0}>
+          <List>
+            <Section header={props.header} footer={props.footer}>
+              <For each={rows.filter((row) => row.visible)}>
+                {(row) => (
+                  <div data-history-row={row.identity} class="[&>div]:rounded-[inherit]">
+                    <Cell class="group" onClick={() => setOpenedIdentity(row.identity)}>
+                      <code title="Click to copy" class="text-[13px] truncate flex w-full">
+                        <span class="w-1/2 truncate">{row.key.id}</span>:
+                        {/* value may be a status if Spoofing disabled */}
+                        <span class="w-1/2 truncate">{row.key.value}</span>
+                      </code>
+                      <div class="text-[10px] text-gray-500 flex justify-between dark:text-neutral-400">
+                        <a
+                          title={row.key.mpd || row.key.url}
+                          target="_blank"
+                          href={row.key.mpd || row.key.url}
+                          class="w-fit truncate hover:underline hover:text-blue-500 dark:hover:text-blue-400"
+                        >
+                          {shorten(row.key.mpd || row.key.url)}
+                        </a>
+                        <div>{formatRelativeTime(new Date(row.key.createdAt).toISOString())}</div>
+                      </div>
+                    </Cell>
+                  </div>
+                )}
+              </For>
+            </Section>
+          </List>
+        </Show>
+      </div>
+      <Show when={openedKey()}>
+        {(key) => (
           <Portal mount={document.getElementById('root')!}>
-            <KeySettings key={openedKey()!} onClose={() => setOpenedKey(null)} />
+            <KeySettings key={key()} onClose={() => setOpenedIdentity(null)} />
           </Portal>
-        }
-      >
-        <List>
-          <Section header={props.header} footer={props.footer}>
-            {props.keys().map(({ id, value, url, mpd, createdAt, ...rest }) => (
-              <Cell
-                class="group"
-                onClick={() => setOpenedKey({ id, value, url, mpd, createdAt, ...rest })}
-              >
-                <code title="Click to copy" class="text-[13px] truncate flex w-full">
-                  <span class="w-1/2 truncate">{id}</span>:
-                  {/* value may be a status if Spoofing disabled */}
-                  <span class="w-1/2 truncate">{value}</span>
-                </code>
-                <div class="text-[10px] text-gray-500 flex justify-between dark:text-neutral-400">
-                  <a
-                    title={mpd || url}
-                    target="_blank"
-                    href={mpd || url}
-                    class="w-fit truncate hover:underline hover:text-blue-500 dark:hover:text-blue-400"
-                  >
-                    {shorten(mpd || url)}
-                  </a>
-                  <div>{formatRelativeTime(new Date(createdAt).toISOString())}</div>
-                </div>
-              </Cell>
-            ))}
-          </Section>
-        </List>
+        )}
       </Show>
-    </Show>
+    </>
   );
 };

--- a/src/extension/entrypoints/popup/components/section.tsx
+++ b/src/extension/entrypoints/popup/components/section.tsx
@@ -11,7 +11,7 @@ export const SectionFooter: Component<{ children: JSX.Element }> = (props) => {
 type SectionProps = {
   header?: JSX.Element;
   footer?: JSX.Element;
-  children?: JSX.ArrayElement;
+  children?: JSX.Element;
 };
 
 export const Section: Component<SectionProps> = (props) => {

--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -16,30 +16,36 @@ type KeySettingsProps = {
 };
 
 export const KeySettings: Component<KeySettingsProps> = (props) => {
-  const [command, setCommand] = createSignal(buildDownloadCommand(props.key));
-
-  const getMainLayoutElement = () => {
-    return document.querySelector<HTMLDivElement>('#root > main');
-  };
-
-  const close = () => {
-    const mainLayout = getMainLayoutElement();
-    if (mainLayout) mainLayout.style.display = 'block';
-    props.onClose();
-  };
+  const generatedCommand = createMemo(() => buildDownloadCommand(props.key));
+  const [command, setCommand] = createSignal(generatedCommand());
+  let previousCommand = generatedCommand();
+  createEffect(() => {
+    const nextCommand = generatedCommand();
+    setCommand((current) => (current === previousCommand ? nextCommand : current));
+    previousCommand = nextCommand;
+  });
 
   onMount(() => {
-    const mainLayout = getMainLayoutElement();
-    if (!mainLayout) return;
-    mainLayout.style.display = 'none';
-    return () => {
-      mainLayout.style.display = 'block';
-    };
+    const mainLayout = document.querySelector<HTMLElement>('#root > main');
+    const root = document.getElementById('root');
+    if (!mainLayout || !root) return;
+    const visibility = mainLayout.style.visibility;
+    const overflow = root.style.overflowY;
+    const inert = mainLayout.inert;
+    // Keep the list's layout and scroll position while details scroll independently.
+    mainLayout.style.visibility = 'hidden';
+    mainLayout.inert = true;
+    root.style.overflowY = 'hidden';
+    onCleanup(() => {
+      mainLayout.style.visibility = visibility;
+      mainLayout.inert = inert;
+      root.style.overflowY = overflow;
+    });
   });
 
   return (
-    <Layout className="w-full h-full">
-      <Header onClose={close}>Key Settings</Header>
+    <Layout className="fixed top-0 left-0 w-full h-full min-h-0 max-h-[600px] overflow-y-auto [scrollbar-gutter:stable]">
+      <Header onClose={props.onClose}>Key Settings</Header>
       <List>
         <Section header="Details">
           <Cell subtitle={props.key.url} onClick={() => window.open(props.key.url, '_blank')}>

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -45,14 +45,24 @@ export const Keys = () => {
     }
   };
 
+  let isDisposed = false;
+  let hasUpdate = false;
+  const unwatch = appStorage.allKeys.raw.watch((records) => {
+    hasUpdate = true;
+    setKeys(records ?? []);
+  });
+  onCleanup(() => {
+    isDisposed = true;
+    unwatch();
+  });
   onMount(async () => {
-    const keys = await appStorage.allKeys.getValue();
-    if (keys) setKeys(keys);
+    const records = await appStorage.allKeys.getValue();
+    // A storage event may arrive before the initial read resolves.
+    if (!isDisposed && !hasUpdate) setKeys(records ?? []);
   });
 
   const clearKeys = async () => {
     await appStorage.allKeys.clear();
-    setKeys([]);
   };
 
   return (
@@ -107,7 +117,7 @@ export const Keys = () => {
             {filteredKeys().length} / {keys().length} keys
           </p>
         </div>
-        <KeysList keys={filteredKeys} header="All Keys" />
+        <KeysList keys={filteredKeys} allKeys={keys} header="All Keys" />
         <Show when={!filteredKeys().length}>
           <Show when={keys().length} fallback={<NoKeys />}>
             <div class="flex flex-col items-center gap-1 py-4 text-center">

--- a/src/extension/entrypoints/popup/utils/history-rows.ts
+++ b/src/extension/entrypoints/popup/utils/history-rows.ts
@@ -1,0 +1,60 @@
+import type { KeyInfo } from '@/utils/storage';
+
+export type HistoryRow = { identity: number; key: KeyInfo; visible: boolean };
+
+// Storage has no record IDs. Match complete identities first, then unambiguous
+// KIDs so a status becoming a captured key keeps its row and open details.
+export const reconcileHistoryRows = (
+  previous: HistoryRow[],
+  records: KeyInfo[],
+  visible: KeyInfo[],
+  nextIdentity: () => number,
+): HistoryRow[] => {
+  const remaining = new Set(previous);
+  const matches = records.map((key) => {
+    const match = [...remaining].find(
+      (row) =>
+        row.key.id === key.id &&
+        row.key.value === key.value &&
+        row.key.url === key.url &&
+        row.key.pssh === key.pssh,
+    );
+    if (match) remaining.delete(match);
+    return match;
+  });
+  return records.map((key, index) => {
+    let match = matches[index];
+    if (!match) {
+      const candidates = [...remaining].filter((row) => row.key.id === key.id);
+      const unmatched = records.filter((record, index) => !matches[index] && record.id === key.id);
+      if (candidates.length === 1 && unmatched.length === 1) {
+        match = candidates[0];
+        if (match) remaining.delete(match);
+      }
+    }
+    return { identity: match?.identity ?? nextIdentity(), key, visible: visible.includes(key) };
+  });
+};
+
+// Save several candidates so removing the first visible row can anchor its neighbor.
+export const captureHistoryScroll = (list: HTMLElement | undefined) => {
+  const root = document.getElementById('root');
+  if (!root || !list) return () => {};
+  const scrollTop = root.scrollTop;
+  const bounds = root.getBoundingClientRect();
+  const anchors = [...list.querySelectorAll<HTMLElement>('[data-history-row]')]
+    .map((element) => ({ element, top: element.getBoundingClientRect().top }))
+    .filter(
+      ({ element, top }) =>
+        top < bounds.bottom && element.getBoundingClientRect().bottom > bounds.top,
+    );
+  return () => {
+    if (!root.isConnected) return;
+    const anchor = anchors.find(
+      ({ element }) => element.isConnected && element.getClientRects().length,
+    );
+    root.scrollTop = anchor
+      ? root.scrollTop + anchor.element.getBoundingClientRect().top - anchor.top
+      : scrollTop;
+  };
+};

--- a/src/extension/utils/storage/json.ts
+++ b/src/extension/utils/storage/json.ts
@@ -15,12 +15,11 @@ export const asJson = <K, T extends WxtStorageItem<K | null, {}> = WxtStorageIte
     const data = JSON.stringify(value) as unknown as K;
     return item.setValue(data);
   },
-  watch: (callback: WatchCallback<K>) => {
+  watch: (callback: WatchCallback<K | null>) => {
     return item.watch((newValue, oldValue) => {
-      if (!newValue) return;
       callback(
-        JSON.parse(newValue as unknown as string) as K,
-        JSON.parse(oldValue as unknown as string) as K,
+        newValue ? (JSON.parse(newValue as unknown as string) as K) : null,
+        oldValue ? (JSON.parse(oldValue as unknown as string) as K) : null,
       );
     });
   },

--- a/test/e2e/live-history.test.ts
+++ b/test/e2e/live-history.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { expect, test } from 'vitest';
+import type { KeyInfo } from '../../src/extension/utils/storage';
+
+test('history updates preserve search, visible rows, and live details', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-live-history-'));
+  const extension = resolve('.output/chrome-mv3');
+  try {
+    const context = await chromium.launchPersistentContext(profile, {
+      channel: 'chromium',
+      headless: true,
+      viewport: { width: 500, height: 600 },
+      args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+    });
+    try {
+      const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      let records: KeyInfo[] = Array.from({ length: 60 }, (_, index) => ({
+        id: index.toString(16).padStart(32, '0'),
+        value: 'usable',
+        url: `https://history.example/watch/${index}`,
+        pssh: '',
+        createdAt: Date.now() + index,
+      }));
+      const save = () =>
+        worker.evaluate(async (records) => {
+          await browser.storage.local.set({ 'all-keys': JSON.stringify(records) });
+        }, records);
+      await save();
+      const popup = await context.newPage();
+      await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
+      await popup.getByRole('link', { name: 'Keys', exact: true }).click();
+      const search = popup.getByRole('searchbox');
+      await search.fill('history.example');
+      const count = popup.getByRole('status');
+      await expect.poll(() => count.textContent()).toBe('60 / 60 keys');
+      const root = popup.locator('#root');
+      await root.evaluate((element) => {
+        element.scrollTop = 1100;
+      });
+      const anchor = popup.locator('[data-history-row]').nth(20);
+      const anchorIdentity = await anchor.getAttribute('data-history-row');
+      const stableAnchor = popup.locator(`[data-history-row="${anchorIdentity}"]`);
+      const before = await stableAnchor.evaluate((element) => element.getBoundingClientRect().top);
+      records = [{ ...records[0]!, id: 'new-record' }, ...records];
+      await save();
+      await expect.poll(() => count.textContent()).toBe('61 / 61 keys');
+      await expect
+        .poll(async () =>
+          Math.abs(
+            (await stableAnchor.evaluate((element) => element.getBoundingClientRect().top)) -
+              before,
+          ),
+        )
+        .toBeLessThanOrEqual(1);
+      records = records.slice(6);
+      await save();
+      await expect.poll(() => count.textContent()).toBe('55 / 55 keys');
+      await expect
+        .poll(async () =>
+          Math.abs(
+            (await stableAnchor.evaluate((element) => element.getBoundingClientRect().top)) -
+              before,
+          ),
+        )
+        .toBeLessThanOrEqual(1);
+      expect(await search.inputValue()).toBe('history.example');
+
+      await stableAnchor.locator('code').click();
+      const details = popup.locator('main').last();
+      const command = details.getByRole('textbox');
+      await expect.poll(() => command.inputValue()).toContain('usable');
+      const selected = records.find((record) => record.id === (20).toString(16).padStart(32, '0'))!;
+      const captured = { ...selected, value: 'a'.repeat(32), mpd: 'https://cdn.example/live.mpd' };
+      records = records.map((record) => (record === selected ? captured : record));
+      await save();
+      await expect.poll(() => command.inputValue()).toContain(captured.value);
+      expect(await details.getByText(captured.value, { exact: true }).isVisible()).toBe(true);
+      await command.fill('my custom command');
+      await details.evaluate((element) => {
+        element.scrollTop = 100;
+      });
+      const detailsScroll = await details.evaluate((element) => element.scrollTop);
+      records = records.map((record) =>
+        record === captured ? { ...captured, pssh: 'updated-pssh' } : record,
+      );
+      await save();
+      await expect.poll(() => details.getByText('updated-pssh', { exact: true }).count()).toBe(1);
+      expect(await command.inputValue()).toBe('my custom command');
+      expect(await details.evaluate((element) => element.scrollTop)).toBe(detailsScroll);
+      await details.locator('svg').first().click();
+      await expect.poll(() => popup.getByText('Key Settings', { exact: true }).count()).toBe(0);
+      expect(await search.isVisible()).toBe(true);
+      expect(
+        Math.abs(
+          (await stableAnchor.evaluate((element) => element.getBoundingClientRect().top)) - before,
+        ),
+      ).toBeLessThanOrEqual(1);
+      await stableAnchor.locator('code').click();
+      records = records.map((record) =>
+        record.id === selected.id ? { ...record, url: 'https://outside.example' } : record,
+      );
+      await save();
+      await expect
+        .poll(() => details.getByText('https://outside.example', { exact: true }).count())
+        .toBe(1);
+      expect(await popup.getByText('Key Settings', { exact: true }).isVisible()).toBe(true);
+      records = records.filter((record) => record.id !== selected.id);
+      await save();
+      await expect.poll(() => popup.getByText('Key Settings', { exact: true }).count()).toBe(0);
+      expect(await search.isVisible()).toBe(true);
+      expect(await search.inputValue()).toBe('history.example');
+      await worker.evaluate(async () => {
+        await browser.storage.local.remove('all-keys');
+      });
+      await expect.poll(() => count.textContent()).toBe('0 / 0 keys');
+      records = [captured];
+      await save();
+      await expect.poll(() => count.textContent()).toBe('1 / 1 keys');
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await rm(profile, { recursive: true, force: true });
+  }
+});

--- a/test/extension-history-rows.test.ts
+++ b/test/extension-history-rows.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+import { reconcileHistoryRows } from '../src/extension/entrypoints/popup/utils/history-rows';
+import type { KeyInfo } from '../src/extension/utils/storage';
+
+const record: KeyInfo = {
+  id: 'shared-kid',
+  value: 'usable',
+  url: 'https://example.com',
+  pssh: '',
+  createdAt: 1,
+};
+
+test('selection follows a status replacement and metadata edits independently of filtering', () => {
+  let identity = 0;
+  const nextIdentity = () => identity++;
+  const original = reconcileHistoryRows([], [record], [record], nextIdentity);
+  const captured = { ...record, value: 'a'.repeat(32), url: 'https://other.example', pssh: 'new' };
+  const updated = reconcileHistoryRows(original, [captured], [], nextIdentity);
+  expect(updated).toEqual([{ identity: original[0]!.identity, key: captured, visible: false }]);
+  expect(reconcileHistoryRows(updated, [], [], nextIdentity)).toEqual([]);
+});
+
+test('duplicate KIDs retain distinct identities when reordered, updated, and removed', () => {
+  let identity = 0;
+  const nextIdentity = () => identity++;
+  const first = { ...record, value: 'a'.repeat(32) };
+  const second = { ...record, value: 'b'.repeat(32), url: 'https://other.example' };
+  const original = reconcileHistoryRows([], [first, second], [first, second], nextIdentity);
+  const changed = { ...first, mpd: 'https://cdn.example/manifest.mpd' };
+  const reordered = reconcileHistoryRows(
+    original,
+    [second, changed],
+    [second, changed],
+    nextIdentity,
+  );
+  expect(reordered.map((row) => row.identity)).toEqual([
+    original[1]!.identity,
+    original[0]!.identity,
+  ]);
+  const remaining = reconcileHistoryRows(reordered, [second], [second], nextIdentity);
+  expect(remaining[0]!.identity).toBe(original[1]!.identity);
+});

--- a/test/extension-storage-json.test.ts
+++ b/test/extension-storage-json.test.ts
@@ -1,0 +1,23 @@
+import { expect, test, vi } from 'vitest';
+import { storage } from '#imports';
+import { browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { asJson } from '../src/extension/utils/storage/json';
+
+test('JSON storage watchers report creation and removal and stop after cleanup', async () => {
+  fakeBrowser.reset();
+  const item = asJson(storage.defineItem<string[]>('local:json-watch-test'));
+  const callback = vi.fn();
+  const unwatch = item.watch(callback);
+  try {
+    await item.setValue(['record']);
+    await vi.waitFor(() => expect(callback).toHaveBeenLastCalledWith(['record'], null));
+    await browser.storage.local.remove('json-watch-test');
+    await vi.waitFor(() => expect(callback).toHaveBeenLastCalledWith(null, ['record']));
+  } finally {
+    unwatch();
+  }
+  callback.mockClear();
+  await item.setValue(['after cleanup']);
+  expect(callback).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

- Keep key history synchronized with storage creation, updates, removals, and clears.
- Preserve search state, row identity, scroll position, and open key details across updates.
- Add resilient JSON storage watcher handling and history reconciliation utilities.

## Testing

- Added unit coverage for history row identity reconciliation and JSON storage watcher lifecycle.
- Added end-to-end coverage for live history updates, filtering, scrolling, detail updates, and removal behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791306351&installation_model_id=424872&pr_number=79&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F79&signature=05c6c5ca63c2de2b8151eb45acf65b65a3d799507aeba373fee89b8e57d47b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->