### PR TITLE
feat(extension): add bulk and per-site record deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ The toolbar badge shows a count capped at `99+`, followed by `W`, `P`, or `C` fo
 
 Reloading or navigating clears the current result; saved keys then appear blue. Hover over the badge for details. Green indicates key retrieval, not verified playback.
 
+### Deleting captured records
+
+In **Keys**, use the large checkboxes to select individual records or **Select All Results** to select the current search results. **Delete Selected** shows the affected count before deleting. Records hidden by a search are deselected.
+
+**Delete This Site** is available on the dashboard and in record details. It removes that site's records from history and recent captures. A site includes its `www.` hostname, but excludes other subdomains. **Delete All** covers every site, regardless of search or selection.
+
+Bulk and site confirmations freeze their target records when opened. Captures arriving afterward are kept. Cancel or press Escape to return without deleting.
+
 ### Installing Chrome extension
 
 1. Download archive from [latest release](https://github.com/azot-labs/okova/releases/latest)

--- a/src/extension/entrypoints/popup/components/delete-keys.tsx
+++ b/src/extension/entrypoints/popup/components/delete-keys.tsx
@@ -1,0 +1,132 @@
+import { createSignal, onMount, Show } from 'solid-js';
+import { TbOutlineTrash } from 'solid-icons/tb';
+import { deleteKeySnapshot, prepareKeyDeletion, type KeyDeletionScope } from '@/utils/storage';
+import { Cell } from './cell';
+
+type Deletion = Awaited<ReturnType<typeof prepareKeyDeletion>> & { description: string };
+
+export const DeleteKeys = (props: {
+  scope: KeyDeletionScope;
+  label: string;
+  disabled?: boolean;
+  onDeleted?: () => void;
+}) => {
+  const [pending, setPending] = createSignal<Deletion | null>(null);
+  const [isBusy, setIsBusy] = createSignal(false);
+  const [error, setError] = createSignal<string>();
+  const prepare = async () => {
+    if (isBusy()) return;
+    setIsBusy(true);
+    setError(undefined);
+    const scope = props.scope;
+    try {
+      const snapshot = await prepareKeyDeletion(scope);
+      const description =
+        scope.kind === 'site'
+          ? `All records for ${scope.domain}, including www.${scope.domain}. Other subdomains are excluded.`
+          : scope.kind === 'all'
+            ? 'All sites, regardless of the current search or selection.'
+            : 'Only the selected records, including their copies in recent captures.';
+      setIsBusy(false);
+      setPending({ ...snapshot, description });
+    } catch {
+      setError('Could not prepare deletion. Please try again.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+  const confirm = async () => {
+    const snapshot = pending();
+    if (!snapshot || isBusy()) return;
+    setIsBusy(true);
+    setError(undefined);
+    try {
+      await deleteKeySnapshot(snapshot.tokens);
+      setPending(null);
+      props.onDeleted?.();
+    } catch {
+      setError('Deletion failed. Please try again.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+  return (
+    <>
+      <Cell
+        component="button"
+        before={<TbOutlineTrash />}
+        variant="danger"
+        disabled={props.disabled || isBusy()}
+        onClick={prepare}
+      >
+        {props.label}
+      </Cell>
+      <Show when={error() && !pending()}>
+        <p role="alert" class="px-3 text-xs text-red-600">
+          {error()}
+        </p>
+      </Show>
+      <Show when={pending()}>
+        {(snapshot) => {
+          let dialog!: HTMLDialogElement;
+          onMount(() => dialog.showModal());
+          return (
+            <dialog
+              ref={dialog}
+              aria-labelledby="delete-title"
+              aria-describedby="delete-description"
+              onCancel={(event) => {
+                event.preventDefault();
+                if (!isBusy()) {
+                  setPending(null);
+                  setError(undefined);
+                }
+              }}
+              class="m-auto w-[calc(100%-32px)] max-w-md max-h-[calc(100vh-32px)] overflow-y-auto rounded-xl bg-white p-4 text-neutral-950 shadow-xl backdrop:bg-black/40 dark:bg-neutral-800 dark:text-neutral-50"
+            >
+              <h2 id="delete-title" class="text-base font-semibold">
+                Delete {snapshot().count} {snapshot().count === 1 ? 'record' : 'records'}?
+              </h2>
+              <p id="delete-description" class="mt-2 text-[13px] break-words">
+                {snapshot().description}
+              </p>
+              <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                Removes records from history and recent captures. This cannot be undone. New
+                captures arriving after this confirmation opened will be kept.
+              </p>
+              <Show when={error()}>
+                <p role="alert" class="mt-2 text-xs text-red-600">
+                  {error()}
+                </p>
+              </Show>
+              <div class="mt-4 flex justify-end gap-2">
+                <button
+                  autofocus
+                  type="button"
+                  disabled={isBusy()}
+                  onClick={() => {
+                    setPending(null);
+                    setError(undefined);
+                  }}
+                  class="min-h-11 rounded-lg px-4 text-[13px] focus-visible:outline-2 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={isBusy() || snapshot().count === 0}
+                  onClick={confirm}
+                  class="min-h-11 rounded-lg bg-red-600 px-4 text-[13px] text-white focus-visible:outline-2 disabled:opacity-50"
+                >
+                  {isBusy()
+                    ? 'Deleting…'
+                    : `Delete ${snapshot().count} ${snapshot().count === 1 ? 'record' : 'records'}`}
+                </button>
+              </div>
+            </dialog>
+          );
+        }}
+      </Show>
+    </>
+  );
+};

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -1,7 +1,8 @@
 import { Accessor, Component, JSX, batch, createComputed, untrack } from 'solid-js';
 import { createStore, reconcile } from 'solid-js/store';
 import { Cell } from './cell';
-import { KeyInfo } from '@/utils/storage';
+import { DeleteKeys } from './delete-keys';
+import { keyRecordToken, KeyInfo } from '@/utils/storage';
 import { List } from './list';
 import { Section } from './section';
 import { KeySettings } from '../routes/key-settings';
@@ -11,6 +12,7 @@ import { captureHistoryScroll, reconcileHistoryRows, type HistoryRow } from '../
 type KeysListProps = {
   keys: Accessor<KeyInfo[]>;
   allKeys?: Accessor<KeyInfo[]>;
+  selectable?: boolean;
   header?: JSX.Element;
   footer?: JSX.Element;
 };
@@ -21,6 +23,14 @@ export const KeysList: Component<KeysListProps> = (props) => {
   const [rows, setRows] = createStore<HistoryRow[]>([]);
   const [openedIdentity, setOpenedIdentity] = createSignal<number | null>(null);
   const openedKey = createMemo(() => rows.find((row) => row.identity === openedIdentity())?.key);
+  const [selected, setSelected] = createSignal<string[]>([]);
+  const selectedRecords = createMemo(() =>
+    props.keys().filter((key) => selected().includes(keyRecordToken(key))),
+  );
+  createEffect(() => {
+    const visible = new Set(props.keys().map(keyRecordToken));
+    setSelected((tokens) => tokens.filter((token) => visible.has(token)));
+  });
   let nextIdentity = 0;
   let list: HTMLDivElement | undefined;
 
@@ -40,14 +50,75 @@ export const KeysList: Component<KeysListProps> = (props) => {
 
   return (
     <>
+      <Show when={props.selectable && props.keys().length}>
+        <div class="sticky top-0 z-10 flex flex-col gap-1 rounded-lg bg-white p-1 shadow-sm dark:bg-neutral-800">
+          <div class="flex items-center justify-between gap-2 px-2 text-[13px]">
+            <label class="flex min-h-11 cursor-pointer items-center gap-3">
+              <input
+                type="checkbox"
+                class="size-5 cursor-pointer accent-blue-600"
+                checked={selectedRecords().length === props.keys().length}
+                ref={(input) =>
+                  createEffect(() => {
+                    input.indeterminate =
+                      selectedRecords().length > 0 &&
+                      selectedRecords().length < props.keys().length;
+                  })
+                }
+                onChange={(event) =>
+                  setSelected(event.currentTarget.checked ? props.keys().map(keyRecordToken) : [])
+                }
+              />
+              Select All Results
+            </label>
+            <span aria-live="polite">{selectedRecords().length} selected</span>
+            <Show when={selectedRecords().length > 0}>
+              <button
+                type="button"
+                class="min-h-11 px-2 text-blue-600 dark:text-blue-400"
+                onClick={() => setSelected([])}
+              >
+                Clear
+              </button>
+            </Show>
+          </div>
+          <DeleteKeys
+            label="Delete Selected"
+            scope={{ kind: 'selected', records: selectedRecords() }}
+            disabled={!selectedRecords().length}
+            onDeleted={() => setSelected([])}
+          />
+        </div>
+      </Show>
       <div ref={list}>
         <Show when={props.keys().length > 0}>
           <List>
             <Section header={props.header} footer={props.footer}>
               <For each={rows.filter((row) => row.visible)}>
                 {(row) => (
-                  <div data-history-row={row.identity} class="[&>div]:rounded-[inherit]">
-                    <Cell class="group" onClick={() => setOpenedIdentity(row.identity)}>
+                  <div
+                    data-history-row={row.identity}
+                    class="flex items-stretch rounded-lg bg-white dark:bg-neutral-800 [&>div]:rounded-[inherit]"
+                  >
+                    <Show when={props.selectable}>
+                      <label class="flex min-w-11 cursor-pointer items-center justify-center rounded-l-lg has-[:checked]:bg-blue-50 dark:has-[:checked]:bg-blue-950">
+                        <input
+                          type="checkbox"
+                          class="size-5 cursor-pointer accent-blue-600"
+                          aria-label={`Select record ${row.key.id} from ${row.key.url}`}
+                          checked={selected().includes(keyRecordToken(row.key))}
+                          onChange={(event) => {
+                            const token = keyRecordToken(row.key);
+                            setSelected((tokens) =>
+                              event.currentTarget.checked
+                                ? [...tokens, token]
+                                : tokens.filter((item) => item !== token),
+                            );
+                          }}
+                        />
+                      </label>
+                    </Show>
+                    <Cell class="group min-w-0" onClick={() => setOpenedIdentity(row.identity)}>
                       <code title="Click to copy" class="text-[13px] truncate flex w-full">
                         <span class="w-1/2 truncate">{row.key.id}</span>:
                         {/* value may be a status if Spoofing disabled */}

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -1,3 +1,4 @@
+import { DeleteKeys } from '../components/delete-keys';
 import { A } from '@solidjs/router';
 import { Cell } from '../components/cell';
 import {
@@ -63,6 +64,11 @@ export const Dashboard = () => {
           )}
         </Show>
 
+        <Show when={activeDomain()}>
+          {(domain) => (
+            <DeleteKeys label="Delete This Site" scope={{ kind: 'site', domain: domain() }} />
+          )}
+        </Show>
         <KeysList
           keys={activeDomainRecentKeys}
           header={

--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'solid-js';
 import { TbOutlineClipboardText, TbOutlineTrash } from 'solid-icons/tb';
-import { appStorage, KeyInfo } from '@/utils/storage';
+import { appStorage, getWebsiteDomain, KeyInfo } from '@/utils/storage';
+import { DeleteKeys } from '../components/delete-keys';
 import { Header } from '../components/header';
 import { Layout } from '../components/layout';
 import { List } from '../components/list';
@@ -101,6 +102,11 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
             Delete
           </Cell>
         </Section>
+        <Show when={getWebsiteDomain(props.key.url)}>
+          {(domain) => (
+            <DeleteKeys label="Delete This Site" scope={{ kind: 'site', domain: domain() }} />
+          )}
+        </Show>
         <Section header="Command builder (Bash / Zsh)">
           <Cell class="w-full">
             <textarea

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -1,4 +1,5 @@
-import { TbOutlineDownload, TbOutlineTrash as TbTrash } from 'solid-icons/tb';
+import { TbOutlineDownload } from 'solid-icons/tb';
+import { DeleteKeys } from '../components/delete-keys';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
 import { Cell } from '../components/cell';
@@ -61,10 +62,6 @@ export const Keys = () => {
     if (!isDisposed && !hasUpdate) setKeys(records ?? []);
   });
 
-  const clearKeys = async () => {
-    await appStorage.allKeys.clear();
-  };
-
   return (
     <Layout>
       <Header backHref="/">Keys</Header>
@@ -97,9 +94,7 @@ export const Keys = () => {
           >
             Export All as TXT
           </Cell>
-          <Cell before={<TbTrash />} variant="danger" onClick={clearKeys}>
-            Delete All
-          </Cell>
+          <DeleteKeys label="Delete All" scope={{ kind: 'all' }} />
         </Section>
         <div class="flex flex-col gap-1.5">
           <label for="key-search" class="px-2 text-[13px] font-medium">
@@ -117,7 +112,7 @@ export const Keys = () => {
             {filteredKeys().length} / {keys().length} keys
           </p>
         </div>
-        <KeysList keys={filteredKeys} allKeys={keys} header="All Keys" />
+        <KeysList keys={filteredKeys} allKeys={keys} header="All Keys" selectable />
         <Show when={!filteredKeys().length}>
           <Show when={keys().length} fallback={<NoKeys />}>
             <div class="flex flex-col items-center gap-1 py-4 text-center">

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -22,6 +22,76 @@ export type KeyInfo = {
   createdAt: number;
 };
 
+// Include the capture time so a later capture of the same key survives confirmation.
+export const keyRecordToken = (key: KeyInfo) =>
+  JSON.stringify([key.id, key.value, key.url, key.pssh, key.createdAt, key.mpd, key.drmSystem]);
+
+export type KeyDeletionScope =
+  | { kind: 'all' }
+  | { kind: 'site'; domain: string }
+  | { kind: 'selected'; records: KeyInfo[] };
+
+const sameKeyRecord = (left: KeyInfo, right: KeyInfo) =>
+  left.id === right.id &&
+  left.url === right.url &&
+  left.pssh === right.pssh &&
+  ((!isCapturedKey(left) && !isCapturedKey(right)) || left.value === right.value);
+
+// Read all three stores under the writer lock before showing the confirmation.
+export const prepareKeyDeletion = (scope: KeyDeletionScope) =>
+  navigator.locks.request('okova:key-history', async () => {
+    const [history, recent, domains] = await Promise.all([
+      appStorage.allKeys.getValue(),
+      appStorage.recentKeys.getValue(),
+      appStorage.recentKeysByDomain.getValue(),
+    ]);
+    const records = [
+      ...(history ?? []),
+      ...(recent ?? []),
+      ...Object.values(domains ?? {}).flat(),
+    ].filter((key) => {
+      switch (scope.kind) {
+        case 'all':
+          return true;
+        case 'site':
+          return getWebsiteDomain(key.url) === scope.domain;
+        case 'selected':
+          return scope.records.some((record) => sameKeyRecord(key, record));
+      }
+    });
+    const unique: KeyInfo[] = [];
+    for (const record of records) {
+      if (!unique.some((key) => sameKeyRecord(key, record))) unique.push(record);
+    }
+    return { count: unique.length, tokens: [...new Set(records.map(keyRecordToken))] };
+  });
+
+export const deleteKeySnapshot = (tokens: string[]) =>
+  mutateKeyHistory(async () => {
+    const targets = new Set(tokens);
+    const keep = (key: KeyInfo) => !targets.has(keyRecordToken(key));
+    const [history, recent, domains] = await Promise.all([
+      appStorage.allKeys.getValue(),
+      appStorage.recentKeys.getValue(),
+      appStorage.recentKeysByDomain.getValue(),
+    ]);
+    await storage.setItems([
+      { key: appStorage.allKeys.raw.key, value: JSON.stringify((history ?? []).filter(keep)) },
+      { key: appStorage.recentKeys.key, value: JSON.stringify((recent ?? []).filter(keep)) },
+      {
+        key: appStorage.recentKeysByDomain.raw.key,
+        value: JSON.stringify(
+          Object.fromEntries(
+            Object.entries(domains ?? {}).map(([domain, records]) => [
+              domain,
+              records.filter(keep),
+            ]),
+          ),
+        ),
+      },
+    ]);
+  });
+
 export const drmStages = {
   setup: 'Request setup',
   client: 'Client loading',

--- a/test/e2e/key-search.test.ts
+++ b/test/e2e/key-search.test.ts
@@ -79,7 +79,11 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
       await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
       await search.fill('');
       await popup.screenshot({ path: resolve('output/playwright/key-search/all-keys.png') });
-      await popup.getByText('Delete All', { exact: true }).click();
+      await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
+      await popup
+        .getByRole('dialog')
+        .getByRole('button', { name: 'Delete 2 records', exact: true })
+        .click();
       await expect.poll(() => count.textContent()).toBe('0 / 0 keys');
       expect(await popup.getByRole('heading', { name: 'Keys will appear here' }).isVisible()).toBe(
         true,

--- a/test/e2e/popup-record-deletion.test.ts
+++ b/test/e2e/popup-record-deletion.test.ts
@@ -1,11 +1,11 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { chromium } from 'playwright';
 import { expect, test } from 'vitest';
 import type { KeyInfo } from '../../src/extension/utils/storage';
 
-test('deletes records immediately, updates history and recent keys, and restores the empty list', async () => {
+test('deletes individual records and confirms frozen selected, site, and all-record scopes', async () => {
   const profile = await mkdtemp(join(tmpdir(), 'okova-record-deletion-'));
   const extension = resolve('.output/chrome-mv3');
   try {
@@ -79,6 +79,87 @@ test('deletes records immediately, updates history and recent keys, and restores
       });
       await expect.poll(() => dashboard.locator('code').count()).toBe(0);
       expect(await dashboard.locator('#root > main').isVisible()).toBe(true);
+      const otherSite = { ...key, url: 'https://other.example/watch' };
+      const records = [key, otherPage, otherSite];
+      const seed = async (records: KeyInfo[]) =>
+        worker.evaluate(async (records) => {
+          await browser.storage.local.set({
+            'all-keys': JSON.stringify(records),
+            'recent-keys': JSON.stringify(records),
+            'recent-keys-by-domain': JSON.stringify({
+              'example.com': records.filter((key) => key.url.startsWith('https://example.com/')),
+              'other.example': records.filter((key) =>
+                key.url.startsWith('https://other.example/'),
+              ),
+            }),
+          });
+        }, records);
+      await seed(records);
+      await expect.poll(() => popup.locator('code').count()).toBe(3);
+      const rowCheckboxes = popup.getByRole('checkbox', { name: /^Select record/ });
+      await rowCheckboxes.first().check();
+      expect(
+        await popup
+          .getByRole('checkbox', { name: 'Select All Results' })
+          .evaluate((element: HTMLInputElement) => element.indeterminate),
+      ).toBe(true);
+      expect(await popup.getByText('1 selected', { exact: true }).isVisible()).toBe(true);
+      expect(await popup.getByRole('heading', { name: 'Key Settings' }).count()).toBe(0);
+      await popup.getByLabel('Search by KID or site').fill('other.example');
+      await expect.poll(() => popup.getByText('0 selected', { exact: true }).count()).toBe(1);
+      await popup.getByLabel('Search by KID or site').fill('example.com');
+      await popup.getByRole('checkbox', { name: 'Select All Results' }).check();
+      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      const dialog = popup.getByRole('dialog');
+      await expect.poll(() => dialog.isVisible()).toBe(true);
+      expect(await dialog.getByRole('heading').innerText()).toBe('Delete 2 records?');
+      expect(
+        await dialog
+          .getByRole('button', { name: 'Cancel' })
+          .evaluate((element) => element === document.activeElement),
+      ).toBe(true);
+      await popup.keyboard.press('Escape');
+      expect(await dialog.count()).toBe(0);
+      expect(await popup.getByText('2 selected', { exact: true }).isVisible()).toBe(true);
+      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      const arriving = { ...key, url: 'https://example.com/new', createdAt: key.createdAt + 100 };
+      await seed([...records, arriving]);
+      expect(await dialog.getByRole('heading').innerText()).toBe('Delete 2 records?');
+      await mkdir(resolve('output/playwright/bulk-deletion'), { recursive: true });
+      await popup.screenshot({ path: resolve('output/playwright/bulk-deletion/confirmation.png') });
+      await popup.setViewportSize({ width: 500, height: 300 });
+      await popup.evaluate(() => document.documentElement.classList.add('dark'));
+      await popup.screenshot({
+        path: resolve('output/playwright/bulk-deletion/confirmation-dark-short.png'),
+      });
+      expect(await dialog.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+        true,
+      );
+      await dialog.getByRole('button', { name: 'Delete 2 records', exact: true }).click();
+      await popup.setViewportSize({ width: 500, height: 650 });
+      await popup.evaluate(() => document.documentElement.classList.remove('dark'));
+      await expect.poll(() => popup.locator('code').count()).toBe(1);
+      expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite, arriving]);
+      await popup.getByLabel('Search by KID or site').fill('');
+      await popup.screenshot({ path: resolve('output/playwright/bulk-deletion/selection.png') });
+      await dashboard.getByRole('button', { name: 'Delete This Site', exact: true }).click();
+      const siteDialog = dashboard.getByRole('dialog');
+      await expect.poll(() => siteDialog.isVisible()).toBe(true);
+      expect(await siteDialog.innerText()).toContain('example.com');
+      await siteDialog.getByRole('button', { name: 'Delete 1 record', exact: true }).click();
+      await expect.poll(() => popup.locator('code').count()).toBe(1);
+      expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite]);
+      await popup.getByLabel('Search by KID or site').fill('no-match');
+      await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
+      await expect.poll(() => dialog.isVisible()).toBe(true);
+      expect(await dialog.innerText()).toContain(
+        'All sites, regardless of the current search or selection.',
+      );
+      await seed([otherSite, arriving]);
+      await dialog.getByRole('button', { name: 'Delete 1 record', exact: true }).click();
+      await expect
+        .poll(async () => JSON.parse(String((await readRecords())['all-keys'])))
+        .toEqual([arriving]);
       expect(errors).toEqual([]);
     } finally {
       await context.close();

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import background from '../src/extension/entrypoints/background';
-import { appStorage, type KeyInfo } from '../src/extension/utils/storage';
+import {
+  appStorage,
+  prepareKeyDeletion,
+  deleteKeySnapshot,
+  type KeyInfo,
+} from '../src/extension/utils/storage';
 import { fromHex, Widevine } from '../src/lib';
 import { Session, setSupportedEngines } from '../src/lib/api';
 import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
@@ -447,3 +452,49 @@ test.each(['usable', key.value])(
     expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': remaining });
   },
 );
+
+test('freezes site deletion across caches and preserves later captures and other subdomains', async () => {
+  const www = { ...key, url: 'https://www.example.com/second' };
+  const subdomain = { ...key, url: 'https://video.example.com/watch' };
+  const recentOnly = { ...key, id: 'recent-only', value: 'usable' };
+  await appStorage.allKeys.setValue([key, www, subdomain]);
+  await appStorage.recentKeys.setValue([key, recentOnly]);
+  await appStorage.recentKeysByDomain.setValue({
+    'example.com': [key, www, recentOnly],
+    'video.example.com': [subdomain],
+  });
+  const snapshot = await prepareKeyDeletion({ kind: 'site', domain: 'example.com' });
+  expect(snapshot.count).toBe(3);
+  const recapture = { ...key, createdAt: key.createdAt + 1 };
+  const newCapture = { ...key, id: 'new' };
+  await appStorage.allKeys.setValue([key, www, subdomain, newCapture]);
+  await appStorage.recentKeys.setValue([recapture, recentOnly, newCapture]);
+  await appStorage.recentKeysByDomain.setForUrl(key.url, [recapture, recentOnly, newCapture]);
+  await deleteKeySnapshot(snapshot.tokens);
+  expect(await appStorage.allKeys.getValue()).toEqual([subdomain, newCapture]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([recapture, newCapture]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({
+    'example.com': [recapture, newCapture],
+    'video.example.com': [subdomain],
+  });
+});
+
+test('selected deletion freezes status variants and all deletion includes recent-only records', async () => {
+  const status = { ...key, value: 'usable' };
+  const expired = { ...status, value: 'expired', createdAt: key.createdAt + 1 };
+  await appStorage.allKeys.setValue([status, key]);
+  await appStorage.recentKeys.setValue([expired, key]);
+  const selected = await prepareKeyDeletion({ kind: 'selected', records: [status] });
+  expect(selected.count).toBe(1);
+  await deleteKeySnapshot(selected.tokens);
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([key]);
+  const recentOnly = { ...key, id: 'recent-only' };
+  await appStorage.recentKeysByDomain.setForUrl(key.url, [recentOnly]);
+  const all = await prepareKeyDeletion({ kind: 'all' });
+  expect(all.count).toBe(2);
+  await deleteKeySnapshot(all.tokens);
+  expect(await appStorage.allKeys.getValue()).toEqual([]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [] });
+});


### PR DESCRIPTION
Managing captured records required deleting them one at a time or clearing everything immediately. Add large record checkboxes, Select All Results, Delete Selected, and Delete This Site on the dashboard and in record details.

Selected, site, and all-record deletion now show a count and explicit scope in a confirmation dialog. Targets are snapshotted across history and recent caches under the storage lock, so later captures survive confirmation. Search-hidden records are deselected; site scope follows the existing www normalization and excludes other subdomains.

Validated with 602 unit tests, all 11 browser smoke tests, TypeScript compilation, lint, and Chrome/Firefox builds. Visually checked light/dark layouts and a 300px popup. Browser coverage includes cancellation, initial Cancel focus, selection/search behavior, cache cleanup, and captures arriving during confirmation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791307257&installation_model_id=424872&pr_number=80&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F80&signature=784dd8dfde5ffb5776ce61f2178a5a748044fa85ef3db803894a5fd6168ef949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->