### PR TITLE
fix(extension): UI fixes after adding bulk deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Reloading or navigating clears the current result; saved keys then appear blue. 
 
 In **Keys**, use the large checkboxes to select individual records or **Select All Results** to select the current search results. **Delete Selected** shows the affected count before deleting. Records hidden by a search are deselected.
 
-**Delete This Site** is available on the dashboard and in record details. It removes that site's records from history and recent captures. A site includes its `www.` hostname, but excludes other subdomains. **Delete All** covers every site, regardless of search or selection.
+**Delete Site Keys** is available on the dashboard and in record details. It removes that site's records from history and recent captures. A site includes its `www.` hostname, but excludes other subdomains. **Delete All** covers every site, regardless of search or selection.
 
 Bulk and site confirmations freeze their target records when opened. Captures arriving afterward are kept. Cancel or press Escape to return without deleting.
 

--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -43,12 +43,12 @@ export const Cell: Component<CellProps> = (props) => {
       <Show when={props.selection}>
         {(selection) => (
           <label
-            class="-my-2 -ml-3 mr-3 flex min-h-11 shrink-0 cursor-pointer items-center px-3"
+            class="-my-2 -ml-3 flex min-h-11 w-[42px] shrink-0 cursor-pointer items-center justify-center"
             onClick={(event) => event.stopPropagation()}
           >
             <input
               type="checkbox"
-              class="size-5 cursor-pointer accent-blue-600"
+              class="size-4 cursor-pointer accent-blue-600 dark:accent-blue-400 dark:hover:accent-blue-300"
               aria-label={selection().label}
               checked={selection().checked}
               ref={(input) =>

--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -10,6 +10,12 @@ interface CellProps {
   variant?: 'default' | 'primary' | 'danger';
   before?: JSX.Element;
   after?: JSX.Element;
+  selection?: {
+    label: string;
+    checked: boolean;
+    indeterminate?: boolean;
+    onChange: (checked: boolean) => void;
+  };
   component?: 'div' | 'button' | 'label';
   disabled?: boolean;
   onClick?: () => void;
@@ -34,6 +40,27 @@ export const Cell: Component<CellProps> = (props) => {
       disabled={cellProps.component === 'button' ? props.disabled : undefined}
       onClick={props.onClick}
     >
+      <Show when={props.selection}>
+        {(selection) => (
+          <label
+            class="-my-2 -ml-3 mr-3 flex min-h-11 shrink-0 cursor-pointer items-center px-3"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              class="size-5 cursor-pointer accent-blue-600"
+              aria-label={selection().label}
+              checked={selection().checked}
+              ref={(input) =>
+                createEffect(() => {
+                  input.indeterminate = selection().indeterminate ?? false;
+                })
+              }
+              onChange={(event) => selection().onChange(event.currentTarget.checked)}
+            />
+          </label>
+        )}
+      </Show>
       {props.before && <div class="[&>svg]:w-[18px] [&>svg]:h-[18px] mr-3">{props.before}</div>}
       <div class="flex flex-col truncate select-none w-full">
         <span class="truncate">{props.children}</span>

--- a/src/extension/entrypoints/popup/components/delete-keys.tsx
+++ b/src/extension/entrypoints/popup/components/delete-keys.tsx
@@ -1,6 +1,7 @@
 import { createSignal, onMount, Show } from 'solid-js';
 import { TbOutlineTrash } from 'solid-icons/tb';
 import { deleteKeySnapshot, prepareKeyDeletion, type KeyDeletionScope } from '@/utils/storage';
+import { Portal } from 'solid-js/web';
 import { Cell } from './cell';
 
 type Deletion = Awaited<ReturnType<typeof prepareKeyDeletion>> & { description: string };
@@ -51,82 +52,82 @@ export const DeleteKeys = (props: {
     }
   };
   return (
-    <>
-      <Cell
-        component="button"
-        before={<TbOutlineTrash />}
-        variant="danger"
-        disabled={props.disabled || isBusy()}
-        onClick={prepare}
-      >
-        {props.label}
-      </Cell>
-      <Show when={error() && !pending()}>
-        <p role="alert" class="px-3 text-xs text-red-600">
-          {error()}
-        </p>
-      </Show>
-      <Show when={pending()}>
-        {(snapshot) => {
-          let dialog!: HTMLDialogElement;
-          onMount(() => dialog.showModal());
-          return (
-            <dialog
-              ref={dialog}
-              aria-labelledby="delete-title"
-              aria-describedby="delete-description"
-              onCancel={(event) => {
-                event.preventDefault();
-                if (!isBusy()) {
-                  setPending(null);
-                  setError(undefined);
-                }
-              }}
-              class="m-auto w-[calc(100%-32px)] max-w-md max-h-[calc(100vh-32px)] overflow-y-auto rounded-xl bg-white p-4 text-neutral-950 shadow-xl backdrop:bg-black/40 dark:bg-neutral-800 dark:text-neutral-50"
-            >
-              <h2 id="delete-title" class="text-base font-semibold">
-                Delete {snapshot().count} {snapshot().count === 1 ? 'record' : 'records'}?
-              </h2>
-              <p id="delete-description" class="mt-2 text-[13px] break-words">
-                {snapshot().description}
-              </p>
-              <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
-                Removes records from history and recent captures. This cannot be undone. New
-                captures arriving after this confirmation opened will be kept.
-              </p>
-              <Show when={error()}>
-                <p role="alert" class="mt-2 text-xs text-red-600">
-                  {error()}
-                </p>
-              </Show>
-              <div class="mt-4 flex justify-end gap-2">
-                <button
-                  autofocus
-                  type="button"
-                  disabled={isBusy()}
-                  onClick={() => {
+    <Cell
+      component="button"
+      before={<TbOutlineTrash />}
+      variant="danger"
+      disabled={props.disabled || isBusy()}
+      onClick={prepare}
+      subtitle={
+        <Show when={error() && !pending()}>
+          <span role="alert">{error()}</span>
+        </Show>
+      }
+    >
+      {props.label}
+      <Portal>
+        <Show when={pending()}>
+          {(snapshot) => {
+            let dialog!: HTMLDialogElement;
+            onMount(() => dialog.showModal());
+            return (
+              <dialog
+                ref={dialog}
+                aria-labelledby="delete-title"
+                aria-describedby="delete-description"
+                onCancel={(event) => {
+                  event.preventDefault();
+                  if (!isBusy()) {
                     setPending(null);
                     setError(undefined);
-                  }}
-                  class="min-h-11 rounded-lg px-4 text-[13px] focus-visible:outline-2 disabled:opacity-50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  disabled={isBusy() || snapshot().count === 0}
-                  onClick={confirm}
-                  class="min-h-11 rounded-lg bg-red-600 px-4 text-[13px] text-white focus-visible:outline-2 disabled:opacity-50"
-                >
-                  {isBusy()
-                    ? 'Deleting…'
-                    : `Delete ${snapshot().count} ${snapshot().count === 1 ? 'record' : 'records'}`}
-                </button>
-              </div>
-            </dialog>
-          );
-        }}
-      </Show>
-    </>
+                  }
+                }}
+                class="m-auto w-[calc(100%-32px)] max-w-md max-h-[calc(100vh-32px)] overflow-y-auto rounded-xl bg-white p-4 text-neutral-950 shadow-xl backdrop:bg-black/40 dark:bg-neutral-800 dark:text-neutral-50"
+              >
+                <h2 id="delete-title" class="text-base font-semibold">
+                  Delete {snapshot().count} {snapshot().count === 1 ? 'record' : 'records'}?
+                </h2>
+                <p id="delete-description" class="mt-2 text-[13px] break-words">
+                  {snapshot().description}
+                </p>
+                <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                  Removes records from history and recent captures. This cannot be undone. New
+                  captures arriving after this confirmation opened will be kept.
+                </p>
+                <Show when={error()}>
+                  <p role="alert" class="mt-2 text-xs text-red-600">
+                    {error()}
+                  </p>
+                </Show>
+                <div class="mt-4 flex justify-end gap-2">
+                  <button
+                    autofocus
+                    type="button"
+                    disabled={isBusy()}
+                    onClick={() => {
+                      setPending(null);
+                      setError(undefined);
+                    }}
+                    class="min-h-11 rounded-lg px-4 text-[13px] focus-visible:outline-2 disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isBusy() || snapshot().count === 0}
+                    onClick={confirm}
+                    class="min-h-11 rounded-lg bg-red-600 px-4 text-[13px] text-white focus-visible:outline-2 disabled:opacity-50"
+                  >
+                    {isBusy()
+                      ? 'Deleting…'
+                      : `Delete ${snapshot().count} ${snapshot().count === 1 ? 'record' : 'records'}`}
+                  </button>
+                </div>
+              </dialog>
+            );
+          }}
+        </Show>
+      </Portal>
+    </Cell>
   );
 };

--- a/src/extension/entrypoints/popup/components/delete-keys.tsx
+++ b/src/extension/entrypoints/popup/components/delete-keys.tsx
@@ -73,6 +73,10 @@ export const DeleteKeys = (props: {
             return (
               <dialog
                 ref={dialog}
+                onClick={(event) => {
+                  // Solid portal events bubble to the opening Cell unless stopped here.
+                  event.stopPropagation();
+                }}
                 aria-labelledby="delete-title"
                 aria-describedby="delete-description"
                 onCancel={(event) => {
@@ -82,24 +86,36 @@ export const DeleteKeys = (props: {
                     setError(undefined);
                   }
                 }}
-                class="m-auto w-[calc(100%-32px)] max-w-md max-h-[calc(100vh-32px)] overflow-y-auto rounded-xl bg-white p-4 text-neutral-950 shadow-xl backdrop:bg-black/40 dark:bg-neutral-800 dark:text-neutral-50"
+                class="m-auto flex w-[280px] max-w-[calc(100%-32px)] max-h-[calc(100vh-32px)] flex-col overflow-hidden rounded-[14px] bg-[#EFEFF4] p-0 text-center text-neutral-950 shadow-xl backdrop:bg-black/40 dark:bg-neutral-800 dark:text-neutral-50"
               >
-                <h2 id="delete-title" class="text-base font-semibold">
-                  Delete {snapshot().count} {snapshot().count === 1 ? 'record' : 'records'}?
-                </h2>
-                <p id="delete-description" class="mt-2 text-[13px] break-words">
-                  {snapshot().description}
-                </p>
-                <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
-                  Removes records from history and recent captures. This cannot be undone. New
-                  captures arriving after this confirmation opened will be kept.
-                </p>
-                <Show when={error()}>
-                  <p role="alert" class="mt-2 text-xs text-red-600">
-                    {error()}
+                <div class="min-h-0 overflow-y-auto p-4">
+                  <h2 id="delete-title" class="text-[14px] font-semibold">
+                    Delete {snapshot().count} {snapshot().count === 1 ? 'record' : 'records'}?
+                  </h2>
+                  <p id="delete-description" class="mt-2 text-[12px] break-words">
+                    {snapshot().description}
                   </p>
-                </Show>
-                <div class="mt-4 flex justify-end gap-2">
+                  <p class="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+                    Removes records from history and recent captures. This cannot be undone. New
+                    captures arriving after this confirmation opened will be kept.
+                  </p>
+                  <Show when={error()}>
+                    <p role="alert" class="mt-2 text-xs text-red-600">
+                      {error()}
+                    </p>
+                  </Show>
+                </div>
+                <div class="flex shrink-0 flex-col">
+                  <button
+                    type="button"
+                    disabled={isBusy() || snapshot().count === 0}
+                    onClick={confirm}
+                    class="min-h-10 w-full cursor-pointer border-t border-neutral-300 px-4 py-2 text-[13px] text-red-600 hover:bg-black/5 focus-visible:outline-2 focus-visible:-outline-offset-2 disabled:cursor-default disabled:opacity-50 dark:border-neutral-600 dark:text-red-400 dark:hover:bg-white/5"
+                  >
+                    {isBusy()
+                      ? 'Deleting…'
+                      : `Delete ${snapshot().count} ${snapshot().count === 1 ? 'record' : 'records'}`}
+                  </button>
                   <button
                     autofocus
                     type="button"
@@ -108,19 +124,9 @@ export const DeleteKeys = (props: {
                       setPending(null);
                       setError(undefined);
                     }}
-                    class="min-h-11 rounded-lg px-4 text-[13px] focus-visible:outline-2 disabled:opacity-50"
+                    class="min-h-10 w-full cursor-pointer border-t border-neutral-300 px-4 py-2 text-[13px] font-semibold text-[#007AFF] hover:bg-black/5 focus-visible:outline-2 focus-visible:-outline-offset-2 disabled:cursor-default disabled:opacity-50 dark:border-neutral-600 dark:text-blue-400 dark:hover:bg-white/5"
                   >
                     Cancel
-                  </button>
-                  <button
-                    type="button"
-                    disabled={isBusy() || snapshot().count === 0}
-                    onClick={confirm}
-                    class="min-h-11 rounded-lg bg-red-600 px-4 text-[13px] text-white focus-visible:outline-2 disabled:opacity-50"
-                  >
-                    {isBusy()
-                      ? 'Deleting…'
-                      : `Delete ${snapshot().count} ${snapshot().count === 1 ? 'record' : 'records'}`}
                   </button>
                 </div>
               </dialog>

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -72,7 +72,7 @@ export const KeysList: Component<KeysListProps> = (props) => {
               <Show when={selectedRecords().length > 0}>
                 <button
                   type="button"
-                  class="-my-2 min-h-11 px-2 text-[13px] text-blue-600 dark:text-blue-400"
+                  class="-my-2 min-h-11 cursor-pointer px-2 text-[13px] text-blue-600 dark:text-blue-400"
                   onClick={(event) => {
                     event.stopPropagation();
                     setSelected([]);

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -51,44 +51,47 @@ export const KeysList: Component<KeysListProps> = (props) => {
   return (
     <>
       <Show when={props.selectable && props.keys().length}>
-        <div class="sticky top-0 z-10 flex flex-col gap-1 rounded-lg bg-white p-1 shadow-sm dark:bg-neutral-800">
-          <div class="flex items-center justify-between gap-2 px-2 text-[13px]">
-            <label class="flex min-h-11 cursor-pointer items-center gap-3">
-              <input
-                type="checkbox"
-                class="size-5 cursor-pointer accent-blue-600"
-                checked={selectedRecords().length === props.keys().length}
-                ref={(input) =>
-                  createEffect(() => {
-                    input.indeterminate =
-                      selectedRecords().length > 0 &&
-                      selectedRecords().length < props.keys().length;
-                  })
-                }
-                onChange={(event) =>
-                  setSelected(event.currentTarget.checked ? props.keys().map(keyRecordToken) : [])
-                }
-              />
-              Select All Results
-            </label>
-            <span aria-live="polite">{selectedRecords().length} selected</span>
-            <Show when={selectedRecords().length > 0}>
-              <button
-                type="button"
-                class="min-h-11 px-2 text-blue-600 dark:text-blue-400"
-                onClick={() => setSelected([])}
-              >
-                Clear
-              </button>
-            </Show>
-          </div>
+        <Section>
+          <Cell
+            selection={{
+              label: 'Select All Results',
+              checked: selectedRecords().length === props.keys().length,
+              indeterminate:
+                selectedRecords().length > 0 && selectedRecords().length < props.keys().length,
+              onChange: (checked) => setSelected(checked ? props.keys().map(keyRecordToken) : []),
+            }}
+            onClick={() =>
+              setSelected(
+                selectedRecords().length === props.keys().length
+                  ? []
+                  : props.keys().map(keyRecordToken),
+              )
+            }
+            subtitle={<span aria-live="polite">{selectedRecords().length} selected</span>}
+            after={
+              <Show when={selectedRecords().length > 0}>
+                <button
+                  type="button"
+                  class="-my-2 min-h-11 px-2 text-[13px] text-blue-600 dark:text-blue-400"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setSelected([]);
+                  }}
+                >
+                  Clear
+                </button>
+              </Show>
+            }
+          >
+            Select All Results
+          </Cell>
           <DeleteKeys
             label="Delete Selected"
             scope={{ kind: 'selected', records: selectedRecords() }}
             disabled={!selectedRecords().length}
             onDeleted={() => setSelected([])}
           />
-        </div>
+        </Section>
       </Show>
       <div ref={list}>
         <Show when={props.keys().length > 0}>
@@ -96,29 +99,27 @@ export const KeysList: Component<KeysListProps> = (props) => {
             <Section header={props.header} footer={props.footer}>
               <For each={rows.filter((row) => row.visible)}>
                 {(row) => (
-                  <div
-                    data-history-row={row.identity}
-                    class="flex items-stretch rounded-lg bg-white dark:bg-neutral-800 [&>div]:rounded-[inherit]"
-                  >
-                    <Show when={props.selectable}>
-                      <label class="flex min-w-11 cursor-pointer items-center justify-center rounded-l-lg has-[:checked]:bg-blue-50 dark:has-[:checked]:bg-blue-950">
-                        <input
-                          type="checkbox"
-                          class="size-5 cursor-pointer accent-blue-600"
-                          aria-label={`Select record ${row.key.id} from ${row.key.url}`}
-                          checked={selected().includes(keyRecordToken(row.key))}
-                          onChange={(event) => {
-                            const token = keyRecordToken(row.key);
-                            setSelected((tokens) =>
-                              event.currentTarget.checked
-                                ? [...tokens, token]
-                                : tokens.filter((item) => item !== token),
-                            );
-                          }}
-                        />
-                      </label>
-                    </Show>
-                    <Cell class="group min-w-0" onClick={() => setOpenedIdentity(row.identity)}>
+                  <div data-history-row={row.identity} class="[&>div]:rounded-[inherit]">
+                    <Cell
+                      class="group min-w-0"
+                      onClick={() => setOpenedIdentity(row.identity)}
+                      selection={
+                        props.selectable
+                          ? {
+                              label: `Select record ${row.key.id} from ${row.key.url}`,
+                              checked: selected().includes(keyRecordToken(row.key)),
+                              onChange: (checked) => {
+                                const token = keyRecordToken(row.key);
+                                setSelected((tokens) =>
+                                  checked
+                                    ? [...tokens, token]
+                                    : tokens.filter((item) => item !== token),
+                                );
+                              },
+                            }
+                          : undefined
+                      }
+                    >
                       <code title="Click to copy" class="text-[13px] truncate flex w-full">
                         <span class="w-1/2 truncate">{row.key.id}</span>:
                         {/* value may be a status if Spoofing disabled */}

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -66,7 +66,7 @@ export const Dashboard = () => {
 
         <Show when={activeDomain()}>
           {(domain) => (
-            <DeleteKeys label="Delete This Site" scope={{ kind: 'site', domain: domain() }} />
+            <DeleteKeys label="Delete Site Keys" scope={{ kind: 'site', domain: domain() }} />
           )}
         </Show>
         <KeysList

--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -101,12 +101,12 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
           >
             Delete
           </Cell>
+          <Show when={getWebsiteDomain(props.key.url)}>
+            {(domain) => (
+              <DeleteKeys label="Delete Site Keys" scope={{ kind: 'site', domain: domain() }} />
+            )}
+          </Show>
         </Section>
-        <Show when={getWebsiteDomain(props.key.url)}>
-          {(domain) => (
-            <DeleteKeys label="Delete This Site" scope={{ kind: 'site', domain: domain() }} />
-          )}
-        </Show>
         <Section header="Command builder (Bash / Zsh)">
           <Cell class="w-full">
             <textarea

--- a/test/e2e/popup-record-deletion.test.ts
+++ b/test/e2e/popup-record-deletion.test.ts
@@ -142,7 +142,7 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite, arriving]);
       await popup.getByLabel('Search by KID or site').fill('');
       await popup.screenshot({ path: resolve('output/playwright/bulk-deletion/selection.png') });
-      await dashboard.getByRole('button', { name: 'Delete This Site', exact: true }).click();
+      await dashboard.getByRole('button', { name: 'Delete Site Keys', exact: true }).click();
       const siteDialog = dashboard.getByRole('dialog');
       await expect.poll(() => siteDialog.isVisible()).toBe(true);
       expect(await siteDialog.innerText()).toContain('example.com');

--- a/test/e2e/popup-record-deletion.test.ts
+++ b/test/e2e/popup-record-deletion.test.ts
@@ -118,6 +118,25 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
           .getByRole('button', { name: 'Cancel' })
           .evaluate((element) => element === document.activeElement),
       ).toBe(true);
+      expect(
+        await dialog
+          .getByRole('button')
+          .evaluateAll((buttons) =>
+            buttons.every((button) => getComputedStyle(button).cursor === 'pointer'),
+          ),
+      ).toBe(true);
+      await dialog.getByRole('button', { name: 'Cancel' }).click();
+      // Let a mistakenly bubbled click finish preparing a second confirmation.
+      await popup.waitForTimeout(150);
+      expect(await dialog.count()).toBe(0);
+      expect(await popup.getByText('2 selected', { exact: true }).isVisible()).toBe(true);
+      expect(
+        await popup
+          .getByRole('button', { name: 'Clear', exact: true })
+          .evaluate((button) => getComputedStyle(button).cursor),
+      ).toBe('pointer');
+      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      await dialog.waitFor({ state: 'visible' });
       await popup.keyboard.press('Escape');
       expect(await dialog.count()).toBe(0);
       expect(await popup.getByText('2 selected', { exact: true }).isVisible()).toBe(true);


### PR DESCRIPTION
The new selection controls did not match the extension's Cell styling, record checkboxes had a separate hover background, and deletion confirmation children disrupted Section corners.

Integrate checkboxes into Cell, use a regular Section for selection actions with the count as a subtitle, and render confirmations through a portal inside the action Cell. Rename the site action to Delete Site Keys and group it with Delete in record details.

Validated with TypeScript, lint, the Chrome build, all 11 browser smoke tests, and light/dark screenshots of hover states and grouped actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791308599&installation_model_id=424872&pr_number=81&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F81&signature=c5d2917abb86ee87ddee802027bcc30044f8e7dd1587b0cd33c7fadc989605b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->