### PR TITLE
feat(extension): add history filters and sorting

### DIFF
--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -6,7 +6,7 @@ interface CellProps {
   title?: string;
   subtitle?: JSX.Element;
   children: JSX.Element;
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   variant?: 'default' | 'primary' | 'danger' | 'warning';
   before?: JSX.Element;
   after?: JSX.Element;
@@ -37,6 +37,8 @@ export const Cell: Component<CellProps> = (props) => {
         props.disabled && 'cursor-default pointer-events-none opacity-70',
         props.size === 'sm' &&
           'text-[13px] font-medium hover:bg-transparent dark:hover:bg-transparent hover:opacity-80 min-h-4 py-1',
+        props.size === 'xs' &&
+          'text-[10px] font-medium bg-transparent dark:bg-transparent hover:bg-neutral-100 hover:dark:bg-neutral-800 min-h-4 py-0 px-1.5',
         props.class,
       )}
       title={props.title}

--- a/src/extension/entrypoints/popup/components/delete-keys.tsx
+++ b/src/extension/entrypoints/popup/components/delete-keys.tsx
@@ -9,7 +9,8 @@ type Deletion = Awaited<ReturnType<typeof prepareKeyDeletion>> & { description: 
 export const DeleteKeys = (props: {
   scope: KeyDeletionScope;
   label: string;
-  compact?: boolean;
+  class?: string;
+  size?: 'xs' | 'sm' | 'md';
   disabled?: boolean;
   onDeleted?: () => void;
 }) => {
@@ -55,9 +56,10 @@ export const DeleteKeys = (props: {
   return (
     <Cell
       component="button"
-      before={props.compact ? undefined : <TbOutlineTrash />}
+      class={props.class}
+      before={props.size === 'xs' || props.size === 'sm' ? undefined : <TbOutlineTrash />}
       variant="danger"
-      size={props.compact ? 'sm' : 'md'}
+      size={props.size ?? 'md'}
       disabled={props.disabled || isBusy()}
       onClick={prepare}
       subtitle={

--- a/src/extension/entrypoints/popup/components/header.tsx
+++ b/src/extension/entrypoints/popup/components/header.tsx
@@ -15,7 +15,7 @@ export const Header: Component<HeaderProps> = (props) => {
   return (
     <div
       class={cn(
-        'text-base font-bold flex gap-3 items-center select-none min-h-11',
+        'text-base font-bold flex gap-3 items-center min-h-11',
         '-mt-4 py-1 mb-3',
         'px-4',
         'rounded-b-lg',

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -8,13 +8,14 @@ import { Section } from './section';
 import { KeySettings } from '../routes/key-settings';
 import { formatRelativeTime } from '../utils/date';
 import { captureHistoryScroll, reconcileHistoryRows, type HistoryRow } from '../utils/history-rows';
-import { TbOutlineSearch, TbOutlineTrash } from 'solid-icons/tb';
+import { TbOutlineSearch } from 'solid-icons/tb';
 
 type KeysListProps = {
   keys: Accessor<KeyInfo[]>;
   allKeys?: Accessor<KeyInfo[]>;
   selectable?: boolean;
   search?: { value: string; onChange: (value: string) => void };
+  controls?: JSX.Element;
   header?: JSX.Element;
   footer?: JSX.Element;
 };
@@ -38,7 +39,9 @@ export const KeysList: Component<KeysListProps> = (props) => {
 
   createComputed(() => {
     const visible = props.keys();
-    const records = props.allKeys?.() ?? visible;
+    const records = props.allKeys
+      ? [...visible, ...props.allKeys().filter((key) => !visible.includes(key))]
+      : visible;
     untrack(() => {
       const restoreScroll = captureHistoryScroll(list);
       const next = reconcileHistoryRows(rows, records, visible, () => nextIdentity++);
@@ -93,36 +96,33 @@ export const KeysList: Component<KeysListProps> = (props) => {
                     : props.keys().map(keyRecordToken),
                 )
               }
-              // after={
-              //   <Show when={selectedRecords().length > 0}>
-              //     <button
-              //       type="button"
-              //       class="-my-2 min-h-11 cursor-pointer px-2 text-[13px] text-blue-600 dark:text-blue-400"
-              //       onClick={(event) => {
-              //         event.stopPropagation();
-              //         setSelected([]);
-              //       }}
-              //     >
-              //       Clear
-              //     </button>
-              //   </Show>
-              // }
             >
               Select All Results
             </Cell>
-            <DeleteKeys
-              label="Delete Selected"
-              scope={{ kind: 'selected', records: selectedRecords() }}
-              disabled={!selectedRecords().length}
-              onDeleted={() => setSelected([])}
-            />
           </Show>
         </Section>
       </Show>
       <div ref={list}>
         <Show when={props.keys().length > 0}>
           <List>
-            <Section header={props.header} footer={props.footer}>
+            <Section
+              header={props.header}
+              headerControls={
+                <>
+                  <Show when={selectedRecords().length}>
+                    <DeleteKeys
+                      label="Delete Selected"
+                      scope={{ kind: 'selected', records: selectedRecords() }}
+                      size="xs"
+                      disabled={!selectedRecords().length}
+                      onDeleted={() => setSelected([])}
+                    />
+                  </Show>
+                  {props.controls}
+                </>
+              }
+              footer={props.footer}
+            >
               <For each={rows.filter((row) => row.visible)}>
                 {(row) => (
                   <div data-history-row={row.identity} class="[&>div]:rounded-[inherit]">

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -103,7 +103,7 @@ export const KeysList: Component<KeysListProps> = (props) => {
         </Section>
       </Show>
       <div ref={list}>
-        <Show when={props.keys().length > 0}>
+        <Show when={props.keys().length > 0 || props.search}>
           <List>
             <Section
               header={props.header}

--- a/src/extension/entrypoints/popup/components/section.tsx
+++ b/src/extension/entrypoints/popup/components/section.tsx
@@ -17,6 +17,14 @@ type SectionProps = {
 
 export const Section: Component<SectionProps> = (props) => {
   const resolved = children(() => props.children);
+  const items = createMemo(() =>
+    resolved
+      .toArray()
+      .filter(
+        (child) =>
+          child !== '' && child !== null && child !== undefined && typeof child !== 'boolean',
+      ),
+  );
   return (
     <section>
       <Show when={props.header}>
@@ -25,20 +33,22 @@ export const Section: Component<SectionProps> = (props) => {
           <div class="ml-auto flex items-center gap-0.5">{props.headerControls}</div>
         </header>
       </Show>
-      <div class="shadow-xs dark:outline-1 dark:outline-neutral-700/80 rounded-[9px]">
-        <div class="rounded-[9px] bg-white dark:bg-neutral-800 [&>*]:rounded-none [&>*:first-child]:rounded-t-lg [&>*:last-child]:rounded-b-lg">
-          <For each={resolved.toArray()}>
-            {(child, index) => (
-              <>
-                {child}
-                <Show when={resolved.toArray() && index() < resolved.toArray().length - 1}>
-                  <div class="h-px bg-gray-100 dark:bg-neutral-700/60 transition-colors"></div>
-                </Show>
-              </>
-            )}
-          </For>
+      <Show when={items().length}>
+        <div class="shadow-xs dark:outline-1 dark:outline-neutral-700/80 rounded-[9px]">
+          <div class="rounded-[9px] bg-white dark:bg-neutral-800 [&>*]:rounded-none [&>*:first-child]:rounded-t-lg [&>*:last-child]:rounded-b-lg">
+            <For each={items()}>
+              {(child, index) => (
+                <>
+                  {child}
+                  <Show when={index() < items().length - 1}>
+                    <div class="h-px bg-gray-100 dark:bg-neutral-700/60 transition-colors"></div>
+                  </Show>
+                </>
+              )}
+            </For>
+          </div>
         </div>
-      </div>
+      </Show>
       <Show when={props.footer}>
         <SectionFooter>{props.footer}</SectionFooter>
       </Show>

--- a/src/extension/entrypoints/popup/components/section.tsx
+++ b/src/extension/entrypoints/popup/components/section.tsx
@@ -10,6 +10,7 @@ export const SectionFooter: Component<{ children: JSX.Element }> = (props) => {
 
 type SectionProps = {
   header?: JSX.Element;
+  headerControls?: JSX.Element;
   footer?: JSX.Element;
   children?: JSX.Element;
 };
@@ -19,8 +20,9 @@ export const Section: Component<SectionProps> = (props) => {
   return (
     <section>
       <Show when={props.header}>
-        <header class="px-2 pt-2 pb-1 text-[10px] cursor-default uppercase text-neutral-500 dark:text-neutral-400">
+        <header class="pl-2 pr-1 pt-2 pb-1 text-[10px] cursor-default uppercase text-neutral-500 dark:text-neutral-400 flex items-center gap-0.5">
           {props.header}
+          <div class="ml-auto flex items-center gap-0.5">{props.headerControls}</div>
         </header>
       </Show>
       <div class="shadow-xs dark:outline-1 dark:outline-neutral-700/80 rounded-[9px]">

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -17,7 +17,6 @@ import { CellImportClient } from '../components/cell-import-client';
 import { NoKeys } from '../components/no-keys';
 import { KeysList } from '../components/keys-list';
 import { getRecentKeysForUrl, getWebsiteDomain, drmStages } from '@/utils/storage';
-import { Section } from '../components/section';
 
 export const Dashboard = () => {
   const [failure] = useDrmFailure();
@@ -40,22 +39,7 @@ export const Dashboard = () => {
 
   return (
     <Layout>
-      <Header
-        subtitle={activeClient()?.client.label}
-        actions={
-          <Show when={activeDomain()}>
-            {(domain) => (
-              <DeleteKeys
-                label="Delete Site Keys"
-                scope={{ kind: 'site', domain: domain() }}
-                compact
-              />
-            )}
-          </Show>
-        }
-      >
-        Dashboard
-      </Header>
+      <Header subtitle={activeClient()?.client.label}>Dashboard</Header>
       <div class="flex flex-col gap-3">
         <Toolbar />
 
@@ -79,9 +63,21 @@ export const Dashboard = () => {
         <KeysList
           keys={activeDomainRecentKeys}
           header={
-            <span class="block truncate" title={recentKeysHeader()}>
+            <div class="block truncate" title={recentKeysHeader()}>
               {recentKeysHeader()}
-            </span>
+            </div>
+          }
+          controls={
+            <Show when={activeDomain()}>
+              {(domain) => (
+                <DeleteKeys
+                  class="w-fit ml-auto"
+                  label="Delete Site Keys"
+                  scope={{ kind: 'site', domain: domain() }}
+                  size="xs"
+                />
+              )}
+            </Show>
           }
           footer={
             <Show when={!settings.spoofing}>

--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -62,7 +62,22 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
 
   return (
     <Layout className="fixed top-0 left-0 w-full h-full min-h-0 max-h-[600px] overflow-y-auto [scrollbar-gutter:stable]">
-      <Header onClose={props.onClose}>Key Settings</Header>
+      <Header
+        actions={
+          <Cell
+            component="button"
+            variant="danger"
+            size="sm"
+            disabled={isDeleting()}
+            onClick={deleteRecord}
+          >
+            Delete Key
+          </Cell>
+        }
+        onClose={props.onClose}
+      >
+        Key Details
+      </Header>
       <List>
         <Section header="Details">
           <Cell subtitle={props.key.url} onClick={() => window.open(props.key.url, '_blank')}>
@@ -92,15 +107,6 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
             </Show>
           }
         >
-          <Cell
-            component="button"
-            before={<TbOutlineTrash />}
-            variant="danger"
-            disabled={isDeleting()}
-            onClick={deleteRecord}
-          >
-            Delete
-          </Cell>
           <Show when={getWebsiteDomain(props.key.url)}>
             {(domain) => (
               <DeleteKeys label="Delete Site Keys" scope={{ kind: 'site', domain: domain() }} />

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -9,22 +9,20 @@ import { NoKeys } from '../components/no-keys';
 import { Section } from '../components/section';
 import { serializeHistory, type HistoryExportFormat } from '../utils/history-export';
 import { saveFile } from '../utils/file';
+import { filterHistory, type HistoryFilters } from '../utils/history-filters';
 
 export const Keys = () => {
   const [keys, setKeys] = createSignal<KeyInfo[]>([]);
   const [search, setSearch] = createSignal('');
-  const filteredKeys = createMemo(() => {
-    const query = search().trim().toLowerCase();
-    if (!query) return keys();
-
-    const kidQuery = query.replaceAll('-', '');
-    return keys().filter(
-      (key) =>
-        (kidQuery.length > 0 && key.id.toLowerCase().replaceAll('-', '').includes(kidQuery)) ||
-        key.url.toLowerCase().includes(query) ||
-        key.mpd?.toLowerCase().includes(query),
-    );
-  });
+  const [drm, setDrm] = createSignal<HistoryFilters['drm']>('all');
+  const [order, setOrder] = createSignal<HistoryFilters['order']>('newest');
+  const filteredKeys = createMemo(() =>
+    filterHistory(keys(), { search: search(), drm: drm(), order: order() }),
+  );
+  const clearFilters = () => {
+    setSearch('');
+    setDrm('all');
+  };
   const [isExporting, setIsExporting] = createSignal(false);
   const [exportError, setExportError] = createSignal<string>();
 
@@ -33,7 +31,7 @@ export const Keys = () => {
     setIsExporting(true);
     setExportError(undefined);
     try {
-      const records = (await appStorage.allKeys.getValue()) ?? [];
+      const records = filteredKeys();
       const content = serializeHistory(records, format);
       const filename = format === 'json' ? 'okova-history.json' : 'okova-keys.txt';
       await saveFile(new TextEncoder().encode(content), filename);
@@ -78,21 +76,21 @@ export const Keys = () => {
             component="button"
             before={<TbOutlineDownload />}
             variant="primary"
-            subtitle="All records, including statuses and metadata"
-            disabled={isExporting()}
+            subtitle="Matching records, including statuses and metadata"
+            disabled={isExporting() || !filteredKeys().length}
             onClick={() => exportKeys('json')}
           >
-            Export All as JSON
+            Export Results as JSON
           </Cell>
           <Cell
             component="button"
             before={<TbOutlineDownload />}
             variant="primary"
             subtitle="Unique KID:KEY pairs, one per line"
-            disabled={isExporting()}
+            disabled={isExporting() || !filteredKeys().length}
             onClick={() => exportKeys('txt')}
           >
-            Export All as TXT
+            Export Results as TXT
           </Cell>
           <DeleteKeys label="Delete All" scope={{ kind: 'all' }} />
         </Section>
@@ -101,6 +99,44 @@ export const Keys = () => {
           allKeys={keys}
           header="All Keys"
           search={{ value: search(), onChange: setSearch }}
+          controls={
+            <>
+              <select
+                aria-label="DRM"
+                class="min-w-[105px] min-h-4 px-0.5 outline-none font-normal rounded-md bg-transparent hover:bg-neutral-100 hover:dark:bg-neutral-800 hover:cursor-pointer dark:[color-scheme:dark]"
+                value={drm()}
+                onChange={(event) => {
+                  const value = event.currentTarget.value;
+                  if (
+                    value === 'all' ||
+                    value === 'W' ||
+                    value === 'P' ||
+                    value === 'C' ||
+                    value === 'unknown'
+                  )
+                    setDrm(value);
+                }}
+              >
+                <option value="all">All DRM systems</option>
+                <option value="W">Widevine</option>
+                <option value="P">PlayReady</option>
+                <option value="C">ClearKey</option>
+                <option value="unknown">Unknown</option>
+              </select>
+              <select
+                aria-label="Order"
+                class="min-w-[82px] min-h-4 px-0.5 outline-none font-normal rounded-md bg-transparent hover:bg-neutral-100 hover:dark:bg-neutral-800 hover:cursor-pointer dark:[color-scheme:dark]"
+                value={order()}
+                onChange={(event) => {
+                  const value = event.currentTarget.value;
+                  if (value === 'newest' || value === 'oldest') setOrder(value);
+                }}
+              >
+                <option value="newest">Newest first</option>
+                <option value="oldest">Oldest first</option>
+              </select>
+            </>
+          }
           selectable
         />
         <Show when={!filteredKeys().length}>
@@ -108,14 +144,14 @@ export const Keys = () => {
             <div class="flex flex-col items-center gap-1 py-4 text-center">
               <h1 class="text-[16px] font-semibold">No matching keys</h1>
               <p class="text-[13px] text-neutral-800 dark:text-neutral-300">
-                Try another KID, page URL, or manifest URL.
+                Try another search or adjust filters.
               </p>
               <button
                 type="button"
-                onClick={() => setSearch('')}
+                onClick={clearFilters}
                 class="rounded px-3 py-2 text-[13px] text-blue-600 hover:underline focus-visible:outline-2 dark:text-blue-400"
               >
-                Clear search
+                Clear filters
               </button>
             </div>
           </Show>

--- a/src/extension/entrypoints/popup/utils/history-filters.ts
+++ b/src/extension/entrypoints/popup/utils/history-filters.ts
@@ -1,0 +1,30 @@
+import type { KeyInfo } from '@/utils/storage';
+
+export type HistoryFilters = {
+  search: string;
+  drm: 'all' | 'unknown' | NonNullable<KeyInfo['drmSystem']>;
+  order: 'newest' | 'oldest';
+};
+
+export const filterHistory = (records: readonly KeyInfo[], filters: HistoryFilters): KeyInfo[] => {
+  const query = filters.search.trim().toLowerCase();
+  const kidQuery = query.replaceAll('-', '');
+
+  return records
+    .filter((key) => {
+      const matchesDrm =
+        filters.drm === 'all' ||
+        (filters.drm === 'unknown' ? !key.drmSystem : key.drmSystem === filters.drm);
+      const matchesSearch =
+        !query ||
+        (kidQuery.length > 0 && key.id.toLowerCase().replaceAll('-', '').includes(kidQuery)) ||
+        key.url.toLowerCase().includes(query) ||
+        key.mpd?.toLowerCase().includes(query);
+      return matchesDrm && matchesSearch;
+    })
+    .sort((left, right) =>
+      filters.order === 'newest'
+        ? right.createdAt - left.createdAt
+        : left.createdAt - right.createdAt,
+    );
+};

--- a/test/e2e/bitmovin.test.ts
+++ b/test/e2e/bitmovin.test.ts
@@ -145,7 +145,6 @@ test.for([
         .toBe(playback);
       // Import persists the first active client without requiring a dashboard visit.
       await popup.goto(popupUrl);
-      await expect.poll(() => popup.getByText('Active', { exact: true }).count()).toBe(1);
       await expect
         .poll(() =>
           worker.evaluate(async () => {

--- a/test/e2e/history-filters.test.ts
+++ b/test/e2e/history-filters.test.ts
@@ -110,10 +110,7 @@ test('filters and ordering control visible history and both export formats', asy
       await popup.getByLabel('DRM', { exact: true }).selectOption('W');
       await expect.poll(visible).toEqual([pair(records[0]!), pair(records[3]!)]);
       await popup.getByLabel('DRM', { exact: true }).selectOption('C');
-      await popup
-        .getByRole('button', { name: 'Clear search and filters', exact: true })
-        .first()
-        .click();
+      await popup.getByRole('button', { name: 'Clear filters', exact: true }).first().click();
       await expect
         .poll(visible)
         .toEqual([records[0]!, records[3]!, records[1]!, records[2]!].map(pair));

--- a/test/e2e/history-filters.test.ts
+++ b/test/e2e/history-filters.test.ts
@@ -1,0 +1,129 @@
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { chromium } from 'playwright';
+import { expect, test } from 'vitest';
+import type { KeyInfo } from '../../src/extension/utils/storage';
+
+test('filters and ordering control visible history and both export formats', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-history-filters-'));
+  const extension = resolve('.output/chrome-mv3');
+  try {
+    const context = await chromium.launchPersistentContext(profile, {
+      channel: 'chromium',
+      headless: true,
+      viewport: { width: 500, height: 600 },
+      args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+    });
+    try {
+      const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      const records: KeyInfo[] = [
+        {
+          id: 'a'.repeat(32),
+          value: '1'.repeat(32),
+          drmSystem: 'W',
+          createdAt: Date.parse('2026-03-08T05:00:00Z'),
+          url: 'https://watch.example/first',
+          pssh: '',
+        },
+        {
+          id: 'b'.repeat(32),
+          value: '2'.repeat(32),
+          drmSystem: 'P',
+          createdAt: Date.parse('2026-03-09T03:59:59Z'),
+          url: 'https://watch.example/second',
+          pssh: '',
+        },
+        {
+          id: 'c'.repeat(32),
+          value: '3'.repeat(32),
+          drmSystem: 'W',
+          createdAt: Date.parse('2026-03-09T04:00:00Z'),
+          url: 'https://watch.example/third',
+          pssh: '',
+        },
+      ];
+      const save = () =>
+        worker.evaluate(async (records) => {
+          await browser.storage.local.set({ 'all-keys': JSON.stringify(records) });
+        }, records);
+      await save();
+      const popup = await context.newPage();
+      await popup.addInitScript(() =>
+        Object.defineProperty(window, 'showSaveFilePicker', { value: undefined }),
+      );
+      await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
+      await popup.getByRole('link', { name: 'Keys', exact: true }).click();
+      const visible = () => popup.locator('[data-history-row] code').allTextContents();
+      const pair = (key: KeyInfo) => `${key.id}:${key.value}`;
+      await expect.poll(visible).toEqual([...records].reverse().map(pair));
+      await popup.getByLabel('Order', { exact: true }).selectOption('oldest');
+      await expect.poll(visible).toEqual(records.map(pair));
+      await popup.getByRole('searchbox').fill('WATCH.EXAMPLE');
+      await popup.getByLabel('DRM', { exact: true }).selectOption('W');
+      await expect.poll(visible).toEqual([records[0]!, records[2]!].map(pair));
+      await popup.getByRole('checkbox', { name: 'Select All Results', exact: true }).check();
+      await expect
+        .poll(() => popup.getByRole('status').textContent())
+        .toBe('2 selected / 2 filtered / 3 total');
+      await popup.getByRole('searchbox').fill('first');
+      await expect.poll(visible).toEqual([pair(records[0]!)]);
+      await expect
+        .poll(() => popup.getByRole('status').textContent())
+        .toBe('1 selected / 1 filtered / 3 total');
+      for (const format of ['JSON', 'TXT']) {
+        const downloaded = popup.waitForEvent('download');
+        await popup.getByRole('button', { name: `Export Results as ${format}` }).click();
+        const download = await downloaded;
+        const path = await download.path();
+        if (!path) throw new Error('Missing export download');
+        const content = await readFile(path, 'utf8');
+        if (format === 'JSON')
+          expect(JSON.parse(content)).toEqual({ version: 1, records: [records[0]] });
+        else expect(content).toBe(`${pair(records[0]!)}\n`);
+      }
+      records.push({
+        ...records[0]!,
+        id: 'd'.repeat(32),
+        createdAt: Date.parse('2026-03-08T10:00:00Z'),
+      });
+      await save();
+      await expect.poll(visible).toEqual([pair(records[0]!), pair(records[3]!)]);
+      await mkdir(resolve('output/playwright/history-filters'), { recursive: true });
+      await popup.screenshot({
+        path: resolve('output/playwright/history-filters/filtered.png'),
+        fullPage: true,
+      });
+      expect(
+        await popup.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+      ).toBe(true);
+      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      await expect.poll(() => popup.getByRole('dialog').isVisible()).toBe(true);
+      await popup.getByRole('button', { name: 'Cancel', exact: true }).click();
+      await popup.getByLabel('DRM', { exact: true }).selectOption('C');
+      await expect.poll(visible).toEqual([]);
+      expect(await popup.getByRole('button', { name: 'Export Results as JSON' }).isDisabled()).toBe(
+        true,
+      );
+      expect(await popup.getByLabel('DRM', { exact: true }).isVisible()).toBe(true);
+      expect(await popup.getByLabel('Order', { exact: true }).isVisible()).toBe(true);
+      await popup.getByLabel('DRM', { exact: true }).selectOption('W');
+      await expect.poll(visible).toEqual([pair(records[0]!), pair(records[3]!)]);
+      await popup.getByLabel('DRM', { exact: true }).selectOption('C');
+      await popup
+        .getByRole('button', { name: 'Clear search and filters', exact: true })
+        .first()
+        .click();
+      await expect
+        .poll(visible)
+        .toEqual([records[0]!, records[3]!, records[1]!, records[2]!].map(pair));
+      expect(await popup.getByRole('searchbox').inputValue()).toBe('');
+      expect(await popup.getByLabel('DRM', { exact: true }).inputValue()).toBe('all');
+      expect(await popup.getByLabel('Order', { exact: true }).inputValue()).toBe('oldest');
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await rm(profile, { recursive: true, force: true });
+  }
+});

--- a/test/e2e/key-search.test.ts
+++ b/test/e2e/key-search.test.ts
@@ -40,9 +40,9 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
       const popup = await context.newPage();
       await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
       await popup.getByRole('link', { name: 'Keys', exact: true }).click();
-      const search = popup.getByRole('searchbox', { name: 'Search by KID or site' });
+      const search = popup.getByRole('searchbox', { name: 'Search' });
       const count = popup.getByRole('status');
-      await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 2 filtered / 2 total');
       for (const query of [
         'aabbccdd-1122-3344-5566-77889900aabb',
         ' DD-1122 ',
@@ -52,19 +52,19 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
         'MANIFEST.MPD',
       ]) {
         await search.fill(query);
-        await expect.poll(() => count.textContent()).toBe('1 / 2 keys');
+        await expect.poll(() => count.textContent()).toBe('0 selected / 1 filtered / 2 total');
         expect(await popup.locator('code').allTextContents()).toEqual([
           `${keys[0]!.id}:${keys[0]!.value}`,
         ]);
       }
       await search.fill('5678ABCDEF90');
-      await expect.poll(() => count.textContent()).toBe('1 / 2 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 1 filtered / 2 total');
       expect(await popup.locator('code').allTextContents()).toEqual([
         `${keys[1]!.id}:${keys[1]!.value}`,
       ]);
       for (const query of ['missing.example', '---', keys[0]!.value]) {
         await search.fill(query);
-        await expect.poll(() => count.textContent()).toBe('0 / 2 keys');
+        await expect.poll(() => count.textContent()).toBe('0 selected / 0 filtered / 2 total');
         expect(await popup.getByRole('heading', { name: 'No matching keys' }).isVisible()).toBe(
           true,
         );
@@ -72,11 +72,11 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
       }
       await mkdir(resolve('output/playwright/key-search'), { recursive: true });
       await popup.screenshot({ path: resolve('output/playwright/key-search/no-matches.png') });
-      await popup.getByRole('button', { name: 'Clear search', exact: true }).click();
-      await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
+      await popup.getByRole('button', { name: 'Clear filters', exact: true }).click();
+      await expect.poll(() => count.textContent()).toBe('0 selected / 2 filtered / 2 total');
       expect(await search.inputValue()).toBe('');
       await search.fill('   ');
-      await expect.poll(() => count.textContent()).toBe('2 / 2 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 2 filtered / 2 total');
       await search.fill('');
       await popup.screenshot({ path: resolve('output/playwright/key-search/all-keys.png') });
       await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
@@ -84,7 +84,7 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
         .getByRole('dialog')
         .getByRole('button', { name: 'Delete 2 records', exact: true })
         .click();
-      await expect.poll(() => count.textContent()).toBe('0 / 0 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 0 filtered / 0 total');
       expect(await popup.getByRole('heading', { name: 'Keys will appear here' }).isVisible()).toBe(
         true,
       );

--- a/test/e2e/live-history.test.ts
+++ b/test/e2e/live-history.test.ts
@@ -35,7 +35,7 @@ test('history updates preserve search, visible rows, and live details', async ()
       const search = popup.getByRole('searchbox');
       await search.fill('history.example');
       const count = popup.getByRole('status');
-      await expect.poll(() => count.textContent()).toBe('60 / 60 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 60 filtered / 60 total');
       const root = popup.locator('#root');
       await root.evaluate((element) => {
         element.scrollTop = 1100;
@@ -43,10 +43,11 @@ test('history updates preserve search, visible rows, and live details', async ()
       const anchor = popup.locator('[data-history-row]').nth(20);
       const anchorIdentity = await anchor.getAttribute('data-history-row');
       const stableAnchor = popup.locator(`[data-history-row="${anchorIdentity}"]`);
+      const anchorKid = await stableAnchor.locator('code span').first().textContent();
       const before = await stableAnchor.evaluate((element) => element.getBoundingClientRect().top);
       records = [{ ...records[0]!, id: 'new-record' }, ...records];
       await save();
-      await expect.poll(() => count.textContent()).toBe('61 / 61 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 61 filtered / 61 total');
       await expect
         .poll(async () =>
           Math.abs(
@@ -57,7 +58,7 @@ test('history updates preserve search, visible rows, and live details', async ()
         .toBeLessThanOrEqual(1);
       records = records.slice(6);
       await save();
-      await expect.poll(() => count.textContent()).toBe('55 / 55 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 55 filtered / 55 total');
       await expect
         .poll(async () =>
           Math.abs(
@@ -72,7 +73,7 @@ test('history updates preserve search, visible rows, and live details', async ()
       const details = popup.locator('main').last();
       const command = details.getByRole('textbox');
       await expect.poll(() => command.inputValue()).toContain('usable');
-      const selected = records.find((record) => record.id === (20).toString(16).padStart(32, '0'))!;
+      const selected = records.find((record) => record.id === anchorKid)!;
       const captured = { ...selected, value: 'a'.repeat(32), mpd: 'https://cdn.example/live.mpd' };
       records = records.map((record) => (record === selected ? captured : record));
       await save();
@@ -91,7 +92,7 @@ test('history updates preserve search, visible rows, and live details', async ()
       expect(await command.inputValue()).toBe('my custom command');
       expect(await details.evaluate((element) => element.scrollTop)).toBe(detailsScroll);
       await details.locator('svg').first().click();
-      await expect.poll(() => popup.getByText('Key Settings', { exact: true }).count()).toBe(0);
+      await expect.poll(() => popup.getByText('Key Details', { exact: true }).count()).toBe(0);
       expect(await search.isVisible()).toBe(true);
       expect(
         Math.abs(
@@ -106,19 +107,19 @@ test('history updates preserve search, visible rows, and live details', async ()
       await expect
         .poll(() => details.getByText('https://outside.example', { exact: true }).count())
         .toBe(1);
-      expect(await popup.getByText('Key Settings', { exact: true }).isVisible()).toBe(true);
+      expect(await popup.getByText('Key Details', { exact: true }).isVisible()).toBe(true);
       records = records.filter((record) => record.id !== selected.id);
       await save();
-      await expect.poll(() => popup.getByText('Key Settings', { exact: true }).count()).toBe(0);
+      await expect.poll(() => popup.getByText('Key Details', { exact: true }).count()).toBe(0);
       expect(await search.isVisible()).toBe(true);
       expect(await search.inputValue()).toBe('history.example');
       await worker.evaluate(async () => {
         await browser.storage.local.remove('all-keys');
       });
-      await expect.poll(() => count.textContent()).toBe('0 / 0 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 0 filtered / 0 total');
       records = [captured];
       await save();
-      await expect.poll(() => count.textContent()).toBe('1 / 1 keys');
+      await expect.poll(() => count.textContent()).toBe('0 selected / 1 filtered / 1 total');
     } finally {
       await context.close();
     }

--- a/test/e2e/popup-record-deletion.test.ts
+++ b/test/e2e/popup-record-deletion.test.ts
@@ -54,9 +54,9 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await popup.getByRole('link', { name: 'Keys', exact: true }).click();
       await expect.poll(() => popup.locator('code').count()).toBe(2);
       await popup.locator('code').first().click();
-      await popup.getByRole('button', { name: 'Delete', exact: true }).click();
+      await popup.getByRole('button', { name: 'Delete Key', exact: true }).click();
       await expect.poll(() => popup.locator('code').count()).toBe(1);
-      expect(await popup.getByRole('status').innerText()).toBe('1 / 1 keys');
+      expect(await popup.getByRole('status').innerText()).toBe('0 selected / 1 filtered / 1 total');
       await expect.poll(() => dashboard.locator('code').count()).toBe(1);
       expect(await popup.locator('#root > main').isVisible()).toBe(true);
       const readRecords = () =>
@@ -69,8 +69,10 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
         'recent-keys-by-domain': JSON.stringify({ 'example.com': [otherPage] }),
       });
       await dashboard.locator('code').click();
-      await dashboard.getByRole('button', { name: 'Delete', exact: true }).click();
-      await expect.poll(() => popup.getByRole('status').innerText()).toBe('0 / 0 keys');
+      await dashboard.getByRole('button', { name: 'Delete Key', exact: true }).click();
+      await expect
+        .poll(() => popup.getByRole('status').innerText())
+        .toBe('0 selected / 0 filtered / 0 total');
       expect(await popup.locator('#root > main').isVisible()).toBe(true);
       expect(await readRecords()).toEqual({
         'all-keys': '[]',
@@ -103,11 +105,15 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
           .getByRole('checkbox', { name: 'Select All Results' })
           .evaluate((element: HTMLInputElement) => element.indeterminate),
       ).toBe(true);
-      expect(await popup.getByText('1 selected', { exact: true }).isVisible()).toBe(true);
-      expect(await popup.getByRole('heading', { name: 'Key Settings' }).count()).toBe(0);
-      await popup.getByLabel('Search by KID or site').fill('other.example');
-      await expect.poll(() => popup.getByText('0 selected', { exact: true }).count()).toBe(1);
-      await popup.getByLabel('Search by KID or site').fill('example.com');
+      await expect
+        .poll(() => popup.getByRole('status').innerText())
+        .toBe('1 selected / 3 filtered / 3 total');
+      expect(await popup.getByRole('heading', { name: 'Key Details' }).count()).toBe(0);
+      await popup.getByLabel('Search').fill('other.example');
+      await expect
+        .poll(() => popup.getByRole('status').innerText())
+        .toBe('0 selected / 1 filtered / 3 total');
+      await popup.getByLabel('Search').fill('example.com');
       await popup.getByRole('checkbox', { name: 'Select All Results' }).check();
       await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
       const dialog = popup.getByRole('dialog');
@@ -129,17 +135,16 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       // Let a mistakenly bubbled click finish preparing a second confirmation.
       await popup.waitForTimeout(150);
       expect(await dialog.count()).toBe(0);
-      expect(await popup.getByText('2 selected', { exact: true }).isVisible()).toBe(true);
-      expect(
-        await popup
-          .getByRole('button', { name: 'Clear', exact: true })
-          .evaluate((button) => getComputedStyle(button).cursor),
-      ).toBe('pointer');
+      await expect
+        .poll(() => popup.getByRole('status').innerText())
+        .toBe('2 selected / 2 filtered / 3 total');
       await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
       await dialog.waitFor({ state: 'visible' });
       await popup.keyboard.press('Escape');
       expect(await dialog.count()).toBe(0);
-      expect(await popup.getByText('2 selected', { exact: true }).isVisible()).toBe(true);
+      await expect
+        .poll(() => popup.getByRole('status').innerText())
+        .toBe('2 selected / 2 filtered / 3 total');
       await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
       const arriving = { ...key, url: 'https://example.com/new', createdAt: key.createdAt + 100 };
       await seed([...records, arriving]);
@@ -159,7 +164,7 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await popup.evaluate(() => document.documentElement.classList.remove('dark'));
       await expect.poll(() => popup.locator('code').count()).toBe(1);
       expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite, arriving]);
-      await popup.getByLabel('Search by KID or site').fill('');
+      await popup.getByLabel('Search').fill('');
       await popup.screenshot({ path: resolve('output/playwright/bulk-deletion/selection.png') });
       await dashboard.getByRole('button', { name: 'Delete Site Keys', exact: true }).click();
       const siteDialog = dashboard.getByRole('dialog');
@@ -168,7 +173,7 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await siteDialog.getByRole('button', { name: 'Delete 1 record', exact: true }).click();
       await expect.poll(() => popup.locator('code').count()).toBe(1);
       expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite]);
-      await popup.getByLabel('Search by KID or site').fill('no-match');
+      await popup.getByLabel('Search').fill('no-match');
       await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
       await expect.poll(() => dialog.isVisible()).toBe(true);
       expect(await dialog.innerText()).toContain(

--- a/test/extension-history-filters.test.ts
+++ b/test/extension-history-filters.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest';
+import {
+  filterHistory,
+  type HistoryFilters,
+} from '../src/extension/entrypoints/popup/utils/history-filters';
+import type { KeyInfo } from '../src/extension/utils/storage';
+
+const defaults: HistoryFilters = { search: '', drm: 'all', order: 'newest' };
+const record = (createdAt: string, drmSystem?: KeyInfo['drmSystem']): KeyInfo => ({
+  id: 'aabbccdd11223344556677889900aabb',
+  value: 'usable',
+  url: 'https://watch.example/show',
+  mpd: 'https://cdn.example/manifest.mpd',
+  pssh: '',
+  createdAt: new Date(createdAt).getTime(),
+  drmSystem,
+});
+const records = [
+  record('2026-03-08T00:00:00', 'W'),
+  record('2026-03-08T23:59:59.999', 'P'),
+  record('2026-03-09T00:00:00', 'C'),
+  record('2026-03-07T23:59:59.999'),
+];
+
+test('combines DRM and normalized search', () => {
+  for (const search of ['AABB-CCDD', ' WATCH.EXAMPLE ', 'MANIFEST.MPD']) {
+    expect(
+      filterHistory(records, {
+        ...defaults,
+        search,
+        drm: 'P',
+      }),
+    ).toEqual([records[1]]);
+  }
+  expect(filterHistory(records, { ...defaults, drm: 'unknown' })).toEqual([records[3]]);
+  expect(filterHistory(records, { ...defaults, drm: 'C' })).toEqual([records[2]]);
+  expect(filterHistory(records, { ...defaults, search: '---' })).toEqual([]);
+});
+
+test('sorts timestamps in both directions without changing storage order and keeps ties stable', () => {
+  const original = [...records];
+  expect(filterHistory(records, defaults)).toEqual([
+    records[2],
+    records[1],
+    records[0],
+    records[3],
+  ]);
+  expect(filterHistory(records, { ...defaults, order: 'oldest' })).toEqual([
+    records[3],
+    records[0],
+    records[1],
+    records[2],
+  ]);
+  expect(records).toEqual(original);
+  const ties = [record('2026-03-08T00:00:00', 'W'), record('2026-03-08T00:00:00', 'P')];
+  expect(filterHistory(ties, defaults)).toEqual(ties);
+});


### PR DESCRIPTION
## Summary

- Add DRM-system filters and newest/oldest sorting to key history.
- Apply active filters to search results, selection, deletion, and JSON/TXT exports.
- Add responsive popup controls and unit/e2e coverage.

## Testing

- Not run; added unit and end-to-end tests cover filtering, sorting, selection, exports, and layout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791391060&installation_model_id=424872&pr_number=82&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F82&signature=d78db0db8b26f735927716653552b4d0595d4590ce9531ca06181d729c564ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->