### PR TITLE
feat(cli): expose PSSH inspection and conversion commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,22 @@ HTTP 503. Idle sessions expire and must be recreated. Waiting for keys beyond
 
 ### Inspect, edit, and convert PSSH boxes
 
+```sh
+okova pssh inspect "$PSSH" --json
+okova pssh kids "$PSSH"
+okova pssh convert "$PSSH" --target playready --la-url https://example.com/license
+```
+
+Pass base64 directly or use `-` to read base64 text from stdin.
+Inspect and KID extraction process all boxes;
+use `--box <index>` to select one by zero-based index, required for conversion
+of multi-box input. Raw DRM headers and media files are not accepted.
+
+`inspect` prints box metadata and KIDs; `kids` prints one KID per line; `convert`
+writes base64. All support `--json`. Inspection JSON includes a KID status of
+`available`, `unsupported`, or `invalid`, distinguishing empty KIDs from errors.
+Conversion warnings go to stderr and also appear in conversion JSON.
+
 ```ts
 import {
   PSSH_SYSTEM_IDS,

--- a/src/cli/commands/pssh/index.ts
+++ b/src/cli/commands/pssh/index.ts
@@ -1,0 +1,161 @@
+import { text } from 'node:stream/consumers';
+import { parseArgs, type ParseArgsOptionsConfig } from 'node:util';
+import {
+  PSSH_SYSTEM_IDS,
+  convertPsshBox,
+  getPsshKeyIds,
+  parsePsshBoxes,
+  psshBoxToBase64,
+  type ParsedPsshBox,
+} from '../../../lib/pssh';
+
+const help = () => {
+  console.log(`Usage: okova pssh <inspect|kids|convert> [base64|-] [options]
+
+Commands:
+  inspect                 Print box metadata and KIDs
+  kids                    Print one KID per line, in box order
+  convert                 Convert one box between Widevine and PlayReady
+
+Options:
+  --box <index>           Select a box by zero-based index
+  --json                  Print structured JSON
+  --target <DRM>          Conversion target: widevine or playready
+  --la-url <url>          License URL for conversion to PlayReady
+  -h, --help              Show this help
+
+Pass base64 directly or use - to read base64 text from stdin.
+Inspect and kids process all boxes unless --box is supplied.
+Conversion requires --box for multiple boxes and writes base64 by default.
+Conversion discards other DRM metadata; warnings go to stderr.
+Only full PSSH boxes are accepted, not raw DRM headers or media files.`);
+};
+
+const inspectKeyIds = (box: ParsedPsshBox) => {
+  const isKnownSystem =
+    box.systemId === PSSH_SYSTEM_IDS.widevine || box.systemId === PSSH_SYSTEM_IDS.playready;
+  if (!isKnownSystem && !box.keyIds.length) {
+    return {
+      status: 'unsupported',
+      error: 'Cannot inspect payload KIDs for this PSSH system',
+    } as const;
+  }
+  try {
+    return { status: 'available', values: getPsshKeyIds(box) } as const;
+  } catch (error) {
+    return {
+      status: 'invalid',
+      error: error instanceof Error ? error.message : String(error),
+    } as const;
+  }
+};
+
+export const pssh = async (argv: string[]) => {
+  const [command, ...rest] = argv;
+  if (!command || command === '--help' || command === '-h') {
+    const args = parseArgs({ args: argv, options: { help: { type: 'boolean', short: 'h' } } });
+    if (args.values.help) return help();
+    throw new Error('PSSH subcommand required: inspect, kids, convert');
+  }
+  if (command !== 'inspect' && command !== 'kids' && command !== 'convert') {
+    throw new Error(`Unknown PSSH subcommand: ${command}`);
+  }
+  const { values, positionals } = parseArgs({
+    args: rest,
+    allowPositionals: true,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      box: { type: 'string' },
+      json: { type: 'boolean' },
+      target: { type: 'string' },
+      'la-url': { type: 'string' },
+    } satisfies ParseArgsOptionsConfig,
+  });
+  if (values.help) return help();
+  if (command !== 'convert' && (values.target !== undefined || values['la-url'] !== undefined)) {
+    throw new Error('--target and --la-url are only supported by pssh convert');
+  }
+  if (positionals.length > 1) {
+    throw new Error('Supply one base64 PSSH argument or - for stdin');
+  }
+  const input = positionals[0];
+  if (input === undefined) {
+    throw new Error('PSSH input required: base64 or - for stdin');
+  }
+  const target = values.target;
+  if (target !== undefined && target !== 'widevine' && target !== 'playready') {
+    throw new Error('Conversion --target must be widevine or playready');
+  }
+  if (command === 'convert' && target === undefined) {
+    throw new Error('Conversion --target required: widevine or playready');
+  }
+  if (values['la-url'] !== undefined && target !== 'playready') {
+    throw new Error('--la-url requires --target playready');
+  }
+  if (values.box !== undefined && !/^(0|[1-9]\d*)$/.test(values.box)) {
+    throw new Error('--box must be a zero-based integer');
+  }
+  const boxes = parsePsshBoxes(input === '-' ? await text(process.stdin) : input);
+  const index = values.box === undefined ? undefined : Number(values.box);
+  if (index !== undefined && (!Number.isSafeInteger(index) || index >= boxes.length)) {
+    throw new Error(`--box is out of range; input contains ${boxes.length} box(es)`);
+  }
+  const selected = boxes
+    .map((box, index) => ({ box, index }))
+    .filter((entry) => index === undefined || entry.index === index);
+  if (target !== undefined) {
+    if (selected.length !== 1) throw new Error('Multiple PSSH boxes found; select one with --box');
+    const converted = convertPsshBox(selected[0].box, target, { laUrl: values['la-url'] });
+    const warnings = [
+      'Conversion preserves KIDs and encryption signaling but discards other DRM metadata, including original license URLs and checksums. No checksums are generated; license servers may reject the result.',
+    ];
+    for (const warning of warnings) console.error(`Warning: ${warning}`);
+    const encoded = psshBoxToBase64(converted);
+    console.log(values.json ? JSON.stringify({ pssh: encoded, warnings }, null, 2) : encoded);
+    return;
+  }
+  const records = selected.map(({ box, index }) => ({
+    index,
+    systemId: box.systemId,
+    system: Object.entries(PSSH_SYSTEM_IDS).find(([, id]) => id === box.systemId)?.[0] ?? 'unknown',
+    version: box.version,
+    flags: box.flags,
+    dataSize: box.data.length,
+    boxKeyIds: box.keyIds,
+    keyIds: inspectKeyIds(box),
+  }));
+  if (command === 'kids') {
+    const ids = records.flatMap((record) => {
+      if (record.keyIds.status !== 'available') {
+        throw new Error(`Box ${record.index}: ${record.keyIds.error}`);
+      }
+      return record.keyIds.values;
+    });
+    if (values.json) console.log(JSON.stringify(ids, null, 2));
+    else if (ids.length) console.log(ids.join('\n'));
+    return;
+  }
+  if (values.json) console.log(JSON.stringify(records, null, 2));
+  else {
+    console.log(
+      records
+        .map((record) =>
+          [
+            `Box ${record.index}: ${record.system}`,
+            `System ID: ${record.systemId}`,
+            `Version: ${record.version}`,
+            `Flags: ${record.flags}`,
+            `Data size: ${record.dataSize} bytes`,
+            `Box KIDs: ${record.boxKeyIds.join(', ') || '(none)'}`,
+            record.keyIds.status === 'available'
+              ? `KIDs: ${record.keyIds.values.join(', ') || '(none)'}`
+              : `KIDs: ${record.keyIds.status}: ${record.keyIds.error}`,
+          ].join('\n'),
+        )
+        .join('\n\n'),
+    );
+  }
+  if (records.some((record) => record.keyIds.status === 'invalid')) {
+    throw new Error('One or more PSSH payloads could not be inspected');
+  }
+};

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { license } from './commands/license';
 import pkg from '../../package.json' with { type: 'json' };
 import { col } from './utils';
 import { serve } from './commands/serve/serve';
+import { pssh } from './commands/pssh';
 
 const helpOption = { help: { type: 'boolean', short: 'h' } } satisfies ParseArgsOptionsConfig;
 const parse = <T extends ParseArgsOptionsConfig>(args: string[], options: T) =>
@@ -22,6 +23,7 @@ const help = () => {
   console.log(col('serve') + 'Run your API instance');
   console.log(col('license <url>') + 'Make a license request');
   console.log(col('client <subcommand>') + 'Widevine and PlayReady client utilities');
+  console.log(col('pssh <subcommand>') + 'Inspect PSSH boxes, extract KIDs, or convert DRM');
   console.log('\nFlags:');
   console.log(col('-v, --version') + 'Print version and exit');
   console.log(col('-h, --help') + 'Display this menu and exit');
@@ -119,6 +121,8 @@ const main = async () => {
       return;
     }
     case 'pssh':
+      await pssh(argv);
+      return;
     case 'test':
       throw new Error(`Command not implemented: ${command}`);
     default:

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,6 +3,18 @@ import { join } from 'node:path';
 import { expect, test } from 'vitest';
 import { parseWvd } from '../src/lib/widevine/wvd';
 import { setupCliTests, directory, input, run, wvd } from './helpers/cli';
+import {
+  PSSH_SYSTEM_IDS,
+  createPsshBox,
+  setPsshKeyIds,
+  serializePsshBox,
+  psshBoxToBase64,
+  parsePsshBoxes,
+  getPsshKeyIds,
+} from '../src/lib/pssh';
+import { WidevinePsshData } from '../src/lib/widevine/proto';
+import { Pssh } from '../src/lib/playready/pssh';
+import { WrmHeader } from '../src/lib/playready/wrmheader';
 
 setupCliTests();
 
@@ -15,11 +27,181 @@ test.each([
   ['client', 'pack', '--help'],
   ['client', 'unpack', '--help'],
   ['client', 'info', '--help'],
+  ['pssh', '--help'],
+  ['pssh', 'inspect', '--help'],
+  ['pssh', 'kids', '--help'],
+  ['pssh', 'convert', '--help'],
 ])('prints help/version without executing %j', (...args) => {
   const result = run(args);
   expect(result.status, result.stderr).toBe(0);
   expect(result.stdout.trim()).not.toBe('');
   expect(result.stderr).toBe('');
+});
+
+const KID = '00112233445566778899aabbccddeeff';
+const widevinePssh = setPsshKeyIds(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine }), [KID]);
+const encodedPssh = psshBoxToBase64(widevinePssh);
+
+test('PSSH inspection preserves box order and distinguishes empty, unsupported, and invalid KIDs', () => {
+  const empty = createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine });
+  const unknown = createPsshBox({ systemId: '00000000000000000000000000000000' });
+  const boxKids = createPsshBox({ ...unknown, version: 1, keyIds: [KID] });
+  const bytes = Buffer.concat([widevinePssh, empty, unknown, boxKids].map(serializePsshBox));
+  const result = run(['pssh', 'inspect', '-', '--json'], directory, bytes.toString('base64'));
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual([
+    expect.objectContaining({
+      index: 0,
+      system: 'widevine',
+      version: 0,
+      flags: 0,
+      dataSize: 18,
+      boxKeyIds: [],
+      keyIds: { status: 'available', values: [KID] },
+    }),
+    expect.objectContaining({ index: 1, keyIds: { status: 'available', values: [] } }),
+    expect.objectContaining({
+      index: 2,
+      system: 'unknown',
+      keyIds: { status: 'unsupported', error: expect.any(String) },
+    }),
+    expect.objectContaining({
+      index: 3,
+      boxKeyIds: [KID],
+      keyIds: { status: 'available', values: [KID] },
+    }),
+  ]);
+  const readable = run(['pssh', 'inspect', encodedPssh]);
+  expect(readable.status, readable.stderr).toBe(0);
+  expect(readable.stdout).toContain('Box 0: widevine');
+  expect(readable.stdout).toContain(`KIDs: ${KID}`);
+  const failedKids = run(['pssh', 'kids', '-'], directory, bytes.toString('base64'));
+  expect(failedKids.status).toBe(1);
+  expect(failedKids.stdout).toBe('');
+  expect(failedKids.stderr).toContain('Box 2');
+  const selected = run(
+    ['pssh', 'kids', '-', '--box', '3', '--json'],
+    directory,
+    bytes.toString('base64'),
+  );
+  expect(selected.status, selected.stderr).toBe(0);
+  expect(JSON.parse(selected.stdout)).toEqual([KID]);
+  expect(run(['pssh', 'kids', psshBoxToBase64(empty)]).stdout).toBe('');
+
+  const invalid = psshBoxToBase64(
+    createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine, data: new Uint8Array([0x12, 0x10, 1]) }),
+  );
+  const failedInspect = run(['pssh', 'inspect', invalid, '--json']);
+  expect(failedInspect.status).toBe(1);
+  expect(JSON.parse(failedInspect.stdout)).toEqual([
+    expect.objectContaining({ keyIds: { status: 'invalid', error: expect.any(String) } }),
+  ]);
+});
+
+test('PSSH commands accept pasted base64 and base64 stdin with whitespace', () => {
+  const pasted = run(['pssh', 'kids', encodedPssh]);
+  const piped = run(['pssh', 'kids', '-'], directory, `\n${encodedPssh}\n`);
+  for (const result of [pasted, piped]) {
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`${KID}\n`);
+    expect(result.stderr).toBe('');
+  }
+});
+
+test.each([0x63656e63, 0x63626373])(
+  'PSSH CLI converts scheme %i both ways with warnings separate from base64',
+  (protectionScheme) => {
+    const source = setPsshKeyIds(
+      createPsshBox({
+        systemId: PSSH_SYSTEM_IDS.widevine,
+        version: 1,
+        flags: 7,
+        data: WidevinePsshData.encode(
+          WidevinePsshData.create({ protectionScheme, provider: 'discard-me' }),
+        ).finish(),
+      }),
+      [KID],
+    );
+    const bytes = Buffer.concat([serializePsshBox(widevinePssh), serializePsshBox(source)]);
+    const result = run(
+      [
+        'pssh',
+        'convert',
+        '-',
+        '--box',
+        '1',
+        '--target',
+        'playready',
+        '--la-url',
+        'https://example.com/license?a=1&b=2',
+      ],
+      directory,
+      bytes.toString('base64'),
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain('discards other DRM metadata');
+    const [converted] = parsePsshBoxes(result.stdout.trim());
+    expect(converted.systemId).toBe(PSSH_SYSTEM_IDS.playready);
+    expect(converted.version).toBe(1);
+    expect(converted.flags).toBe(7);
+    expect(getPsshKeyIds(converted)).toEqual([KID]);
+    const header = new WrmHeader(new Pssh(serializePsshBox(converted)).wrmHeaders[0]);
+    expect(header.laUrl).toBe('https://example.com/license?a=1&b=2');
+    const restored = run([
+      'pssh',
+      'convert',
+      result.stdout.trim(),
+      '--target',
+      'widevine',
+      '--json',
+    ]);
+    expect(restored.status, restored.stderr).toBe(0);
+    const output = JSON.parse(restored.stdout);
+    expect(output.warnings).toEqual([expect.stringContaining('discards other DRM metadata')]);
+    const [box] = parsePsshBoxes(output.pssh);
+    expect(box.systemId).toBe(PSSH_SYSTEM_IDS.widevine);
+    expect(getPsshKeyIds(box)).toEqual([KID]);
+    expect(WidevinePsshData.decode(box.data).protectionScheme).toBe(protectionScheme);
+    expect(WidevinePsshData.decode(box.data).provider).toBe('');
+  },
+);
+
+test.each([
+  ['inspect'],
+  ['unknown'],
+  ['inspect', '%%%'],
+  ['inspect', ''],
+  ['inspect', encodedPssh.slice(0, -8)],
+  ['inspect', encodedPssh, 'extra'],
+  ['inspect', encodedPssh, '--target', 'widevine'],
+  ['inspect', encodedPssh, '--box', '-1'],
+  ['inspect', encodedPssh, '--box', '1.5'],
+  ['inspect', encodedPssh, '--box', '1'],
+  ['convert', encodedPssh],
+  ['convert', encodedPssh, '--target', 'other'],
+  ['convert', encodedPssh, '--to', 'playready'],
+  ['convert', encodedPssh, '--target', 'widevine'],
+  ['convert', encodedPssh, '--target', 'widevine', '--la-url', 'https://example.com'],
+  ['convert', encodedPssh, '--target', 'playready', '--la-url', 'invalid'],
+  [
+    'convert',
+    psshBoxToBase64(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine })),
+    '--target',
+    'playready',
+  ],
+  [
+    'convert',
+    Buffer.concat([serializePsshBox(widevinePssh), serializePsshBox(widevinePssh)]).toString(
+      'base64',
+    ),
+    '--target',
+    'playready',
+  ],
+])('PSSH rejects invalid invocation %j', (...args) => {
+  const result = run(['pssh', ...args]);
+  expect(result.status, result.stdout).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(result.stderr.trim()).not.toBe('');
 });
 
 test.each([

--- a/test/helpers/cli.ts
+++ b/test/helpers/cli.ts
@@ -67,9 +67,10 @@ export const setupCliTests = () => {
   });
 };
 
-export const run = (args: string[], cwd = directory) =>
+export const run = (args: string[], cwd = directory, stdin?: string) =>
   spawnSync(process.execPath, [executable, ...args], {
     cwd,
     encoding: 'utf8',
+    input: stdin,
     timeout: 10_000,
   });


### PR DESCRIPTION
## Summary

- Add `okova pssh inspect`, `kids`, and `convert` commands.
- Support base64 arguments, stdin input, JSON output, box selection, and KID inspection.
- Document PSSH CLI usage and add comprehensive command tests.

## Testing

- Added CLI coverage for inspection, KID extraction, conversion, stdin input, JSON output, validation, and warnings.
- Not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791391857&installation_model_id=424872&pr_number=83&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F83&signature=568b51e4f0994aeaddfb5d3a5689dc64a633285ec4166ea4d3a08c5fcc3fc3bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->