### PR TITLE
fix: support subsamples and pattern encryption in packet decryption

### DIFF
--- a/src/lib/decrypt.ts
+++ b/src/lib/decrypt.ts
@@ -43,20 +43,6 @@ const normalizeCounterBlock = (iv: Uint8Array) => {
   throw new Error(`Unsupported IV length ${iv.byteLength}. Expected 8 or 16 bytes.`);
 };
 
-const normalizeCbcIv = (iv: Uint8Array) => {
-  if (iv.byteLength === AES_BLOCK_SIZE) {
-    return iv.slice();
-  }
-
-  if (iv.byteLength === 8) {
-    const cbcIv = new Uint8Array(AES_BLOCK_SIZE);
-    cbcIv.set(iv, 0);
-    return cbcIv;
-  }
-
-  throw new Error(`Unsupported IV length ${iv.byteLength}. Expected 8 or 16 bytes.`);
-};
-
 const normalizeKeyId = (keyId: string) => keyId.toLowerCase();
 
 const getKeyCandidates = (keyId: string) => {
@@ -98,17 +84,95 @@ export const decryptPacketWithKeyBytes = async (packet: EncryptedPacket, keyByte
     );
   }
 
-  if (packet.scheme === 'cbcs') {
-    if (packet.data.byteLength % AES_BLOCK_SIZE !== 0) {
-      throw new Error('CBCS encrypted packet length must be a multiple of 16 bytes.');
-    }
-
-    const cipher = cbc(keyBytes, normalizeCbcIv(packet.iv), { disablePadding: true });
-    return cipher.decrypt(packet.data);
+  if (!['cenc', 'cens', 'cbcs'].includes(packet.scheme)) {
+    throw new Error(`Unsupported encryption scheme ${packet.scheme}.`);
   }
 
-  const cipher = ctr(keyBytes, normalizeCounterBlock(packet.iv));
-  return cipher.decrypt(packet.data);
+  const iv = normalizeCounterBlock(packet.iv);
+  const subsamples = packet.subsamples?.length
+    ? packet.subsamples
+    : [{ clearLen: 0, protectedLen: packet.data.byteLength }];
+  let packetOffset = 0;
+  for (const { clearLen, protectedLen } of subsamples) {
+    if (
+      !Number.isSafeInteger(clearLen) ||
+      clearLen < 0 ||
+      !Number.isSafeInteger(protectedLen) ||
+      protectedLen < 0
+    ) {
+      throw new Error('Subsample lengths must be non-negative safe integers.');
+    }
+    packetOffset += clearLen + protectedLen;
+    if (packetOffset > packet.data.byteLength) {
+      throw new Error('Subsamples exceed packet length.');
+    }
+  }
+  if (packetOffset !== packet.data.byteLength) {
+    throw new Error('Subsamples must cover the entire packet.');
+  }
+
+  const pattern = packet.scheme === 'cenc' ? null : packet.pattern;
+  if (pattern) {
+    for (const blocks of [pattern.cryptByteBlock, pattern.skipByteBlock]) {
+      if (!Number.isInteger(blocks) || blocks < 0 || blocks > 15) {
+        throw new Error('Pattern block counts must be integers between 0 and 15.');
+      }
+    }
+  }
+  const hasPattern =
+    pattern !== null && (pattern.cryptByteBlock !== 0 || pattern.skipByteBlock !== 0);
+  const cryptBytes = hasPattern ? pattern.cryptByteBlock * AES_BLOCK_SIZE : 0;
+  const skipBytes = hasPattern ? pattern.skipByteBlock * AES_BLOCK_SIZE : 0;
+  const output = new Uint8Array(packet.data);
+  let ranges: { offset: number; length: number }[] = [];
+
+  // Gather only encrypted bytes so skipped bytes never consume cipher state.
+  const decryptRanges = () => {
+    const length = ranges.reduce((total, range) => total + range.length, 0);
+    if (length === 0) return;
+    const encrypted = new Uint8Array(length);
+    let offset = 0;
+    for (const range of ranges) {
+      encrypted.set(packet.data.subarray(range.offset, range.offset + range.length), offset);
+      offset += range.length;
+    }
+    const cipher =
+      packet.scheme === 'cbcs' ? cbc(keyBytes, iv, { disablePadding: true }) : ctr(keyBytes, iv);
+    const decrypted = cipher.decrypt(encrypted);
+    offset = 0;
+    for (const range of ranges) {
+      output.set(decrypted.subarray(offset, offset + range.length), range.offset);
+      offset += range.length;
+    }
+  };
+
+  packetOffset = 0;
+  for (const { clearLen, protectedLen } of subsamples) {
+    packetOffset += clearLen;
+    const encryptedLength =
+      packet.scheme === 'cenc'
+        ? protectedLen
+        : Math.floor(protectedLen / AES_BLOCK_SIZE) * AES_BLOCK_SIZE;
+    if (!hasPattern) {
+      ranges.push({ offset: packetOffset, length: encryptedLength });
+    } else if (cryptBytes > 0) {
+      // Each subsample starts a new pattern, including after a partial block.
+      for (let offset = 0; offset < encryptedLength; offset += cryptBytes + skipBytes) {
+        ranges.push({
+          offset: packetOffset + offset,
+          length: Math.min(cryptBytes, encryptedLength - offset),
+        });
+      }
+    }
+    packetOffset += protectedLen;
+    if (packet.scheme === 'cbcs') {
+      // CBCS restarts chaining with the packet IV for each subsample.
+      decryptRanges();
+      ranges = [];
+    }
+  }
+  if (packet.scheme !== 'cbcs') decryptRanges();
+  return output;
 };
 
 export const decryptPacketWithKeys = async (

--- a/test/decrypt.test.ts
+++ b/test/decrypt.test.ts
@@ -1,0 +1,236 @@
+import { createCipheriv } from 'node:crypto';
+import { describe, expect, test } from 'vitest';
+import { decryptPacketWithKeyBytes, type EncryptedPacket } from '../src/lib/decrypt';
+
+const key = Uint8Array.from({ length: 16 }, (_, index) => index);
+const iv = Uint8Array.from({ length: 16 }, (_, index) => 16 + index);
+
+const makePacket = (overrides: Partial<EncryptedPacket> = {}): EncryptedPacket => ({
+  data: new Uint8Array(0),
+  keyId: 'test-key',
+  psshBoxes: [],
+  scheme: 'cenc',
+  iv,
+  timestamp: 0,
+  subsamples: null,
+  pattern: null,
+  ...overrides,
+});
+
+// Explicit byte ranges form an independent oracle for subsample and pattern selection.
+const encryptRanges = (
+  plaintext: Uint8Array,
+  groups: [number, number][][],
+  scheme: EncryptedPacket['scheme'],
+  counter = iv,
+) => {
+  const encrypted = new Uint8Array(plaintext);
+  for (const ranges of groups) {
+    const cipher = createCipheriv(scheme === 'cbcs' ? 'aes-128-cbc' : 'aes-128-ctr', key, counter);
+    cipher.setAutoPadding(false);
+    const ciphertext = Buffer.concat([
+      cipher.update(Buffer.concat(ranges.map(([start, end]) => plaintext.subarray(start, end)))),
+      cipher.final(),
+    ]);
+    let offset = 0;
+    for (const [start, end] of ranges) {
+      encrypted.set(ciphertext.subarray(offset, offset + end - start), start);
+      offset += end - start;
+    }
+  }
+  return encrypted;
+};
+
+const plaintext = Uint8Array.from({ length: 157 }, (_, index) => (index * 7 + 3) % 256);
+
+describe('packet decryption', () => {
+  test.each([8, 16])(
+    'CENC preserves clear bytes and CTR state across partial subsamples, %i-byte IV',
+    async (ivLength) => {
+      const packetIv = iv.slice(0, ivLength);
+      const counter = new Uint8Array(16);
+      counter.set(packetIv);
+      const data = encryptRanges(
+        plaintext,
+        [
+          [
+            [5, 12],
+            [15, 34],
+            [43, 157],
+          ],
+        ],
+        'cenc',
+        counter,
+      );
+      const packet = makePacket({
+        data,
+        iv: packetIv,
+        subsamples: [
+          { clearLen: 5, protectedLen: 7 },
+          { clearLen: 3, protectedLen: 19 },
+          { clearLen: 9, protectedLen: 114 },
+        ],
+        // CENC does not use pattern encryption.
+        pattern: { cryptByteBlock: 1, skipByteBlock: 1 },
+      });
+      const original = data.slice();
+      await expect(decryptPacketWithKeyBytes(packet, key)).resolves.toEqual(plaintext);
+      expect(data).toEqual(original);
+      expect(packet.iv).toEqual(packetIv);
+    },
+  );
+
+  test.each(['cens', 'cbcs'] as const)(
+    '%s restarts patterns, preserves skipped blocks and tails, and uses the correct cipher state',
+    async (scheme) => {
+      const first: [number, number][] = [
+        [5, 21],
+        [37, 53],
+        [69, 85],
+      ];
+      const second: [number, number][] = [
+        [92, 108],
+        [124, 140],
+      ];
+      const data = encryptRanges(
+        plaintext,
+        scheme === 'cbcs' ? [first, second] : [[...first, ...second]],
+        scheme,
+      );
+      const packet = makePacket({
+        scheme,
+        data,
+        pattern: { cryptByteBlock: 1, skipByteBlock: 1 },
+        subsamples: [
+          { clearLen: 5, protectedLen: 83 },
+          { clearLen: 4, protectedLen: 65 },
+        ],
+      });
+      const original = data.slice();
+      await expect(decryptPacketWithKeyBytes(packet, key)).resolves.toEqual(plaintext);
+      expect(data).toEqual(original);
+    },
+  );
+
+  test.each(['cens', 'cbcs'] as const)(
+    '%s handles multi-block crypt/skip patterns and a partial crypt run',
+    async (scheme) => {
+      const data = encryptRanges(
+        plaintext,
+        [
+          [
+            [0, 32],
+            [80, 112],
+          ],
+        ],
+        scheme,
+      );
+      await expect(
+        decryptPacketWithKeyBytes(
+          makePacket({
+            data,
+            scheme,
+            pattern: { cryptByteBlock: 2, skipByteBlock: 3 },
+          }),
+          key,
+        ),
+      ).resolves.toEqual(plaintext);
+      const shortPlaintext = plaintext.subarray(0, 105);
+      const shortData = encryptRanges(
+        shortPlaintext,
+        [
+          [
+            [0, 32],
+            [80, 96],
+          ],
+        ],
+        scheme,
+      );
+      await expect(
+        decryptPacketWithKeyBytes(
+          makePacket({
+            data: shortData,
+            scheme,
+            pattern: { cryptByteBlock: 2, skipByteBlock: 3 },
+          }),
+          key,
+        ),
+      ).resolves.toEqual(shortPlaintext);
+    },
+  );
+
+  test.each(['cenc', 'cens', 'cbcs'] as const)(
+    '%s supports absent subsamples and disabled patterns',
+    async (scheme) => {
+      const end = scheme === 'cenc' ? plaintext.length : 144;
+      const data = encryptRanges(plaintext, [[[0, end]]], scheme);
+      for (const subsamples of [null, []]) {
+        for (const pattern of [
+          null,
+          { cryptByteBlock: 0, skipByteBlock: 0 },
+          { cryptByteBlock: 1, skipByteBlock: 0 },
+        ]) {
+          await expect(
+            decryptPacketWithKeyBytes(makePacket({ data, scheme, subsamples, pattern }), key),
+          ).resolves.toEqual(plaintext);
+        }
+      }
+    },
+  );
+
+  test.each(['cenc', 'cens', 'cbcs'] as const)(
+    '%s supports clear-only and empty packets',
+    async (scheme) => {
+      await expect(decryptPacketWithKeyBytes(makePacket({ scheme }), key)).resolves.toEqual(
+        new Uint8Array(0),
+      );
+      const result = await decryptPacketWithKeyBytes(
+        makePacket({
+          scheme,
+          data: plaintext,
+          subsamples: [{ clearLen: plaintext.length, protectedLen: 0 }],
+        }),
+        key,
+      );
+      expect(result).toEqual(plaintext);
+      expect(result).not.toBe(plaintext);
+    },
+  );
+
+  test.each(['cens', 'cbcs'] as const)('%s supports a skip-only pattern', async (scheme) => {
+    await expect(
+      decryptPacketWithKeyBytes(
+        makePacket({
+          scheme,
+          data: plaintext,
+          pattern: { cryptByteBlock: 0, skipByteBlock: 2 },
+        }),
+        key,
+      ),
+    ).resolves.toEqual(plaintext);
+  });
+
+  test.each([
+    { clearLen: -1, protectedLen: 158 },
+    { clearLen: 0.5, protectedLen: 156.5 },
+    { clearLen: 0, protectedLen: NaN },
+    { clearLen: Infinity, protectedLen: 0 },
+    { clearLen: 0, protectedLen: 158 },
+    { clearLen: 0, protectedLen: 156 },
+  ])('rejects malformed subsample lengths: %j', async (subsample) => {
+    await expect(
+      decryptPacketWithKeyBytes(makePacket({ data: plaintext, subsamples: [subsample] }), key),
+    ).rejects.toThrow(/Subsample/);
+  });
+
+  test.each([-1, 0.5, NaN, Infinity, 16])('rejects invalid pattern count %s', async (blocks) => {
+    for (const pattern of [
+      { cryptByteBlock: blocks, skipByteBlock: 1 },
+      { cryptByteBlock: 1, skipByteBlock: blocks },
+    ]) {
+      await expect(
+        decryptPacketWithKeyBytes(makePacket({ scheme: 'cbcs', data: plaintext, pattern }), key),
+      ).rejects.toThrow(/Pattern/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Support CENC, CENS, and CBCS packet decryption with subsamples.
- Implement pattern encryption, skipped bytes, partial blocks, and per-subsample cipher state.
- Validate subsample lengths, coverage, pattern counts, and encryption schemes.
- Add comprehensive packet decryption tests.

## Testing

- Added Vitest coverage for CENC, CENS, and CBCS decryption.
- Tested 8-byte and 16-byte IVs, clear-only packets, empty packets, disabled patterns, and skip-only patterns.
- Tested malformed subsample lengths and invalid pattern counts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791395950&installation_model_id=424872&pr_number=84&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F84&signature=7ca7817d409534ce49a49e99e99c51300bdcad396c127cfda99ca255278f5112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->