### PR TITLE
fix(widevine): validate license response types and IDs

### DIFF
--- a/src/lib/widevine/session.ts
+++ b/src/lib/widevine/session.ts
@@ -258,6 +258,12 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
       await this.generateRequest(this.initData, this.initDataType);
       return;
     }
+    if (type !== SignedMessage.MessageType.LICENSE) {
+      const name = SignedMessage.MessageType[type] ?? type;
+      throw new Error(
+        `Unexpected Widevine response message type: ${name}; expected LICENSE or SERVICE_CERTIFICATE`,
+      );
+    }
 
     let signedLicense = null;
     try {
@@ -268,8 +274,19 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
       throw new Error('Unable to parse license - check protobufs', { cause: error });
     }
 
-    const license = License.decode(signedLicense.msg);
-    const requestId = fromBuffer(license.id!.requestId!).toText();
+    let license: License;
+    try {
+      license = License.decode(signedLicense.msg);
+    } catch (error) {
+      throw new Error('Failed to parse Widevine license payload', { cause: error });
+    }
+    if (!license.id) {
+      throw new Error('Invalid Widevine license ID: missing id');
+    }
+    if (!license.id.requestId?.length) {
+      throw new Error('Invalid Widevine license ID: missing or empty requestId');
+    }
+    const requestId = fromBuffer(license.id.requestId).toText();
     const context = this.contexts.get(requestId);
     if (!context) {
       throw new Error(`Failed to find context to decrypt keys, requestId: ${requestId}`);

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -13,6 +13,8 @@ import {
   LicenseRequest,
   SignedMessage,
   ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
 } from '../src/lib/widevine/proto';
 import { WidevineSession } from '../src/lib/widevine/session';
 
@@ -94,6 +96,81 @@ test('session update rejects immediately when the license is not a SignedMessage
     'Failed to parse message as SignedMessage',
   );
 });
+
+test.each([
+  ...Object.values(SignedMessage.MessageType)
+    .filter((type) => typeof type === 'number')
+    .filter(
+      (type) =>
+        type !== SignedMessage.MessageType.LICENSE &&
+        type !== SignedMessage.MessageType.SERVICE_CERTIFICATE,
+    )
+    .map((type) => ({
+      name: `message type ${SignedMessage.MessageType[type]}`,
+      response: SignedMessage.encode({ type }).finish(),
+      error: 'Unexpected Widevine response message type',
+    })),
+  {
+    name: 'unknown message type',
+    response: new Uint8Array([0x08, 0x7f]),
+    error: 'Unexpected Widevine response message type: 127',
+  },
+  {
+    name: 'missing message type',
+    response: SignedMessage.encode({}).finish(),
+    error: 'Unexpected Widevine response message type',
+  },
+  ...[
+    { name: 'missing license ID', license: {}, error: 'missing id' },
+    { name: 'missing request ID', license: { id: {} }, error: 'missing or empty requestId' },
+    {
+      name: 'empty request ID',
+      license: { id: { requestId: new Uint8Array() } },
+      error: 'missing or empty requestId',
+    },
+  ].map(({ name, license, error }) => ({
+    name,
+    response: SignedMessage.encode({
+      type: SignedMessage.MessageType.LICENSE,
+      msg: License.encode(license).finish(),
+    }).finish(),
+    error: `Invalid Widevine license ID: ${error}`,
+  })),
+  {
+    name: 'malformed license payload',
+    response: SignedMessage.encode({
+      type: SignedMessage.MessageType.LICENSE,
+      msg: new Uint8Array([0x0a, 0x02, 0xff]),
+    }).finish(),
+    error: 'Failed to parse Widevine license payload',
+  },
+  {
+    name: 'unknown request ID',
+    response: SignedMessage.encode({
+      type: SignedMessage.MessageType.LICENSE,
+      msg: License.encode({ id: { requestId: new Uint8Array([1]) } }).finish(),
+    }).finish(),
+    error: 'Failed to find context to decrypt keys',
+  },
+])(
+  'session update rejects $name before decryption and preserves state',
+  async ({ response, error }) => {
+    const credentials = new WidevineDeviceCredentials(
+      ClientIdentification.create({
+        token: SignedDrmCertificate.encode({
+          drmCertificate: DrmCertificate.encode({ systemId: 1 }).finish(),
+        }).finish(),
+      }),
+    );
+    const session = new WidevineSession('temporary', credentials);
+    session.contexts.set('pending', { enc: new Uint8Array(16), auth: new Uint8Array(16) });
+    const state = session.pause();
+
+    await expect(session.update(response)).rejects.toThrow(error);
+
+    expect(session.pause()).toBe(state);
+  },
+);
 
 test('android license requests use an OEMCrypto-like request id and set keyControlNonce', async () => {
   const challenge = await new WidevineSession(


### PR DESCRIPTION
## Summary

- Reject unexpected Widevine response message types before decryption.
- Validate license payload decoding and required license/request IDs.
- Add regression coverage for malformed, unsupported, and unknown responses.

## Testing

- Not run; tests were added but not executed in this change request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/azot-labs/codesmith/okova/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791396058&installation_model_id=424872&pr_number=85&repository=azot-labs%2Fokova&return_to=https%3A%2F%2Fgithub.com%2Fazot-labs%2Fokova%2Fpull%2F85&signature=24db3f005c09f392f8cdd6ae96acf668524b89625a426220510770c819248b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->