### PR TITLE
fix(extension): harden manifest URLs and key history writes

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -508,8 +508,7 @@ export default defineBackground({
         stage = 'setup';
         const settings = await run(appStorage.settings.getValue());
         const setRecentKeys = async (keys: KeyInfo[]) => {
-          await run(appStorage.recentKeys.setValue(keys));
-          await run(appStorage.recentKeysByDomain.setForUrl(message.url, keys));
+          await run(appStorage.recentKeys.setForUrl(message.url, keys));
           updateBadgeForTabInBackground(sender.tab);
         };
 

--- a/src/extension/utils/manifest-inspection.ts
+++ b/src/extension/utils/manifest-inspection.ts
@@ -1,12 +1,15 @@
 import { z } from 'zod/mini';
-import { splitPssh } from '@/utils/manifest';
+import { isManifestUrl, splitPssh } from '@/utils/manifest';
 
 const DASH_NAMESPACE = 'urn:mpeg:dash:schema:mpd:2011';
 const CENC_NAMESPACE = 'urn:mpeg:cenc:2013';
 const responseSchema = z.object({
   namespace: z.literal('okova:network'),
   method: z.literal('response'),
-  params: z.object({ url: z.string(), text: z.string().check(z.maxLength(1024 * 1024)) }),
+  params: z.object({
+    url: z.string().check(z.refine(isManifestUrl)),
+    text: z.string().check(z.maxLength(1024 * 1024)),
+  }),
 });
 
 declare global {

--- a/src/extension/utils/manifest.ts
+++ b/src/extension/utils/manifest.ts
@@ -28,13 +28,23 @@ export const splitPssh = (initData: string): string[] => {
   }
 };
 
+export const isManifestUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 export const findManifest = (initData: string | undefined) => {
   if (!initData || !(window.MPD_LIST instanceof Map)) return undefined;
   const exact = window.MPD_LIST.get(initData);
-  if (exact) return exact;
+  if (isManifestUrl(exact)) return exact;
   for (const pssh of splitPssh(initData)) {
     const url = window.MPD_LIST.get(pssh);
-    if (url) return url;
+    if (isManifestUrl(url)) return url;
   }
   return undefined;
 };

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -362,6 +362,19 @@ export const appStorage = {
   recentKeys: {
     ...recentKeys,
     setValue: (keys: KeyInfo[]) => mutateKeyHistory(() => recentKeys.setValue(retainKeys(keys))),
+    setForUrl: (url: string | undefined, keys: KeyInfo[]) =>
+      mutateKeyHistory(async () => {
+        const domain = getWebsiteDomain(url);
+        const items = [{ key: recentKeys.key, value: JSON.stringify(retainKeys(keys)) }];
+        if (domain) {
+          const domains = (await appStorage.recentKeysByDomain.getValue()) ?? {};
+          items.push({
+            key: appStorage.recentKeysByDomain.raw.key,
+            value: JSON.stringify(retainDomains({ ...domains, [domain]: keys })),
+          });
+        }
+        await storage.setItems(items);
+      }),
   },
   recentKeysByDomain: {
     raw: asJson(storage.defineItem<RecentKeysByDomain>('local:recent-keys-by-domain')),

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -101,6 +101,62 @@ test('serializes status upgrades and duplicate captures', async () => {
   expect(await appStorage.allKeys.getValue()).toEqual([key]);
 });
 
+test('keeps recent stores consistent across captures and deletion snapshots', async () => {
+  const otherKey = { ...key, url: 'https://other.example/video' };
+  const [, snapshot, stores] = await Promise.all([
+    appStorage.recentKeys.setForUrl(key.url, [key]),
+    prepareKeyDeletion({ kind: 'all' }),
+    navigator.locks.request('okova:key-history', async () => ({
+      recent: await appStorage.recentKeys.getValue(),
+      domains: await appStorage.recentKeysByDomain.getValue(),
+    })),
+    appStorage.recentKeys.setForUrl(otherKey.url, [otherKey]),
+  ]);
+
+  expect(snapshot.count).toBe(1);
+  expect(stores).toEqual({ recent: [key], domains: { 'example.com': [key] } });
+  expect(await appStorage.recentKeys.getValue()).toEqual([otherKey]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({
+    'example.com': [key],
+    'other.example': [otherKey],
+  });
+
+  await Promise.all([appStorage.recentKeys.setForUrl(key.url, [key]), appStorage.allKeys.clear()]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({});
+});
+
+test('releases the recent-store lock after a failed batch write', async () => {
+  await appStorage.recentKeys.setForUrl(key.url, [key]);
+  const error = new Error('Storage write failed');
+  vi.spyOn(browser.storage.local, 'set').mockRejectedValueOnce(error);
+
+  await expect(appStorage.recentKeys.setForUrl(key.url, [])).rejects.toThrow(error);
+  expect(await appStorage.recentKeys.getValue()).toEqual([key]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [key] });
+
+  await appStorage.recentKeys.setForUrl(key.url, []);
+  expect(await appStorage.recentKeys.getValue()).toEqual([]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [] });
+});
+
+test('bounds combined recent writes and preserves empty and unscoped results', async () => {
+  const keys = Array.from({ length: 1_005 }, (_, index) => ({
+    ...key,
+    id: String(index),
+    createdAt: index,
+  }));
+  await appStorage.recentKeys.setForUrl(key.url, keys);
+  expect(await appStorage.recentKeys.getValue()).toEqual(keys.slice(5));
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({
+    'example.com': keys.slice(5),
+  });
+  await appStorage.recentKeys.setForUrl(key.url, []);
+  await appStorage.recentKeys.setForUrl(undefined, [key]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([key]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [] });
+});
+
 test('serializes removals with captures and ignores repeated removals', async () => {
   const otherKey = { ...key, id: '112233445566778899aabbccddeeff00' };
   await appStorage.allKeys.add(key);

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -16,10 +16,10 @@ const mpd = (pssh: string, scheme: string = PSSH_SYSTEM_IDS.widevine) => `
       <other:pssh>\n ${pssh.slice(0, 16)}\n ${pssh.slice(16)} \n</other:pssh>
     </dash:ContentProtection></dash:AdaptationSet></dash:Period>
   </dash:MPD>`;
-const post = (text: string) =>
+const post = (text: string, manifestUrl = url) =>
   receive({
     source: window,
-    data: { namespace: 'okova:network', method: 'response', params: { url, text } },
+    data: { namespace: 'okova:network', method: 'response', params: { url: manifestUrl, text } },
   });
 
 beforeEach(() => {
@@ -32,6 +32,38 @@ beforeEach(() => {
   installManifestInspection();
 });
 afterEach(() => vi.unstubAllGlobals());
+
+test.each([
+  'javascript:alert(1)',
+  'data:application/dash+xml,<MPD/>',
+  'file:///tmp/manifest.mpd',
+  'blob:https://example.test/manifest',
+  'ftp://example.test/manifest.mpd',
+  '//example.test/manifest.mpd',
+  '/manifest.mpd',
+  'not a URL',
+  'https://',
+  '',
+])('rejects unsafe or invalid manifest URLs: %s', (manifestUrl) => {
+  post(mpd(widevine), manifestUrl);
+  expect(window.MPD_LIST.size).toBe(0);
+
+  // The page can also write directly to the cache.
+  window.MPD_LIST.set(widevine, manifestUrl);
+  expect(findManifest(widevine)).toBeUndefined();
+  expect(findManifest(combined)).toBeUndefined();
+  window.MPD_LIST.set(playready, url);
+  window.MPD_LIST.set(combined, manifestUrl);
+  expect(findManifest(combined)).toBe(url);
+});
+
+test.each(['http://example.test/manifest.mpd', url, 'HTTPS://example.test/manifest.mpd'])(
+  'accepts HTTP(S) manifest URLs: %s',
+  (manifestUrl) => {
+    post(mpd(widevine), manifestUrl);
+    expect(findManifest(widevine)).toBe(manifestUrl);
+  },
+);
 
 test.each([null, undefined, false, 42, 'page-owned', {}, []])(
   'replaces an incompatible page-owned manifest cache: %j',

--- a/test/extension-sessions.test.ts
+++ b/test/extension-sessions.test.ts
@@ -528,11 +528,11 @@ test('an old document cannot clear a new document failure after navigation', asy
   const send = startBackground();
   const started = Promise.withResolvers<void>();
   const resumeWrite = Promise.withResolvers<void>();
-  const setRecentKeys = appStorage.recentKeys.setValue;
-  vi.spyOn(appStorage.recentKeys, 'setValue').mockImplementationOnce(async (keys) => {
+  const setRecentKeys = appStorage.recentKeys.setForUrl;
+  vi.spyOn(appStorage.recentKeys, 'setForUrl').mockImplementationOnce(async (url, keys) => {
     started.resolve();
     await resumeWrite.promise;
-    await setRecentKeys(keys);
+    await setRecentKeys(url, keys);
   });
   const oldRequest = send(
     'keystatuseschange',

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     'build:done': async (wxt) => {
       if (wxt.config.mode !== 'production') return;
       // Bound both the isolated bridge and the combined MAIN startup scripts.
-      const budgetBytes = 20 * 1024;
+      const budgetBytes = 32 * 1024;
       for (const paths of [
         ['content-scripts/content.js'],
         ['content-scripts/bootstrap.js', 'eme-bootstrap.js', 'network.js'],


### PR DESCRIPTION
## Summary

- Validate cached and received manifest URLs to allow only HTTP(S) URLs.
- Atomically update recent key stores while preserving bounded history and lock recovery.
- Add regression coverage for unsafe URLs, concurrent writes, failed batches, and storage limits.

## Testing

- Not run.