### PR TITLE
fix(extension): isolate private browsing history

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Reloading or navigating clears the current result; saved keys then appear blue. 
 
 In **Keys**, use the large checkboxes to select individual records or **Select All Results** to select the current search results. **Delete Selected** shows the affected count before deleting. Records hidden by a search are deselected.
 
+Private windows use separate history and recent captures held in session storage. Private history is cleared when the last private window closes or the browser restarts. History views, exports, deletion, and badges use the current window’s browsing mode. Settings and imported clients remain shared. Previously saved records have no browsing-mode metadata and are not retroactively separated.
+
 **Delete Site Keys** is available on the dashboard and in record details. It removes that site's records from history and recent captures. A site includes its `www.` hostname, but excludes other subdomains. **Delete All** covers every site, regardless of search or selection.
 
 Bulk and site confirmations freeze their target records when opened. Captures arriving afterward are kept. Cancel or press Escape to return without deleting.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Reloading or navigating clears the current result; saved keys then appear blue. 
 
 In **Keys**, use the large checkboxes to select individual records or **Select All Results** to select the current search results. **Delete Selected** shows the affected count before deleting. Records hidden by a search are deselected.
 
-Private windows use separate history and recent captures held in session storage. Private history is cleared when the last private window closes or the browser restarts. History views, exports, deletion, and badges use the current window’s browsing mode. Settings and imported clients remain shared. Previously saved records have no browsing-mode metadata and are not retroactively separated.
-
 **Delete Site Keys** is available on the dashboard and in record details. It removes that site's records from history and recent captures. A site includes its `www.` hostname, but excludes other subdomains. **Delete All** covers every site, regardless of search or selection.
 
 Bulk and site confirmations freeze their target records when opened. Captures arriving afterward are kept. Cancel or press Escape to return without deleting.

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -77,6 +77,7 @@ export default defineBackground({
         console.warn('[okova] Unable to clear private history', error),
       );
     };
+    browser.windows.onCreated.addListener(clearPrivateHistory);
     browser.windows.onRemoved.addListener(clearPrivateHistory);
     clearPrivateHistory();
 
@@ -289,7 +290,7 @@ export default defineBackground({
       const update = (badgeUpdates.get(tabId) ?? Promise.resolve())
         .catch(() => {})
         .then(async () => {
-          const history = getKeyHistory(tab?.incognito === true);
+          const history = await getKeyHistory(tab?.incognito === true, tab?.windowId);
           const badgeStorage = getBadgeStorage(tabId);
           if (result === null) await badgeStorage.removeValue();
           else if (result) {
@@ -416,7 +417,8 @@ export default defineBackground({
       const run = <T>(operation: T | Promise<T>) =>
         withAbort(Promise.resolve(operation), controller.signal);
       let stage: DrmStage = 'setup';
-      const history = getKeyHistory(sender.tab?.incognito === true);
+      const historyReady = getKeyHistory(sender.tab?.incognito === true, sender.tab?.windowId);
+      void historyReady.catch(() => {});
       const tabId = sender.tab?.id;
       const tabGeneration = tabId === undefined ? 0 : (tabGenerations.get(tabId) ?? 0);
       const system = getBadgeDrmSystem(message.keySystem);
@@ -437,6 +439,7 @@ export default defineBackground({
         }
       };
       const handleMessage = async () => {
+        const history = await run(historyReady);
         if (message.action === 'load-eme') {
           if (tabId === undefined || sender.frameId === undefined)
             throw new Error('Missing injection frame');

--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -7,6 +7,9 @@ import {
 } from '@/utils/badge';
 import {
   appStorage,
+  getKeyHistory,
+  privateHistory,
+  clearClosedPrivateHistory,
   defaultSettings,
   clientInfoSchema,
   fromClientToInfo,
@@ -69,6 +72,14 @@ type SessionEntry = {
 export default defineBackground({
   type: 'module',
   main: () => {
+    const clearPrivateHistory = () => {
+      void clearClosedPrivateHistory().catch((error: unknown) =>
+        console.warn('[okova] Unable to clear private history', error),
+      );
+    };
+    browser.windows.onRemoved.addListener(clearPrivateHistory);
+    clearPrivateHistory();
+
     let scriptUpdates = Promise.resolve();
     const updateInterceptionScripts = () => {
       scriptUpdates = scriptUpdates
@@ -278,6 +289,7 @@ export default defineBackground({
       const update = (badgeUpdates.get(tabId) ?? Promise.resolve())
         .catch(() => {})
         .then(async () => {
+          const history = getKeyHistory(tab?.incognito === true);
           const badgeStorage = getBadgeStorage(tabId);
           if (result === null) await badgeStorage.removeValue();
           else if (result) {
@@ -288,8 +300,8 @@ export default defineBackground({
             ]);
           }
           const [recentKeys, recentKeysByDomain, storedResult] = await Promise.all([
-            appStorage.recentKeys.getValue(),
-            appStorage.recentKeysByDomain.getValue(),
+            history.recentKeys.getValue(),
+            history.recentKeysByDomain.getValue(),
             badgeStorage.getValue(),
           ]);
           const keys = getRecentKeysForUrl(tab?.url, recentKeysByDomain, recentKeys);
@@ -339,6 +351,9 @@ export default defineBackground({
     };
 
     updateActiveTabBadgesInBackground();
+
+    privateHistory.recentKeys.watch(updateActiveTabBadgesInBackground);
+    privateHistory.recentKeysByDomain.watch(updateActiveTabBadgesInBackground);
 
     appStorage.recentKeys.watch(() => {
       updateActiveTabBadgesInBackground();
@@ -401,6 +416,7 @@ export default defineBackground({
       const run = <T>(operation: T | Promise<T>) =>
         withAbort(Promise.resolve(operation), controller.signal);
       let stage: DrmStage = 'setup';
+      const history = getKeyHistory(sender.tab?.incognito === true);
       const tabId = sender.tab?.id;
       const tabGeneration = tabId === undefined ? 0 : (tabGenerations.get(tabId) ?? 0);
       const system = getBadgeDrmSystem(message.keySystem);
@@ -508,7 +524,7 @@ export default defineBackground({
         stage = 'setup';
         const settings = await run(appStorage.settings.getValue());
         const setRecentKeys = async (keys: KeyInfo[]) => {
-          await run(appStorage.recentKeys.setForUrl(message.url, keys));
+          await run(history.recentKeys.setForUrl(message.url, keys));
           updateBadgeForTabInBackground(sender.tab);
         };
 
@@ -531,7 +547,7 @@ export default defineBackground({
             }));
             stage = 'history';
             await setRecentKeys(results);
-            await run(appStorage.allKeys.add(...results));
+            await run(history.allKeys.add(...results));
             await run(clearFailure());
             await recordBadgeResult({ kind: 'success', system, keys: results.map(getBadgeKey) });
             stage = 'close';
@@ -557,8 +573,8 @@ export default defineBackground({
           stage = 'history';
           const recentKeys = getRecentKeysForUrl(
             message.url,
-            await run(appStorage.recentKeysByDomain.getValue()),
-            await run(appStorage.recentKeys.getValue()),
+            await run(history.recentKeysByDomain.getValue()),
+            await run(history.recentKeys.getValue()),
           );
           // Status events must not replace extracted keys or borrow another capture's metadata.
           const capturedKeys = recentKeys.filter(
@@ -566,7 +582,7 @@ export default defineBackground({
           );
           const capturedIds = new Set(capturedKeys.map((key) => key.id));
           await setRecentKeys([...capturedKeys, ...keys.filter((key) => !capturedIds.has(key.id))]);
-          await run(appStorage.allKeys.add(...keys));
+          await run(history.allKeys.add(...keys));
           await run(clearFailure());
           respond();
           return;
@@ -709,7 +725,7 @@ export default defineBackground({
           }));
           stage = 'history';
           await setRecentKeys(results);
-          await run(appStorage.allKeys.add(...results));
+          await run(history.allKeys.add(...results));
           await run(clearFailure());
           await recordBadgeResult({ kind: 'success', system, keys: results.map(getBadgeKey) });
           stage = 'close';

--- a/src/extension/entrypoints/popup/components/delete-keys.tsx
+++ b/src/extension/entrypoints/popup/components/delete-keys.tsx
@@ -1,10 +1,13 @@
+import { popupHistory } from '../utils/history';
 import { createSignal, onMount, Show } from 'solid-js';
 import { TbOutlineTrash } from 'solid-icons/tb';
-import { deleteKeySnapshot, prepareKeyDeletion, type KeyDeletionScope } from '@/utils/storage';
+import { type KeyDeletionScope } from '@/utils/storage';
 import { Portal } from 'solid-js/web';
 import { Cell } from './cell';
 
-type Deletion = Awaited<ReturnType<typeof prepareKeyDeletion>> & { description: string };
+type Deletion = Awaited<ReturnType<typeof popupHistory.prepareKeyDeletion>> & {
+  description: string;
+};
 
 export const DeleteKeys = (props: {
   scope: KeyDeletionScope;
@@ -23,7 +26,7 @@ export const DeleteKeys = (props: {
     setError(undefined);
     const scope = props.scope;
     try {
-      const snapshot = await prepareKeyDeletion(scope);
+      const snapshot = await popupHistory.prepareKeyDeletion(scope);
       const description =
         scope.kind === 'site'
           ? `All records for ${scope.domain}, including www.${scope.domain}. Other subdomains are excluded.`
@@ -44,7 +47,7 @@ export const DeleteKeys = (props: {
     setIsBusy(true);
     setError(undefined);
     try {
-      await deleteKeySnapshot(snapshot.tokens);
+      await popupHistory.deleteKeySnapshot(snapshot.tokens);
       setPending(null);
       props.onDeleted?.();
     } catch {

--- a/src/extension/entrypoints/popup/components/toolbar.tsx
+++ b/src/extension/entrypoints/popup/components/toolbar.tsx
@@ -1,3 +1,4 @@
+import { popupHistory } from '../utils/history';
 import { A } from '@solidjs/router';
 import {
   TbOutlineKey as TbKey,
@@ -6,7 +7,7 @@ import {
 } from 'solid-icons/tb';
 import { CardButton } from './card-button';
 import { Section } from './section';
-import { appStorage, isCapturedKey } from '@/utils/storage';
+import { isCapturedKey } from '@/utils/storage';
 import { useClients } from '../utils/state';
 
 export const Toolbar = () => {
@@ -14,7 +15,7 @@ export const Toolbar = () => {
   const [capturedKeyCount, setCapturedKeyCount] = createSignal(0);
   let hasUpdate = false;
   let isDisposed = false;
-  const unwatch = appStorage.allKeys.raw.watch((keys) => {
+  const unwatch = popupHistory.allKeys.raw.watch((keys) => {
     hasUpdate = true;
     setCapturedKeyCount(keys?.filter(isCapturedKey).length ?? 0);
   });
@@ -23,7 +24,7 @@ export const Toolbar = () => {
     unwatch();
   });
   onMount(async () => {
-    const keys = await appStorage.allKeys.getValue();
+    const keys = await popupHistory.allKeys.getValue();
     if (!isDisposed && !hasUpdate) setCapturedKeyCount(keys?.filter(isCapturedKey).length ?? 0);
   });
 

--- a/src/extension/entrypoints/popup/main.tsx
+++ b/src/extension/entrypoints/popup/main.tsx
@@ -3,6 +3,7 @@ import { Route, Router } from '@solidjs/router';
 import { createEffect, createSignal, onCleanup, onMount } from 'solid-js';
 
 import './styles.css';
+import { initializePopupHistory } from './utils/history';
 import { Dashboard } from './routes/dashboard';
 import { Clients } from './routes/clients';
 import { Keys } from './routes/keys';
@@ -42,4 +43,10 @@ const Popup = () => {
   );
 };
 
-render(() => <Popup />, document.getElementById('root')!);
+initializePopupHistory()
+  .then(() => render(() => <Popup />, document.getElementById('root')!))
+  .catch((error: unknown) => {
+    console.error('[okova] Unable to initialize popup history', error);
+    document.getElementById('root')!.textContent =
+      'Unable to open history. Please reopen the popup.';
+  });

--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -1,6 +1,7 @@
+import { popupHistory } from '../utils/history';
 import { Component } from 'solid-js';
 import { TbOutlineClipboardText, TbOutlineTrash } from 'solid-icons/tb';
-import { appStorage, getWebsiteDomain, KeyInfo } from '@/utils/storage';
+import { getWebsiteDomain, KeyInfo } from '@/utils/storage';
 import { DeleteKeys } from '../components/delete-keys';
 import { Header } from '../components/header';
 import { Layout } from '../components/layout';
@@ -33,7 +34,7 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
     setIsDeleting(true);
     setDeleteError(undefined);
     try {
-      await appStorage.allKeys.remove(props.key);
+      await popupHistory.allKeys.remove(props.key);
       props.onClose();
     } catch {
       setDeleteError('Deletion failed. Please try again.');

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -1,9 +1,10 @@
+import { popupHistory } from '../utils/history';
 import { TbOutlineDownload } from 'solid-icons/tb';
 import { DeleteKeys } from '../components/delete-keys';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
 import { Cell } from '../components/cell';
-import { appStorage, KeyInfo } from '@/utils/storage';
+import { KeyInfo } from '@/utils/storage';
 import { KeysList } from '../components/keys-list';
 import { NoKeys } from '../components/no-keys';
 import { Section } from '../components/section';
@@ -46,7 +47,7 @@ export const Keys = () => {
 
   let isDisposed = false;
   let hasUpdate = false;
-  const unwatch = appStorage.allKeys.raw.watch((records) => {
+  const unwatch = popupHistory.allKeys.raw.watch((records) => {
     hasUpdate = true;
     setKeys(records ?? []);
   });
@@ -55,7 +56,7 @@ export const Keys = () => {
     unwatch();
   });
   onMount(async () => {
-    const records = await appStorage.allKeys.getValue();
+    const records = await popupHistory.allKeys.getValue();
     // A storage event may arrive before the initial read resolves.
     if (!isDisposed && !hasUpdate) setKeys(records ?? []);
   });

--- a/src/extension/entrypoints/popup/utils/history.ts
+++ b/src/extension/entrypoints/popup/utils/history.ts
@@ -5,5 +5,5 @@ export let popupHistory = privateHistory;
 
 export const initializePopupHistory = async () => {
   const window = await browser.windows.getCurrent();
-  popupHistory = getKeyHistory(window.incognito);
+  popupHistory = await getKeyHistory(window.incognito, window.id);
 };

--- a/src/extension/entrypoints/popup/utils/history.ts
+++ b/src/extension/entrypoints/popup/utils/history.ts
@@ -1,0 +1,9 @@
+import { browser } from 'wxt/browser';
+import { getKeyHistory, privateHistory } from '@/utils/storage';
+
+export let popupHistory = privateHistory;
+
+export const initializePopupHistory = async () => {
+  const window = await browser.windows.getCurrent();
+  popupHistory = getKeyHistory(window.incognito);
+};

--- a/src/extension/entrypoints/popup/utils/state.ts
+++ b/src/extension/entrypoints/popup/utils/state.ts
@@ -1,3 +1,4 @@
+import { popupHistory } from './history';
 import {
   appStorage,
   StoredClient,
@@ -81,12 +82,14 @@ export const useSyncStateWithStorage = () => {
       const failure = await failureStorage.getValue();
       if (!isDisposed && !hasUpdate) setDrmFailure(failure);
     });
-    appStorage.recentKeys.getValue().then((recentKeys) => recentKeys && setRecentKeys(recentKeys));
-    appStorage.recentKeys.watch((newKeys) => setRecentKeys(newKeys || []));
-    appStorage.recentKeysByDomain
+    popupHistory.recentKeys
+      .getValue()
+      .then((recentKeys) => recentKeys && setRecentKeys(recentKeys));
+    popupHistory.recentKeys.watch((newKeys) => setRecentKeys(newKeys || []));
+    popupHistory.recentKeysByDomain
       .getValue()
       .then((recentKeysByDomain) => setRecentKeysByDomain(recentKeysByDomain || {}));
-    appStorage.recentKeysByDomain.watch((newKeysByDomain) =>
+    popupHistory.recentKeysByDomain.watch((newKeysByDomain) =>
       setRecentKeysByDomain(newKeysByDomain || {}),
     );
   });

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -294,17 +294,61 @@ const clientStorage = {
   },
 };
 
+type PrivateSession = { generation: string; windowIds: number[] };
+const privateSession = storage.defineItem<PrivateSession>('session:incognito:history-session');
+const PRIVATE_HISTORY_LOCK = 'okova:incognito-key-history';
+const PRIVATE_HISTORY_KEYS = [
+  'session:incognito:all-keys',
+  'session:incognito:recent-keys',
+  'session:incognito:recent-keys-by-domain',
+] as const;
+
+// Queue the observation immediately, before awaiting the window snapshot. Window events,
+// capture binding, and writes must observe session transitions in the same lock order.
+const withPrivateSession = <T>(operation: (session: PrivateSession | null) => Promise<T>) => {
+  const observedSession = privateSession.getValue();
+  const windows = browser.windows.getAll();
+  return navigator.locks.request(PRIVATE_HISTORY_LOCK, async () => {
+    const observedGeneration = (await observedSession)?.generation;
+    const previous = await privateSession.getValue();
+    // Another extension context may have advanced the generation before this lock.
+    // Its records cannot be cleared using a window snapshot from the old generation.
+    const snapshot = await windows;
+    const currentWindows =
+      previous?.generation === observedGeneration ? snapshot : await browser.windows.getAll();
+    const windowIds = currentWindows
+      .filter((window) => window.incognito)
+      .flatMap((window) => (window.id === undefined ? [] : [window.id]));
+    const isSameSession = previous?.windowIds.some((id) => windowIds.includes(id));
+    let session = previous;
+    if (!isSameSession) {
+      // Only this generation can own the shared history keys while the lock is held.
+      await storage.removeItems([...PRIVATE_HISTORY_KEYS]);
+      session = windowIds.length ? { generation: crypto.randomUUID(), windowIds } : null;
+    } else if (session) {
+      session = { ...session, windowIds };
+    }
+    if (session) await privateSession.setValue(session);
+    else await privateSession.removeValue();
+    return operation(session);
+  });
+};
+
 // Both contexts share extension storage, so private records need their own session keys.
-const createKeyHistory = (isIncognito: boolean) => {
+const createKeyHistory = (isIncognito: boolean, generation?: string) => {
   const prefix = isIncognito ? 'session:incognito:' : 'local:';
-  const lockName = isIncognito ? 'okova:incognito-key-history' : 'okova:key-history';
-  const mutateKeyHistory = (mutation: () => Promise<void>) =>
-    navigator.locks.request(lockName, async () => {
-      // A capture finishing after the last private window closes must not restore history.
-      if (isIncognito && !(await browser.windows.getAll()).some((window) => window.incognito))
-        return;
+  const lockName = isIncognito ? PRIVATE_HISTORY_LOCK : 'okova:key-history';
+  const mutateKeyHistory = (mutation: () => Promise<void>) => {
+    if (!isIncognito) return navigator.locks.request(lockName, mutation);
+    const expectedGeneration =
+      generation === undefined
+        ? withPrivateSession(async (session) => session?.generation)
+        : Promise.resolve(generation);
+    return withPrivateSession(async (session) => {
+      if (!session || session.generation !== (await expectedGeneration)) return;
       await mutation();
     });
+  };
   const recentKeys = asJson(storage.defineItem<KeyInfo[]>(`${prefix}recent-keys`));
 
   // Read all three stores under the writer lock before showing the confirmation.
@@ -486,21 +530,20 @@ const createKeyHistory = (isIncognito: boolean) => {
 
 export const regularHistory = createKeyHistory(false);
 export const privateHistory = createKeyHistory(true);
-export const getKeyHistory = (isIncognito: boolean) =>
-  isIncognito ? privateHistory : regularHistory;
-
-export const clearClosedPrivateHistory = async () => {
-  // Preserve the closure snapshot before waiting behind history writes. A replacement
-  // private window must not cancel cleanup of the session that just ended.
-  if ((await browser.windows.getAll()).some((window) => window.incognito)) return;
-  await navigator.locks.request('okova:incognito-key-history', async () => {
-    await storage.removeItems([
-      privateHistory.allKeys.raw.key,
-      privateHistory.recentKeys.key,
-      privateHistory.recentKeysByDomain.raw.key,
-    ]);
-  });
+// Bind before asynchronous capture work, so an old request cannot join a replacement session.
+export const getKeyHistory = async (isIncognito: boolean, windowId?: number) => {
+  if (!isIncognito) return regularHistory;
+  return withPrivateSession(async (session) =>
+    createKeyHistory(
+      true,
+      session && (windowId === undefined || session.windowIds.includes(windowId))
+        ? session.generation
+        : crypto.randomUUID(),
+    ),
+  );
 };
+
+export const clearClosedPrivateHistory = () => withPrivateSession(async () => {});
 
 export const { prepareKeyDeletion, deleteKeySnapshot } = regularHistory;
 export const appStorage = {

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -1,4 +1,4 @@
-import { storage } from '#imports';
+import { browser, storage } from '#imports';
 import { z } from 'zod';
 import { remoteConfigSchema } from '@okova/lib/remote/config';
 import { RemoteClient } from '../remote-client';
@@ -36,61 +36,6 @@ const sameKeyRecord = (left: KeyInfo, right: KeyInfo) =>
   left.url === right.url &&
   left.pssh === right.pssh &&
   ((!isCapturedKey(left) && !isCapturedKey(right)) || left.value === right.value);
-
-// Read all three stores under the writer lock before showing the confirmation.
-export const prepareKeyDeletion = (scope: KeyDeletionScope) =>
-  navigator.locks.request('okova:key-history', async () => {
-    const [history, recent, domains] = await Promise.all([
-      appStorage.allKeys.getValue(),
-      appStorage.recentKeys.getValue(),
-      appStorage.recentKeysByDomain.getValue(),
-    ]);
-    const records = [
-      ...(history ?? []),
-      ...(recent ?? []),
-      ...Object.values(domains ?? {}).flat(),
-    ].filter((key) => {
-      switch (scope.kind) {
-        case 'all':
-          return true;
-        case 'site':
-          return getWebsiteDomain(key.url) === scope.domain;
-        case 'selected':
-          return scope.records.some((record) => sameKeyRecord(key, record));
-      }
-    });
-    const unique: KeyInfo[] = [];
-    for (const record of records) {
-      if (!unique.some((key) => sameKeyRecord(key, record))) unique.push(record);
-    }
-    return { count: unique.length, tokens: [...new Set(records.map(keyRecordToken))] };
-  });
-
-export const deleteKeySnapshot = (tokens: string[]) =>
-  mutateKeyHistory(async () => {
-    const targets = new Set(tokens);
-    const keep = (key: KeyInfo) => !targets.has(keyRecordToken(key));
-    const [history, recent, domains] = await Promise.all([
-      appStorage.allKeys.getValue(),
-      appStorage.recentKeys.getValue(),
-      appStorage.recentKeysByDomain.getValue(),
-    ]);
-    await storage.setItems([
-      { key: appStorage.allKeys.raw.key, value: JSON.stringify((history ?? []).filter(keep)) },
-      { key: appStorage.recentKeys.key, value: JSON.stringify((recent ?? []).filter(keep)) },
-      {
-        key: appStorage.recentKeysByDomain.raw.key,
-        value: JSON.stringify(
-          Object.fromEntries(
-            Object.entries(domains ?? {}).map(([domain, records]) => [
-              domain,
-              records.filter(keep),
-            ]),
-          ),
-        ),
-      },
-    ]);
-  });
 
 export const drmStages = {
   setup: 'Request setup',
@@ -200,13 +145,6 @@ export const fromClientToInfo = async (client: Client): Promise<ClientInfo> => {
   const data = fromBuffer(await client.pack()).toBase64();
   return { type, data };
 };
-
-// A shared browser lock serializes background and popup writes, including clears.
-// Call raw setters inside the lock to avoid acquiring the same lock recursively.
-const mutateKeyHistory = (mutation: () => Promise<void>) =>
-  navigator.locks.request('okova:key-history', mutation);
-
-const recentKeys = asJson(storage.defineItem<KeyInfo[]>('local:recent-keys'));
 
 const clientRegistrySchema = z.object({
   clients: z.array(z.object({ id: z.string(), info: clientInfoSchema })),
@@ -356,117 +294,214 @@ const clientStorage = {
   },
 };
 
+// Both contexts share extension storage, so private records need their own session keys.
+const createKeyHistory = (isIncognito: boolean) => {
+  const prefix = isIncognito ? 'session:incognito:' : 'local:';
+  const lockName = isIncognito ? 'okova:incognito-key-history' : 'okova:key-history';
+  const mutateKeyHistory = (mutation: () => Promise<void>) =>
+    navigator.locks.request(lockName, async () => {
+      // A capture finishing after the last private window closes must not restore history.
+      if (isIncognito && !(await browser.windows.getAll()).some((window) => window.incognito))
+        return;
+      await mutation();
+    });
+  const recentKeys = asJson(storage.defineItem<KeyInfo[]>(`${prefix}recent-keys`));
+
+  // Read all three stores under the writer lock before showing the confirmation.
+  const prepareKeyDeletion = (scope: KeyDeletionScope) =>
+    navigator.locks.request(lockName, async () => {
+      const [history, recent, domains] = await Promise.all([
+        keyHistory.allKeys.getValue(),
+        keyHistory.recentKeys.getValue(),
+        keyHistory.recentKeysByDomain.getValue(),
+      ]);
+      const records = [
+        ...(history ?? []),
+        ...(recent ?? []),
+        ...Object.values(domains ?? {}).flat(),
+      ].filter((key) => {
+        switch (scope.kind) {
+          case 'all':
+            return true;
+          case 'site':
+            return getWebsiteDomain(key.url) === scope.domain;
+          case 'selected':
+            return scope.records.some((record) => sameKeyRecord(key, record));
+        }
+      });
+      const unique: KeyInfo[] = [];
+      for (const record of records) {
+        if (!unique.some((key) => sameKeyRecord(key, record))) unique.push(record);
+      }
+      return { count: unique.length, tokens: [...new Set(records.map(keyRecordToken))] };
+    });
+
+  const deleteKeySnapshot = (tokens: string[]) =>
+    mutateKeyHistory(async () => {
+      const targets = new Set(tokens);
+      const keep = (key: KeyInfo) => !targets.has(keyRecordToken(key));
+      const [history, recent, domains] = await Promise.all([
+        keyHistory.allKeys.getValue(),
+        keyHistory.recentKeys.getValue(),
+        keyHistory.recentKeysByDomain.getValue(),
+      ]);
+      await storage.setItems([
+        { key: keyHistory.allKeys.raw.key, value: JSON.stringify((history ?? []).filter(keep)) },
+        { key: keyHistory.recentKeys.key, value: JSON.stringify((recent ?? []).filter(keep)) },
+        {
+          key: keyHistory.recentKeysByDomain.raw.key,
+          value: JSON.stringify(
+            Object.fromEntries(
+              Object.entries(domains ?? {}).map(([domain, records]) => [
+                domain,
+                records.filter(keep),
+              ]),
+            ),
+          ),
+        },
+      ]);
+    });
+
+  const keyHistory = {
+    prepareKeyDeletion,
+    deleteKeySnapshot,
+
+    recentKeys: {
+      ...recentKeys,
+      setValue: (keys: KeyInfo[]) => mutateKeyHistory(() => recentKeys.setValue(retainKeys(keys))),
+      setForUrl: (url: string | undefined, keys: KeyInfo[]) =>
+        mutateKeyHistory(async () => {
+          const domain = getWebsiteDomain(url);
+          const items = [{ key: recentKeys.key, value: JSON.stringify(retainKeys(keys)) }];
+          if (domain) {
+            const domains = (await keyHistory.recentKeysByDomain.getValue()) ?? {};
+            items.push({
+              key: keyHistory.recentKeysByDomain.raw.key,
+              value: JSON.stringify(retainDomains({ ...domains, [domain]: keys })),
+            });
+          }
+          await storage.setItems(items);
+        }),
+    },
+    recentKeysByDomain: {
+      raw: asJson(storage.defineItem<RecentKeysByDomain>(`${prefix}recent-keys-by-domain`)),
+      setValue: (keys: RecentKeysByDomain) =>
+        mutateKeyHistory(() => keyHistory.recentKeysByDomain.raw.setValue(retainDomains(keys))),
+      getValue: async () => {
+        return keyHistory.recentKeysByDomain.raw.getValue();
+      },
+      watch: (
+        callback: (
+          newValue: RecentKeysByDomain | null,
+          oldValue: RecentKeysByDomain | null,
+        ) => void,
+      ) => {
+        return keyHistory.recentKeysByDomain.raw.watch(callback);
+      },
+      clear: () => mutateKeyHistory(() => keyHistory.recentKeysByDomain.raw.setValue({})),
+      setForUrl: async (url: string | undefined, keys: KeyInfo[]) => {
+        const domain = getWebsiteDomain(url);
+        if (!domain) return;
+
+        await mutateKeyHistory(async () => {
+          const keysByDomain = (await keyHistory.recentKeysByDomain.getValue()) || {};
+          await keyHistory.recentKeysByDomain.raw.setValue(
+            retainDomains({ ...keysByDomain, [domain]: keys }),
+          );
+        });
+      },
+    },
+    allKeys: {
+      raw: asJson(storage.defineItem<KeyInfo[]>(`${prefix}all-keys`)),
+      setValue: (keys: KeyInfo[]) =>
+        mutateKeyHistory(() => keyHistory.allKeys.raw.setValue(retainKeys(keys))),
+      getValue: async () => {
+        return keyHistory.allKeys.raw.getValue();
+      },
+      clear: () =>
+        mutateKeyHistory(async () => {
+          await keyHistory.allKeys.raw.setValue([]);
+          await recentKeys.setValue([]);
+          await keyHistory.recentKeysByDomain.raw.setValue({});
+        }),
+      add: (...newKeys: KeyInfo[]) =>
+        mutateKeyHistory(async () => {
+          const keys = (await keyHistory.allKeys.getValue()) || [];
+          for (const newKey of newKeys) {
+            const index = keys.findIndex(
+              (key) =>
+                key.id === newKey.id &&
+                (!isCapturedKey(key) ||
+                  !isCapturedKey(newKey) ||
+                  (key.value === newKey.value &&
+                    key.pssh === newKey.pssh &&
+                    key.url === newKey.url)),
+            );
+            if (index === -1) {
+              keys.push(newKey);
+            } else if (!isCapturedKey(keys[index]!) && isCapturedKey(newKey)) {
+              keys[index] = newKey;
+            }
+          }
+          await keyHistory.allKeys.raw.setValue(retainKeys(keys));
+        }),
+      remove: (key: KeyInfo) =>
+        mutateKeyHistory(async () => {
+          // Status values can change in recent caches while history retains the original.
+          // Captured keys still require an exact value match; timestamps may differ.
+          const keepRecord = (storedKey: KeyInfo) =>
+            storedKey.id !== key.id ||
+            ((isCapturedKey(storedKey) || isCapturedKey(key)) && storedKey.value !== key.value) ||
+            storedKey.pssh !== key.pssh ||
+            storedKey.url !== key.url;
+          const [keys, recent, domains] = await Promise.all([
+            keyHistory.allKeys.getValue(),
+            recentKeys.getValue(),
+            keyHistory.recentKeysByDomain.getValue(),
+          ]);
+          await storage.setItems([
+            {
+              key: keyHistory.allKeys.raw.key,
+              value: JSON.stringify((keys ?? []).filter(keepRecord)),
+            },
+            { key: recentKeys.key, value: JSON.stringify((recent ?? []).filter(keepRecord)) },
+            {
+              key: keyHistory.recentKeysByDomain.raw.key,
+              value: JSON.stringify(
+                Object.fromEntries(
+                  Object.entries(domains ?? {}).map(([domain, records]) => [
+                    domain,
+                    records.filter(keepRecord),
+                  ]),
+                ),
+              ),
+            },
+          ]);
+        }),
+    },
+  };
+
+  return keyHistory;
+};
+
+export const regularHistory = createKeyHistory(false);
+export const privateHistory = createKeyHistory(true);
+export const getKeyHistory = (isIncognito: boolean) =>
+  isIncognito ? privateHistory : regularHistory;
+
+export const clearClosedPrivateHistory = () =>
+  navigator.locks.request('okova:incognito-key-history', async () => {
+    if ((await browser.windows.getAll()).some((window) => window.incognito)) return;
+    await storage.removeItems([
+      privateHistory.allKeys.raw.key,
+      privateHistory.recentKeys.key,
+      privateHistory.recentKeysByDomain.raw.key,
+    ]);
+  });
+
+export const { prepareKeyDeletion, deleteKeySnapshot } = regularHistory;
 export const appStorage = {
   settings: settingsStorage,
-
-  recentKeys: {
-    ...recentKeys,
-    setValue: (keys: KeyInfo[]) => mutateKeyHistory(() => recentKeys.setValue(retainKeys(keys))),
-    setForUrl: (url: string | undefined, keys: KeyInfo[]) =>
-      mutateKeyHistory(async () => {
-        const domain = getWebsiteDomain(url);
-        const items = [{ key: recentKeys.key, value: JSON.stringify(retainKeys(keys)) }];
-        if (domain) {
-          const domains = (await appStorage.recentKeysByDomain.getValue()) ?? {};
-          items.push({
-            key: appStorage.recentKeysByDomain.raw.key,
-            value: JSON.stringify(retainDomains({ ...domains, [domain]: keys })),
-          });
-        }
-        await storage.setItems(items);
-      }),
-  },
-  recentKeysByDomain: {
-    raw: asJson(storage.defineItem<RecentKeysByDomain>('local:recent-keys-by-domain')),
-    setValue: (keys: RecentKeysByDomain) =>
-      mutateKeyHistory(() => appStorage.recentKeysByDomain.raw.setValue(retainDomains(keys))),
-    getValue: async () => {
-      return appStorage.recentKeysByDomain.raw.getValue();
-    },
-    watch: (
-      callback: (newValue: RecentKeysByDomain | null, oldValue: RecentKeysByDomain | null) => void,
-    ) => {
-      return appStorage.recentKeysByDomain.raw.watch(callback);
-    },
-    clear: () => mutateKeyHistory(() => appStorage.recentKeysByDomain.raw.setValue({})),
-    setForUrl: async (url: string | undefined, keys: KeyInfo[]) => {
-      const domain = getWebsiteDomain(url);
-      if (!domain) return;
-
-      await mutateKeyHistory(async () => {
-        const keysByDomain = (await appStorage.recentKeysByDomain.getValue()) || {};
-        await appStorage.recentKeysByDomain.raw.setValue(
-          retainDomains({ ...keysByDomain, [domain]: keys }),
-        );
-      });
-    },
-  },
-  allKeys: {
-    raw: asJson(storage.defineItem<KeyInfo[]>('local:all-keys')),
-    setValue: (keys: KeyInfo[]) =>
-      mutateKeyHistory(() => appStorage.allKeys.raw.setValue(retainKeys(keys))),
-    getValue: async () => {
-      return appStorage.allKeys.raw.getValue();
-    },
-    clear: () =>
-      mutateKeyHistory(async () => {
-        await appStorage.allKeys.raw.setValue([]);
-        await recentKeys.setValue([]);
-        await appStorage.recentKeysByDomain.raw.setValue({});
-      }),
-    add: (...newKeys: KeyInfo[]) =>
-      mutateKeyHistory(async () => {
-        const keys = (await appStorage.allKeys.getValue()) || [];
-        for (const newKey of newKeys) {
-          const index = keys.findIndex(
-            (key) =>
-              key.id === newKey.id &&
-              (!isCapturedKey(key) ||
-                !isCapturedKey(newKey) ||
-                (key.value === newKey.value && key.pssh === newKey.pssh && key.url === newKey.url)),
-          );
-          if (index === -1) {
-            keys.push(newKey);
-          } else if (!isCapturedKey(keys[index]!) && isCapturedKey(newKey)) {
-            keys[index] = newKey;
-          }
-        }
-        await appStorage.allKeys.raw.setValue(retainKeys(keys));
-      }),
-    remove: (key: KeyInfo) =>
-      mutateKeyHistory(async () => {
-        // Status values can change in recent caches while history retains the original.
-        // Captured keys still require an exact value match; timestamps may differ.
-        const keepRecord = (storedKey: KeyInfo) =>
-          storedKey.id !== key.id ||
-          ((isCapturedKey(storedKey) || isCapturedKey(key)) && storedKey.value !== key.value) ||
-          storedKey.pssh !== key.pssh ||
-          storedKey.url !== key.url;
-        const [keys, recent, domains] = await Promise.all([
-          appStorage.allKeys.getValue(),
-          recentKeys.getValue(),
-          appStorage.recentKeysByDomain.getValue(),
-        ]);
-        await storage.setItems([
-          {
-            key: appStorage.allKeys.raw.key,
-            value: JSON.stringify((keys ?? []).filter(keepRecord)),
-          },
-          { key: recentKeys.key, value: JSON.stringify((recent ?? []).filter(keepRecord)) },
-          {
-            key: appStorage.recentKeysByDomain.raw.key,
-            value: JSON.stringify(
-              Object.fromEntries(
-                Object.entries(domains ?? {}).map(([domain, records]) => [
-                  domain,
-                  records.filter(keepRecord),
-                ]),
-              ),
-            ),
-          },
-        ]);
-      }),
-  },
-
+  ...regularHistory,
   clients: clientStorage,
 };

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -489,15 +489,18 @@ export const privateHistory = createKeyHistory(true);
 export const getKeyHistory = (isIncognito: boolean) =>
   isIncognito ? privateHistory : regularHistory;
 
-export const clearClosedPrivateHistory = () =>
-  navigator.locks.request('okova:incognito-key-history', async () => {
-    if ((await browser.windows.getAll()).some((window) => window.incognito)) return;
+export const clearClosedPrivateHistory = async () => {
+  // Preserve the closure snapshot before waiting behind history writes. A replacement
+  // private window must not cancel cleanup of the session that just ended.
+  if ((await browser.windows.getAll()).some((window) => window.incognito)) return;
+  await navigator.locks.request('okova:incognito-key-history', async () => {
     await storage.removeItems([
       privateHistory.allKeys.raw.key,
       privateHistory.recentKeys.key,
       privateHistory.recentKeysByDomain.raw.key,
     ]);
   });
+};
 
 export const { prepareKeyDeletion, deleteKeySnapshot } = regularHistory;
 export const appStorage = {

--- a/test/extension-private-history.test.ts
+++ b/test/extension-private-history.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { browser } from 'wxt/browser';
+import { browser, type Browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import {
   appStorage,
   privateHistory,
   clearClosedPrivateHistory,
+  getKeyHistory,
   type KeyInfo,
 } from '../src/extension/utils/storage';
 import { initializePopupHistory } from '../src/extension/entrypoints/popup/utils/history';
@@ -93,8 +94,91 @@ test.each([true, false])(
       incognito,
     }));
     await initializePopupHistory();
-    expect(popup.popupHistory.allKeys).toBe(
-      incognito ? privateHistory.allKeys : appStorage.allKeys,
+    expect(popup.popupHistory.allKeys.raw.key).toBe(
+      (incognito ? privateHistory : appStorage).allKeys.raw.key,
     );
   },
 );
+
+test('rejects captures bound to a closed generation after a replacement session starts', async () => {
+  const oldHistory = await getKeyHistory(true, privateWindow.id);
+  await capture(oldHistory, key);
+  await capture(appStorage, key);
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => []);
+  await clearClosedPrivateHistory();
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => [{ ...privateWindow, id: 3 }]);
+  const replacementHistory = await getKeyHistory(true, 3);
+  const replacementKey = { ...key, pssh: 'replacement', createdAt: 2 };
+  await capture(replacementHistory, replacementKey);
+
+  await capture(oldHistory, key);
+  await oldHistory.allKeys.clear();
+  const closedWindowHistory = await getKeyHistory(true, privateWindow.id);
+  await capture(closedWindowHistory, key);
+
+  expect(await replacementHistory.allKeys.getValue()).toEqual([replacementKey]);
+  expect(await replacementHistory.recentKeys.getValue()).toEqual([replacementKey]);
+  expect(await replacementHistory.recentKeysByDomain.getValue()).toEqual({
+    'example.com': [replacementKey],
+  });
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+});
+
+test('orders a delayed closure snapshot before replacement-session captures', async () => {
+  const oldHistory = await getKeyHistory(true, privateWindow.id);
+  await capture(oldHistory, key);
+  const snapshot = Promise.withResolvers<Browser.windows.Window[]>();
+  vi.mocked(browser.windows.getAll).mockImplementationOnce(() => snapshot.promise);
+  const clearing = clearClosedPrivateHistory();
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => [{ ...privateWindow, id: 3 }]);
+  const replacementKey = { ...key, pssh: 'replacement', createdAt: 2 };
+  const capturing = Promise.resolve(getKeyHistory(true, 3)).then((history) =>
+    capture(history, replacementKey),
+  );
+  snapshot.resolve([]);
+  await Promise.all([clearing, capturing]);
+  expect(await privateHistory.allKeys.getValue()).toEqual([replacementKey]);
+  expect(await privateHistory.recentKeys.getValue()).toEqual([replacementKey]);
+  expect(await privateHistory.recentKeysByDomain.getValue()).toEqual({
+    'example.com': [replacementKey],
+  });
+});
+
+test('keeps a generation while private windows overlap and across history-handle recreation', async () => {
+  const firstHistory = await getKeyHistory(true, privateWindow.id);
+  await capture(firstHistory, key);
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => [
+    privateWindow,
+    { ...privateWindow, id: 3 },
+  ]);
+  await clearClosedPrivateHistory();
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => [{ ...privateWindow, id: 3 }]);
+  await clearClosedPrivateHistory();
+  const restoredHistory = await getKeyHistory(true, 3);
+  expect(await restoredHistory.allKeys.getValue()).toEqual([key]);
+  const laterKey = { ...key, id: 'another-id', createdAt: 2 };
+  await firstHistory.allKeys.add(laterKey);
+  expect(await restoredHistory.allKeys.getValue()).toEqual([key, laterKey]);
+});
+
+test('does not apply an old cleanup snapshot after another context advances the generation', async () => {
+  await capture(await getKeyHistory(true, privateWindow.id), key);
+  const locked = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const holding = navigator.locks.request('okova:incognito-key-history', async () => {
+    locked.resolve();
+    await release.promise;
+  });
+  await locked.promise;
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => [{ ...privateWindow, id: 3 }]);
+  const replacement = getKeyHistory(true, 3);
+  vi.mocked(browser.windows.getAll).mockImplementationOnce(async () => []);
+  const clearing = clearClosedPrivateHistory();
+  release.resolve();
+  const history = await replacement;
+  await Promise.all([holding, clearing]);
+  const replacementKey = { ...key, pssh: 'replacement', createdAt: 2 };
+  await capture(history, replacementKey);
+  expect(await history.allKeys.getValue()).toEqual([replacementKey]);
+  expect(await history.recentKeys.getValue()).toEqual([replacementKey]);
+});

--- a/test/extension-private-history.test.ts
+++ b/test/extension-private-history.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { browser } from 'wxt/browser';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import {
+  appStorage,
+  privateHistory,
+  clearClosedPrivateHistory,
+  type KeyInfo,
+} from '../src/extension/utils/storage';
+import { initializePopupHistory } from '../src/extension/entrypoints/popup/utils/history';
+import * as popup from '../src/extension/entrypoints/popup/utils/history';
+
+const privateWindow = {
+  id: 2,
+  incognito: true,
+  focused: true,
+  alwaysOnTop: false,
+  type: 'normal',
+  state: 'normal',
+} as const;
+const key: KeyInfo = {
+  id: '00112233445566778899aabbccddeeff',
+  value: 'ffeeddccbbaa99887766554433221100',
+  url: 'https://example.com/private',
+  pssh: 'private-pssh',
+  createdAt: 1,
+};
+const capture = async (history: typeof privateHistory, record: KeyInfo) => {
+  await history.recentKeys.setForUrl(record.url, [record]);
+  await history.allKeys.add(record);
+};
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  vi.spyOn(browser.windows, 'getAll').mockImplementation(async () => [privateWindow]);
+});
+afterEach(() => vi.restoreAllMocks());
+
+test('isolates private history, recent caches, watchers, and deletion from local storage', async () => {
+  const regularKey = { ...key, url: 'https://example.com/public', pssh: 'public-pssh' };
+  await capture(appStorage, regularKey);
+  const localBefore = await browser.storage.local.get(null);
+  const onRegularHistory = vi.fn();
+  const unwatch = appStorage.allKeys.raw.watch(onRegularHistory);
+  try {
+    await capture(privateHistory, key);
+    expect(await privateHistory.allKeys.getValue()).toEqual([key]);
+    expect(await privateHistory.recentKeysByDomain.getValue()).toEqual({ 'example.com': [key] });
+    expect(await browser.storage.local.get(null)).toEqual(localBefore);
+    expect(onRegularHistory).not.toHaveBeenCalled();
+
+    const snapshot = await privateHistory.prepareKeyDeletion({ kind: 'all' });
+    expect(snapshot.count).toBe(1);
+    await privateHistory.deleteKeySnapshot(snapshot.tokens);
+    expect(await privateHistory.allKeys.getValue()).toEqual([]);
+    expect(await privateHistory.recentKeys.getValue()).toEqual([]);
+    expect(await privateHistory.recentKeysByDomain.getValue()).toEqual({ 'example.com': [] });
+    expect(await browser.storage.local.get(null)).toEqual(localBefore);
+
+    await capture(privateHistory, key);
+    await appStorage.allKeys.clear();
+    expect(await privateHistory.allKeys.getValue()).toEqual([key]);
+  } finally {
+    unwatch();
+  }
+});
+
+test('retains private history while a private window exists, then clears it and rejects late writes', async () => {
+  await capture(appStorage, key);
+  await capture(privateHistory, key);
+  await clearClosedPrivateHistory();
+  expect(await privateHistory.allKeys.getValue()).toEqual([key]);
+
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => []);
+  await clearClosedPrivateHistory();
+  await capture(privateHistory, key);
+  expect(await privateHistory.allKeys.getValue()).toBeNull();
+  expect(await privateHistory.recentKeys.getValue()).toBeNull();
+  expect(await privateHistory.recentKeysByDomain.getValue()).toBeNull();
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+
+  vi.mocked(browser.windows.getAll).mockImplementation(async () => [privateWindow]);
+  expect(await privateHistory.allKeys.getValue()).toBeNull();
+  await capture(privateHistory, key);
+  expect(await privateHistory.allKeys.getValue()).toEqual([key]);
+});
+
+test.each([true, false])(
+  'selects popup history using the window incognito flag %s',
+  async (incognito) => {
+    vi.spyOn(browser.windows, 'getCurrent').mockImplementation(async () => ({
+      ...privateWindow,
+      incognito,
+    }));
+    await initializePopupHistory();
+    expect(popup.popupHistory.allKeys).toBe(
+      incognito ? privateHistory.allKeys : appStorage.allKeys,
+    );
+  },
+);

--- a/test/extension-runtime-background.test.ts
+++ b/test/extension-runtime-background.test.ts
@@ -230,6 +230,49 @@ test('clears private history on the last window removal', async () => {
   await expect.poll(() => privateHistory.allKeys.getValue()).toBeNull();
 });
 
+test('clears the closed private session when a replacement window opens during a history write', async () => {
+  const privateWindow = { id: 1, incognito: true, focused: true, alwaysOnTop: false };
+  const windows = vi
+    .spyOn(browser.windows, 'getAll')
+    .mockImplementation(async () => [privateWindow]);
+  const onRemoved = vi.spyOn(browser.windows.onRemoved, 'addListener');
+  start();
+  const key = {
+    id: widevineId,
+    value: 'usable',
+    url: 'https://example.com/private',
+    pssh: '',
+    createdAt: 1,
+  };
+  await appStorage.allKeys.add(key);
+  await privateHistory.recentKeys.setForUrl(key.url, [key]);
+  const writeStarted = Promise.withResolvers<void>();
+  const releaseWrite = Promise.withResolvers<void>();
+  const setValue = privateHistory.allKeys.raw.setValue;
+  vi.spyOn(privateHistory.allKeys.raw, 'setValue').mockImplementationOnce(async (records) => {
+    writeStarted.resolve();
+    await releaseWrite.promise;
+    await setValue(records);
+  });
+  const writing = privateHistory.allKeys.add(key);
+  await writeStarted.promise;
+  try {
+    windows.mockImplementation(async () => []);
+    onRemoved.mock.calls[0]![0](privateWindow.id);
+    windows.mockImplementation(async () => [{ ...privateWindow, id: 2 }]);
+  } finally {
+    releaseWrite.resolve();
+  }
+  await writing;
+  await expect.poll(() => privateHistory.allKeys.getValue()).toBeNull();
+  expect(await privateHistory.recentKeys.getValue()).toBeNull();
+  expect(await privateHistory.recentKeysByDomain.getValue()).toBeNull();
+  expect(await appStorage.allKeys.getValue()).toEqual([key]);
+
+  await privateHistory.allKeys.add({ ...key, createdAt: 2 });
+  expect(await privateHistory.allKeys.getValue()).toEqual([{ ...key, createdAt: 2 }]);
+});
+
 test('does not show ordinary same-site keys on a private tab badge', async () => {
   await appStorage.recentKeys.setForUrl('https://example.com/public', [
     {

--- a/test/extension-runtime-background.test.ts
+++ b/test/extension-runtime-background.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { browser, type Browser } from 'wxt/browser';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { getCaptureUrl } from '../src/extension/utils/capture-url';
-import { appStorage, defaultSettings, getRecentKeysForUrl } from '../src/extension/utils/storage';
+import {
+  appStorage,
+  defaultSettings,
+  getRecentKeysForUrl,
+  privateHistory,
+} from '../src/extension/utils/storage';
 import background from '../src/extension/entrypoints/background';
 import { createPsshBox, psshBoxToBase64, PSSH_SYSTEM_IDS } from '../src/lib/pssh';
 
@@ -160,4 +165,85 @@ test.each([
   expect(
     getRecentKeysForUrl(expectedUrl, await appStorage.recentKeysByDomain.getValue(), []),
   ).toEqual(history);
+});
+
+test.each(['keystatuseschange', 'update'])(
+  'routes private %s captures using sender metadata',
+  async (action) => {
+    vi.spyOn(browser.windows, 'getAll').mockImplementation(async () => [
+      {
+        id: 1,
+        incognito: true,
+        focused: true,
+        alwaysOnTop: false,
+      },
+    ]);
+    await appStorage.settings.setValue(defaultSettings);
+    const localBefore = await browser.storage.local.get(null);
+    const send = start();
+    const license = new TextEncoder().encode(
+      JSON.stringify({
+        keys: [{ kty: 'oct', kid: 'AAAAAAAAAAAAAAAAAAAAAA', k: 'AQEBAQEBAQEBAQEBAQEBAQ' }],
+      }),
+    );
+    const message = {
+      action,
+      keySystem: 'org.w3.clearkey',
+      initData: '',
+      message: Object.fromEntries(license.entries()),
+      keyStatuses: { AAAAAAAAAAAAAAAAAAAAAA: 'usable' },
+      incognito: false,
+    };
+    await send(message, {
+      tab: { ...tab, incognito: true, url: 'https://example.com/private' },
+      url: 'https://example.com/private',
+      frameId: 0,
+    });
+    expect(await privateHistory.allKeys.getValue()).toEqual([
+      expect.objectContaining({ url: 'https://example.com/private' }),
+    ]);
+    expect(await privateHistory.recentKeys.getValue()).toEqual(
+      await privateHistory.allKeys.getValue(),
+    );
+    expect(await browser.storage.local.get(null)).toEqual(localBefore);
+    expect(await appStorage.allKeys.getValue()).toBeNull();
+  },
+);
+
+test('clears private history on the last window removal', async () => {
+  const windows = vi
+    .spyOn(browser.windows, 'getAll')
+    .mockImplementation(async () => [
+      { id: 1, incognito: true, focused: true, alwaysOnTop: false },
+    ]);
+  const onRemoved = vi.spyOn(browser.windows.onRemoved, 'addListener');
+  start();
+  await privateHistory.allKeys.add({
+    id: widevineId,
+    value: 'usable',
+    url: 'https://example.com/private',
+    pssh: '',
+    createdAt: 1,
+  });
+  windows.mockImplementation(async () => []);
+  onRemoved.mock.calls[0]![0](1);
+  await expect.poll(() => privateHistory.allKeys.getValue()).toBeNull();
+});
+
+test('does not show ordinary same-site keys on a private tab badge', async () => {
+  await appStorage.recentKeys.setForUrl('https://example.com/public', [
+    {
+      id: widevineId,
+      value: '1'.repeat(32),
+      url: 'https://example.com/public',
+      pssh: '',
+      createdAt: 1,
+    },
+  ]);
+  vi.mocked(browser.tabs.query).mockImplementation(async () => [
+    { ...tab, incognito: true, url: 'https://example.com/private' },
+  ]);
+  const setBadgeText = vi.spyOn(browser.action, 'setBadgeText');
+  start();
+  await expect.poll(() => setBadgeText.mock.calls).toContainEqual([{ tabId: tab.id, text: '' }]);
 });


### PR DESCRIPTION
## Summary
- Store private-window history and recent captures separately in session storage.
- Route popup views, badges, exports, and deletion through the current browsing mode.
- Clear private history when the last private window closes and cover the behavior with tests.

## Testing
- Not run.