### PR TITLE
fix(serve): harden server access boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,34 +207,25 @@ Pass the original text without XML escaping. Remote clients accept the same
 
 ### Remote sessions
 
-`POST /sessions` accepts `keySystem` and an optional `client`. Without a client,
-the server selects the first authorized device for that DRM system. An explicit
-client must match the requested system.
+Start a local API with your device file and a secret of your choice:
 
-Wait for each session mutation to finish before starting another; overlapping
-requests return HTTP 409. Requests for different sessions can run concurrently.
-
-`okova serve` reads `okova.config.json` in the current directory and uses defaults
-if that file is absent. An explicit `--config <path>` must be readable. Malformed
-JSON or invalid settings stop startup before the server opens a listening socket.
-
-The server limits sessions and concurrent requests across all users and devices.
-In `okova.config.json`, optional `sessionLimits` fields override these defaults:
-
-```json
-{
-  "sessionLimits": {
-    "maxSessions": 64,
-    "maxConcurrentRequests": 64,
-    "idleTimeoutMs": 300000,
-    "keyWaitTimeoutMs": 30000
-  }
-}
+```sh
+okova serve --client client.wvd --secret 'replace-with-your-secret'
 ```
 
-Limits must be positive integers. Exceeding session or request limits returns
-HTTP 503. Idle sessions expire and must be recreated. Waiting for keys beyond
-`keyWaitTimeoutMs` returns HTTP 504.
+The API is available at `http://127.0.0.1:4000`. Create a session:
+
+```sh
+curl http://127.0.0.1:4000/sessions \
+  -H 'Content-Type: application/json' \
+  -H 'x-secret-key: replace-with-your-secret' \
+  -d '{"keySystem":"com.widevine.alpha"}'
+```
+
+For anonymous access, replace `--secret ...` with `--public`.
+
+See the [remote client example](examples/remote-session) to request licenses and
+keys.
 
 ### Inspect, edit, and convert PSSH boxes
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ curl http://127.0.0.1:4000/sessions \
   -d '{"keySystem":"com.widevine.alpha"}'
 ```
 
-For anonymous access, replace `--secret ...` with `--public`.
+For anonymous access, replace `--secret ...` with `--public` and remove the
+`x-secret-key` header from the curl command.
 
 See the [remote client example](examples/remote-session) to request licenses and
 keys.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ Start a local API with your device file and a secret of your choice:
 okova serve --client client.wvd --secret 'replace-with-your-secret'
 ```
 
-The API is available at `http://127.0.0.1:4000`. Create a session:
+The API uses the host and port from `okova.config.json`, defaulting to
+`http://127.0.0.1:4000`. Create a session using your server address:
 
 ```sh
 curl http://127.0.0.1:4000/sessions \

--- a/examples/instance/okova.config.json
+++ b/examples/instance/okova.config.json
@@ -1,5 +1,5 @@
 {
-  "host": "0.0.0.0",
+  "host": "127.0.0.1",
   "port": 4000,
   "clients": ["Pixel_10_Pro_L3.wvd"],
   "users": {

--- a/src/cli/commands/serve/api/session.ts
+++ b/src/cli/commands/serve/api/session.ts
@@ -40,8 +40,6 @@ app.use(async (c, next) => {
   }
 });
 
-app.use(requestBody);
-
 const reserveSession = createMiddleware(async (c, next) => {
   const release = sessions.reserve();
   if (!release) return c.json({ error: 'Session capacity reached' }, 503);
@@ -80,6 +78,7 @@ const exclusiveSessionMutation = createMiddleware(async (c, next) => {
 
 app.post(
   '/',
+  requestBody,
   reserveSession,
   zValidator(
     'json',
@@ -173,6 +172,7 @@ app.post(
 
 app.post(
   '/:id/generate-request',
+  requestBody,
   exclusiveSessionMutation,
   zValidator('param', z.object({ id: z.string() })),
   zValidator(
@@ -266,6 +266,7 @@ app.post(
 
 app.post(
   '/:id/update',
+  requestBody,
   exclusiveSessionMutation,
   zValidator('param', z.object({ id: z.string() })),
   zValidator('json', z.object({ response: base64 })),

--- a/src/cli/commands/serve/api/session.ts
+++ b/src/cli/commands/serve/api/session.ts
@@ -10,6 +10,7 @@ import { WidevineDeviceCredentials } from '../../../../lib/widevine/device-crede
 import { PlayReadyDeviceCredentials } from '../../../../lib/playready/device-credentials';
 import { clients, config, resolveClient, sessions } from '../state';
 import { normalizeKeySystem } from '../../../../lib/key-system';
+import { requestBody } from '../request-boundary';
 import { WidevineSession } from '../../../../lib/widevine/session';
 
 const app = new Hono();
@@ -17,12 +18,11 @@ const SESSION_MESSAGE_TIMEOUT_MS = 5_000;
 const SESSION_UPDATE_SYNC_TIMEOUT_MS = 250;
 
 const secretKeyMiddleware = createMiddleware(async (c, next) => {
-  // If no users are configured, allow public access
-  const isPublic = Object.keys(config.users).length === 0;
-  const isSecretRequired = !isPublic;
-
   const secretKey = c.req.header('x-secret-key');
-  if (isSecretRequired && !secretKey) {
+  if (secretKey && !Object.hasOwn(config.users, secretKey)) {
+    return c.json({ error: 'Invalid secret key' }, 403);
+  }
+  if (!secretKey && !config.public) {
     return c.json({ error: 'No secret key provided' }, 403);
   }
 
@@ -40,6 +40,8 @@ app.use(async (c, next) => {
   }
 });
 
+app.use(requestBody);
+
 const reserveSession = createMiddleware(async (c, next) => {
   const release = sessions.reserve();
   if (!release) return c.json({ error: 'Session capacity reached' }, 503);
@@ -49,6 +51,14 @@ const reserveSession = createMiddleware(async (c, next) => {
     release();
   }
 });
+
+const base64 = z
+  .base64()
+  .min(1)
+  .refine(
+    (value) => Buffer.from(value, 'base64').toString('base64') === value,
+    'Expected canonical padded base64',
+  );
 
 const busySessions = new WeakSet<Session>();
 
@@ -169,8 +179,8 @@ app.post(
     'json',
     z.object({
       initDataType: z.string().optional(),
-      initData: z.string(),
-      serverCertificate: z.base64().min(1).optional(),
+      initData: base64,
+      serverCertificate: base64.optional(),
     }),
   ),
   async (c) => {
@@ -258,7 +268,7 @@ app.post(
   '/:id/update',
   exclusiveSessionMutation,
   zValidator('param', z.object({ id: z.string() })),
-  zValidator('json', z.object({ response: z.string() })),
+  zValidator('json', z.object({ response: base64 })),
   async (c) => {
     const secretKey = c.req.header('x-secret-key') as string;
     const sessionId = c.req.valid('param').id;

--- a/src/cli/commands/serve/help.ts
+++ b/src/cli/commands/serve/help.ts
@@ -4,12 +4,13 @@ export const help = () => {
   console.log(`okova serve: Run your API instance\n`);
   console.log(`Usage: okova serve [...flags]\n`);
   console.log(`Flags:`);
-  console.log(col(`--host`) + 'server host (default: 0.0.0.0)');
+  console.log(col(`--host`) + 'server host (default: 127.0.0.1)');
   console.log(col(`--port`) + 'server port (default: 4000)');
   console.log(col(`--config`) + 'path to config file (default: okova.config.json)');
   console.log(
     col(`-c, --client`) + 'path to client (.wvd/.prd file or directory with credential files)',
   );
   console.log(col(`-s, --secret`) + 'secret key to access API endpoints');
+  console.log(col(`--public`) + 'explicitly allow anonymous API access');
   console.log(col(`-h, --help`) + 'display this menu and exit');
 };

--- a/src/cli/commands/serve/request-boundary.ts
+++ b/src/cli/commands/serve/request-boundary.ts
@@ -1,0 +1,70 @@
+import { createMiddleware } from 'hono/factory';
+import { cors } from 'hono/cors';
+import { config } from './state';
+
+// Validate the authority before comparing Origin, so rebinding cannot supply both.
+export const requestBoundary = createMiddleware(async (c, next) => {
+  const url = new URL(c.req.url);
+  const hostname = config.host === '::1' ? '[::1]' : config.host;
+  const hosts = config.allowedHosts.length
+    ? config.allowedHosts
+    : ['127.0.0.1', '[::1]', 'localhost'].includes(hostname)
+      ? ['127.0.0.1', '[::1]', 'localhost']
+      : [hostname];
+  const host = c.req.header('host');
+  if (!hosts.includes(url.hostname) || !host || host.toLowerCase() !== url.host) {
+    return c.json({ error: 'Host is not allowed' }, 403);
+  }
+  const origin = c.req.header('origin');
+  if (
+    config.allowedOrigins !== null &&
+    origin !== undefined &&
+    origin !== url.origin &&
+    !config.allowedOrigins.includes(origin)
+  ) {
+    return c.json({ error: 'Origin is not allowed' }, 403);
+  }
+  return cors({
+    origin: config.allowedOrigins === null ? '*' : (origin ?? ''),
+    allowMethods: ['GET', 'POST', 'DELETE'],
+    allowHeaders: ['Content-Type', 'X-Secret-Key'],
+  })(c, next);
+});
+
+// Count actual bytes, including chunked bodies, before JSON parsing or device work.
+export const requestBody = createMiddleware(async (c, next) => {
+  const needsJson = c.req.method === 'POST' && !c.req.path.endsWith('/close');
+  if (needsJson && !/^application\/json(?:\s*;|$)/i.test(c.req.header('content-type') ?? '')) {
+    return c.json({ error: 'Content-Type must be application/json' }, 415);
+  }
+  const contentEncoding = c.req.header('content-encoding');
+  if (contentEncoding && contentEncoding.toLowerCase() !== 'identity') {
+    return c.json({ error: 'Content-Encoding is not supported' }, 415);
+  }
+  const limit = config.maxRequestBodyBytes;
+  const length = c.req.header('content-length');
+  if (length !== undefined && (!/^\d+$/.test(length) || Number(length) > limit)) {
+    return c.json({ error: 'Request body is too large or Content-Length is invalid' }, 413);
+  }
+  if (c.req.raw.body) {
+    const reader = c.req.raw.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let sizeBytes = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        sizeBytes += value.byteLength;
+        if (sizeBytes > limit) {
+          void reader.cancel().catch(() => {});
+          return c.json({ error: 'Request body is too large' }, 413);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    c.req.raw = new Request(c.req.raw, { body: Buffer.concat(chunks, sizeBytes) });
+  }
+  await next();
+});

--- a/src/cli/commands/serve/request-boundary.ts
+++ b/src/cli/commands/serve/request-boundary.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net';
 import { createMiddleware } from 'hono/factory';
 import { cors } from 'hono/cors';
 import { config } from './state';
@@ -5,7 +6,10 @@ import { config } from './state';
 // Validate the authority before comparing Origin, so rebinding cannot supply both.
 export const requestBoundary = createMiddleware(async (c, next) => {
   const url = new URL(c.req.url);
-  const hostname = config.host === '::1' ? '[::1]' : config.host;
+  const hostname =
+    isIP(config.host) === 6
+      ? new URL(`http://[${config.host}]`).hostname
+      : config.host.toLowerCase();
   const hosts = config.allowedHosts.length
     ? config.allowedHosts
     : ['127.0.0.1', '[::1]', 'localhost'].includes(hostname)
@@ -31,10 +35,10 @@ export const requestBoundary = createMiddleware(async (c, next) => {
   })(c, next);
 });
 
+// Attach only to JSON routes; close and delete must not wait for unused uploads.
 // Count actual bytes, including chunked bodies, before JSON parsing or device work.
 export const requestBody = createMiddleware(async (c, next) => {
-  const needsJson = c.req.method === 'POST' && !c.req.path.endsWith('/close');
-  if (needsJson && !/^application\/json(?:\s*;|$)/i.test(c.req.header('content-type') ?? '')) {
+  if (!/^application\/json(?:\s*;|$)/i.test(c.req.header('content-type') ?? '')) {
     return c.json({ error: 'Content-Type must be application/json' }, 415);
   }
   const contentEncoding = c.req.header('content-encoding');

--- a/src/cli/commands/serve/serve.ts
+++ b/src/cli/commands/serve/serve.ts
@@ -8,6 +8,7 @@ import { serve as nodeServe } from '@hono/node-server';
 import { help } from './help';
 import { config, loadConfig, sessions } from './state';
 import session from './api/session';
+import { requestBoundary } from './request-boundary';
 
 type ServeOptions = {
   host?: string;
@@ -15,6 +16,7 @@ type ServeOptions = {
   config?: string;
   client?: string;
   secret?: string;
+  public?: boolean;
 };
 
 export const serve = async (options: ServeOptions = {}) => {
@@ -27,10 +29,25 @@ export const serve = async (options: ServeOptions = {}) => {
   }
   if (options.secret) {
     const anonymousUser = { name: 'anonymous', clients: [] };
-    const user = config.users[options.secret] || anonymousUser;
+    const user = Object.hasOwn(config.users, options.secret)
+      ? config.users[options.secret]!
+      : anonymousUser;
     const clientPath = options.client ?? config.clients.at(-1);
     if (!user.clients.length && clientPath) user.clients.push(resolve(clientPath));
-    config.users[options.secret] = user;
+    config.users = { ...config.users, [options.secret]: user };
+  }
+
+  config.public = options.public ?? config.public;
+  config.host = options.host ?? config.host;
+  if (!config.public && !Object.keys(config.users).length) {
+    throw new Error(
+      'Configure users or --secret, or explicitly enable anonymous access with --public',
+    );
+  }
+  if (['0.0.0.0', '::'].includes(config.host) && !config.allowedHosts.length) {
+    throw new Error(
+      'Wildcard binding requires allowedHosts with the names or IP addresses clients use',
+    );
   }
 
   const app = new Hono();
@@ -52,6 +69,8 @@ export const serve = async (options: ServeOptions = {}) => {
   app.use(logger());
   app.use(secureHeaders());
 
+  app.use(requestBoundary);
+
   app.route('/sessions', session);
 
   showRoutes(app);
@@ -59,7 +78,7 @@ export const serve = async (options: ServeOptions = {}) => {
   const server = nodeServe({
     fetch: app.fetch,
     port: options.port ?? config.port ?? 4000,
-    hostname: options.host ?? config.host ?? '0.0.0.0',
+    hostname: config.host,
   });
 
   const shutdown = () => {

--- a/src/cli/commands/serve/state.ts
+++ b/src/cli/commands/serve/state.ts
@@ -8,11 +8,50 @@ import { SessionRegistry, sessionLimitsSchema } from './session-registry';
 export const clients = new Map<string, WidevineDeviceCredentials | PlayReadyDeviceCredentials>();
 
 const configSchema = z.strictObject({
-  host: z.string().min(1).default('0.0.0.0'),
+  host: z.string().min(1).default('127.0.0.1'),
+  public: z.boolean().default(false),
+  maxRequestBodyBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(64 * 1024 * 1024)
+    .default(1024 * 1024),
+  allowedHosts: z
+    .array(
+      z
+        .string()
+        .min(1)
+        .refine((host) => {
+          try {
+            const url = new URL(`http://${host}`);
+            return (
+              /^[a-z0-9._-]+$|^\[[0-9a-f:]+\]$/.test(host) &&
+              url.host === host &&
+              url.hostname === host
+            );
+          } catch {
+            return false;
+          }
+        }, 'Expected a lowercase hostname or bracketed IPv6 address without a port'),
+    )
+    .default([]),
+  allowedOrigins: z
+    .array(
+      z.string().refine((origin) => {
+        try {
+          const url = new URL(origin);
+          return ['http:', 'https:'].includes(url.protocol) && url.origin === origin;
+        } catch {
+          return false;
+        }
+      }, 'Expected an HTTP(S) origin without a trailing slash'),
+    )
+    .optional()
+    .transform((origins) => origins ?? null),
   port: z.number().int().min(0).max(65535).default(4000),
   clients: z.array(z.string().min(1)).default([]),
   users: z
-    .record(z.string(), z.strictObject({ name: z.string(), clients: z.array(z.string()) }))
+    .record(z.string().min(1), z.strictObject({ name: z.string(), clients: z.array(z.string()) }))
     .default({}),
   forcePrivacyMode: z.boolean().default(true),
   sessionLimits: sessionLimitsSchema.strict().prefault({}),

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -50,6 +50,7 @@ const main = async () => {
         host: { type: 'string' },
         port: { type: 'string' },
         secret: { type: 'string', short: 's' },
+        public: { type: 'boolean' },
         config: { type: 'string' },
         client: { type: 'string', short: 'c' },
       });

--- a/test/integration/playready-custom-data.test.ts
+++ b/test/integration/playready-custom-data.test.ts
@@ -109,6 +109,7 @@ test('helper sends the configured custom data in the license request', async () 
 test('remote API keeps custom data separate for sessions sharing credentials', async () => {
   config.clients = ['custom-data.prd'];
   config.users = {};
+  config.public = true;
   config.forcePrivacyMode = false;
   clients.set(resolve('custom-data.prd'), deviceCredentials);
   const app = new Hono().route('/sessions', sessionApi);
@@ -165,6 +166,7 @@ test.each([
 test('remote capacity applies across separate PlayReady engines', async () => {
   config.clients = ['capacity.prd'];
   config.users = {};
+  config.public = true;
   config.sessionLimits = { ...originalConfig.sessionLimits, maxSessions: 16 };
   clients.set(resolve('capacity.prd'), deviceCredentials);
   const responses = await Promise.all(

--- a/test/integration/privacy.test.ts
+++ b/test/integration/privacy.test.ts
@@ -23,6 +23,7 @@ const app = new Hono().route('/sessions', sessionApi);
 beforeEach(async () => {
   config.clients = ['test.wvd'];
   config.users = {};
+  config.public = true;
   config.forcePrivacyMode = true;
   clients.set(resolve('test.wvd'), await loadWidevineDeviceCredentials());
 });

--- a/test/integration/serve-devices.test.ts
+++ b/test/integration/serve-devices.test.ts
@@ -20,6 +20,7 @@ beforeEach(async () => {
   await writeFile(clientPath, await loadWidevineClientData());
   config.clients = [relative(process.cwd(), clientPath)];
   config.users = {};
+  config.public = true;
 });
 
 afterEach(async () => {

--- a/test/serve-config.test.ts
+++ b/test/serve-config.test.ts
@@ -25,6 +25,9 @@ test('only a missing implicit configuration uses defaults', async () => {
     process.chdir(directories[0]!);
     await loadConfig();
     expect(config.port).toBe(4000);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.public).toBe(false);
+    expect(config.maxRequestBodyBytes).toBe(1024 * 1024);
     expect(config.clients).toEqual([]);
     await writeFile('okova.config.json', '{');
     await expect(loadConfig()).rejects.toThrow('Invalid server config');
@@ -46,13 +49,15 @@ test.each(['{', 'null', '[]', '{"port":"4000"}', '{"clients":false}'])(
 
 test('loading a new config resets omitted settings to defaults', async () => {
   const path = await setup();
-  await writeFile(path, JSON.stringify({ port: 1234, clients: ['test.wvd'] }));
+  await writeFile(path, JSON.stringify({ port: 1234, clients: ['test.wvd'], allowedOrigins: [] }));
   await loadConfig(path);
   expect(config.port).toBe(1234);
+  expect(config.allowedOrigins).toEqual([]);
   await writeFile(path, '{}');
   await loadConfig(path);
   expect(config.port).toBe(4000);
   expect(config.clients).toEqual([]);
+  expect(config.allowedOrigins).toBeNull();
 });
 
 test.each([
@@ -65,4 +70,22 @@ test.each([
   await writeFile(path, JSON.stringify(data));
   await expect(loadConfig(path)).rejects.toThrow('Unrecognized key');
   expect(config).toEqual(before);
+});
+
+test.each([
+  { public: 'true' },
+  { maxRequestBodyBytes: 0 },
+  { maxRequestBodyBytes: 1.5 },
+  { maxRequestBodyBytes: 64 * 1024 * 1024 + 1 },
+  { allowedHosts: ['*'] },
+  { allowedHosts: ['localhost:4000'] },
+  { allowedHosts: ['user@localhost'] },
+  { allowedOrigins: ['null'] },
+  { allowedOrigins: ['*'] },
+  { allowedOrigins: ['https://example.com/'] },
+  { users: { '': { name: 'test', clients: [] } } },
+])('rejects invalid security settings %j', async (data) => {
+  const path = await setup();
+  await writeFile(path, JSON.stringify(data));
+  await expect(loadConfig(path)).rejects.toThrow('Invalid server config');
 });

--- a/test/serve-hardening.test.ts
+++ b/test/serve-hardening.test.ts
@@ -153,37 +153,43 @@ test('limits declared and actual body bytes before session creation', async () =
   expect(sessions.size).toBe(1);
 });
 
-test('bounds chunked requests through the Node HTTP adapter', async () => {
-  config.maxRequestBodyBytes = 2;
-  const server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 });
-  try {
-    if (!server.listening) await once(server, 'listening');
-    const address = server.address();
-    if (!address || typeof address === 'string') throw new Error('Missing TCP address');
-    const status = await new Promise<number | undefined>((resolve, reject) => {
-      const req = request(
-        {
-          hostname: '127.0.0.1',
-          port: address.port,
-          path: '/sessions',
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-        },
-        (res) => {
-          res.resume();
-          res.on('end', () => resolve(res.statusCode));
-        },
-      );
-      req.on('error', reject);
-      req.write('{}');
-      req.end(' ');
-    });
-    expect(status).toBe(413);
-    expect(sessions.size).toBe(0);
-  } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
-});
+test.each([
+  { suffix: '', status: 200 },
+  { suffix: ' ', status: 413 },
+])(
+  'handles chunked bodies through the Node HTTP adapter: %j',
+  async ({ suffix, status: expectedStatus }) => {
+    config.maxRequestBodyBytes = 2;
+    const server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 });
+    try {
+      if (!server.listening) await once(server, 'listening');
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Missing TCP address');
+      const status = await new Promise<number | undefined>((resolve, reject) => {
+        const req = request(
+          {
+            hostname: '127.0.0.1',
+            port: address.port,
+            path: '/sessions',
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+          },
+          (res) => {
+            res.resume();
+            res.on('end', () => resolve(res.statusCode));
+          },
+        );
+        req.on('error', reject);
+        req.write('{}');
+        req.end(suffix);
+      });
+      expect(status).toBe(expectedStatus);
+      expect(sessions.size).toBe(expectedStatus === 200 ? 1 : 0);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  },
+);
 
 test.each(['', '!', 'AQ', 'AQ=', 'AR==', 'AQ==\n', 'AQ==garbage', 'AA-_', 'AA==='])(
   'rejects invalid base64 %j before device operations',
@@ -241,6 +247,85 @@ test('explicit hosts replace defaults and forwarded headers cannot bypass the bo
           'x-forwarded-host': 'api.example:4000',
           forwarded: 'host=api.example:4000',
         },
+        body: '{}',
+      })
+    ).status,
+  ).toBe(403);
+});
+
+test.each(['::2', 'fe80::1', '2001:DB8:0:0:0:0:0:1', '::ffff:192.0.2.1'])(
+  'accepts the configured IPv6 bind address %s',
+  async (host) => {
+    config.host = host;
+    const url = new URL(`http://[${host}]:4000/sessions`);
+    expect(
+      (
+        await app.request(url.href, {
+          method: 'POST',
+          headers: { host: url.host, 'content-type': 'application/json' },
+          body: '{}',
+        })
+      ).status,
+    ).toBe(200);
+  },
+);
+
+test.each(['close', 'delete'])(
+  '%s completes without waiting for an unused body and releases its request slot',
+  async (operation) => {
+    const opened = await post();
+    const { id } = await opened.json();
+    config.sessionLimits.maxConcurrentRequests = 1;
+    const server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 });
+    let upload: ReturnType<typeof request> | undefined;
+    try {
+      if (!server.listening) await once(server, 'listening');
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Missing TCP address');
+      const status = await new Promise<number | undefined>((resolve, reject) => {
+        upload = request(
+          {
+            hostname: '127.0.0.1',
+            port: address.port,
+            path: `/sessions/${id}${operation === 'close' ? '/close' : ''}`,
+            method: operation === 'close' ? 'POST' : 'DELETE',
+            headers: { 'content-type': 'application/json', 'transfer-encoding': 'chunked' },
+          },
+          (response) => {
+            response.resume();
+            response.on('end', () => resolve(response.statusCode));
+          },
+        );
+        upload.on('error', reject);
+        upload.setTimeout(1000, () => upload?.destroy(new Error('Handler waited for unused body')));
+        upload.write('{');
+      });
+      expect(status).toBe(200);
+      expect(sessions.size).toBe(0);
+      expect((await post()).status).toBe(200);
+    } finally {
+      upload?.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  },
+);
+
+test.each([
+  { configured: 'CDM.Example.COM', hostname: 'cdm.example.com' },
+  { configured: 'LOCALHOST', hostname: '127.0.0.1' },
+])('normalizes the configured DNS host $configured', async ({ configured, hostname }) => {
+  config.host = configured;
+  const response = await app.request(`http://${hostname}:4000/sessions`, {
+    method: 'POST',
+    headers: { host: `${hostname}:4000`, 'content-type': 'application/json' },
+    body: '{}',
+  });
+  expect(response.status).toBe(200);
+  expect(
+    (
+      await app.request('http://untrusted.example:4000/sessions', {
+        method: 'POST',
+        headers: { host: 'untrusted.example:4000', 'content-type': 'application/json' },
         body: '{}',
       })
     ).status,

--- a/test/serve-hardening.test.ts
+++ b/test/serve-hardening.test.ts
@@ -1,0 +1,248 @@
+import { once } from 'node:events';
+import { request } from 'node:http';
+import { resolve } from 'node:path';
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import sessionApi from '../src/cli/commands/serve/api/session';
+import { requestBoundary } from '../src/cli/commands/serve/request-boundary';
+import { clients, config, sessions } from '../src/cli/commands/serve/state';
+import { Widevine } from '../src/lib/widevine/engine';
+import { WidevineDeviceCredentials } from '../src/lib/widevine/device-credentials';
+import {
+  ClientIdentification,
+  DrmCertificate,
+  SignedDrmCertificate,
+} from '../src/lib/widevine/proto';
+
+const originalConfig = structuredClone(config);
+const app = new Hono().use(requestBoundary).route('/sessions', sessionApi);
+const credentials = new WidevineDeviceCredentials(
+  ClientIdentification.create({
+    token: SignedDrmCertificate.encode(
+      SignedDrmCertificate.create({
+        drmCertificate: DrmCertificate.encode(DrmCertificate.create({ systemId: 1 })).finish(),
+      }),
+    ).finish(),
+  }),
+);
+
+beforeEach(() => {
+  config.public = true;
+  config.clients = ['test.wvd'];
+  clients.set(resolve('test.wvd'), credentials);
+});
+
+afterEach(async () => {
+  await sessions.clear();
+  clients.clear();
+  Object.assign(config, structuredClone(originalConfig));
+  vi.restoreAllMocks();
+});
+
+const post = (headers: Record<string, string> = {}, body = '{}', path = '/sessions') =>
+  app.request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { host: 'localhost', 'content-type': 'application/json', ...headers },
+    body,
+  });
+
+test.each(['text/plain', 'application/x-www-form-urlencoded', 'multipart/form-data', ''])(
+  'rejects session creation with content type %j before creating a session',
+  async (type) => {
+    const create = vi.spyOn(Widevine.prototype, 'createSession');
+    expect((await post({ 'content-type': type })).status).toBe(415);
+    expect(create).not.toHaveBeenCalled();
+    expect(sessions.size).toBe(0);
+  },
+);
+
+test('public JSON access is explicit and unknown keys never fall back to anonymous', async () => {
+  config.public = false;
+  expect((await post()).status).toBe(403);
+  config.users = { secret: { name: 'test', clients: ['test.wvd'] } };
+  expect((await post({ 'x-secret-key': 'secret' })).status).toBe(200);
+  config.public = true;
+  expect((await post()).status).toBe(200);
+  for (const secret of ['unknown', 'toString', '__proto__']) {
+    expect((await post({ 'x-secret-key': secret })).status).toBe(403);
+    expect(
+      (
+        await app.request('http://localhost/sessions/missing/keys', {
+          headers: { host: 'localhost', 'x-secret-key': secret },
+        })
+      ).status,
+    ).toBe(403);
+  }
+});
+
+test('an explicit empty allowlist rejects cross-origin requests and untrusted hosts', async () => {
+  config.allowedOrigins = [];
+  expect(
+    (await post({ origin: 'https://evil.example', 'content-type': 'text/plain' })).status,
+  ).toBe(403);
+  expect((await post({ origin: 'null' })).status).toBe(403);
+  expect((await post({ host: 'evil.example' })).status).toBe(403);
+  expect(
+    (
+      await app.request('http://evil.example/sessions', {
+        method: 'POST',
+        headers: {
+          host: 'evil.example',
+          origin: 'http://evil.example',
+          'content-type': 'application/json',
+        },
+        body: '{}',
+      })
+    ).status,
+  ).toBe(403);
+  expect(sessions.size).toBe(0);
+  expect((await post({ origin: 'http://localhost' })).status).toBe(200);
+});
+
+test.each([
+  { isPublic: false, isRestricted: false },
+  { isPublic: true, isRestricted: false },
+  { isPublic: false, isRestricted: true },
+  { isPublic: true, isRestricted: true },
+])('browser access preserves authentication with %j', async ({ isPublic, isRestricted }) => {
+  config.public = isPublic;
+  config.users = { secret: { name: 'test', clients: ['test.wvd'] } };
+  if (isRestricted) config.allowedOrigins = ['https://dashboard.example'];
+  const origin = 'https://dashboard.example';
+  const preflight = await app.request('http://localhost/sessions', {
+    method: 'OPTIONS',
+    headers: {
+      host: 'localhost',
+      origin,
+      'access-control-request-method': 'POST',
+      'access-control-request-headers': 'content-type,x-secret-key',
+    },
+  });
+  expect(preflight.status).toBe(204);
+  const allowedOrigin = isRestricted ? origin : '*';
+  expect(preflight.headers.get('access-control-allow-origin')).toBe(allowedOrigin);
+  expect(sessions.size).toBe(0);
+  const anonymous = await post({ origin });
+  expect(anonymous.status).toBe(isPublic ? 200 : 403);
+  const authenticated = await post({ origin, 'x-secret-key': 'secret' });
+  expect(authenticated.status).toBe(200);
+  expect(authenticated.headers.get('access-control-allow-origin')).toBe(allowedOrigin);
+  expect((await post({ origin: 'https://evil.example', 'x-secret-key': 'secret' })).status).toBe(
+    isRestricted ? 403 : 200,
+  );
+});
+
+test('unrestricted origins include null while JSON content types are still required', async () => {
+  const response = await post({ origin: 'null' });
+  expect(response.status).toBe(200);
+  expect(response.headers.get('access-control-allow-origin')).toBe('*');
+  expect((await post({ origin: 'https://example.com', 'content-type': 'text/plain' })).status).toBe(
+    415,
+  );
+  expect(sessions.size).toBe(1);
+});
+
+test('limits declared and actual body bytes before session creation', async () => {
+  config.maxRequestBodyBytes = 2;
+  expect((await post({}, '{}')).status).toBe(200);
+  expect((await post({}, '{} ')).status).toBe(413);
+  expect((await post({ 'content-length': '3' }, '{}')).status).toBe(413);
+  expect((await post({ 'content-length': '1' }, '{} ')).status).toBe(413);
+  expect((await post({ 'content-encoding': 'gzip' })).status).toBe(415);
+  expect(sessions.size).toBe(1);
+});
+
+test('bounds chunked requests through the Node HTTP adapter', async () => {
+  config.maxRequestBodyBytes = 2;
+  const server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 });
+  try {
+    if (!server.listening) await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing TCP address');
+    const status = await new Promise<number | undefined>((resolve, reject) => {
+      const req = request(
+        {
+          hostname: '127.0.0.1',
+          port: address.port,
+          path: '/sessions',
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', () => resolve(res.statusCode));
+        },
+      );
+      req.on('error', reject);
+      req.write('{}');
+      req.end(' ');
+    });
+    expect(status).toBe(413);
+    expect(sessions.size).toBe(0);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test.each(['', '!', 'AQ', 'AQ=', 'AR==', 'AQ==\n', 'AQ==garbage', 'AA-_', 'AA==='])(
+  'rejects invalid base64 %j before device operations',
+  async (value) => {
+    const opened = await post();
+    const { id } = await opened.json();
+    const session = sessions.get(`:${id}`);
+    if (!session) throw new Error('Missing session');
+    const generate = vi.spyOn(session, 'generateRequest');
+    const update = vi.spyOn(session, 'update');
+    const certificate = vi.spyOn(session.engine, 'setServerCertificate');
+    expect(
+      (await post({}, JSON.stringify({ initData: value }), `/sessions/${id}/generate-request`))
+        .status,
+    ).toBe(400);
+    expect(
+      (
+        await post(
+          {},
+          JSON.stringify({ initData: 'AQ==', serverCertificate: value }),
+          `/sessions/${id}/generate-request`,
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (await post({}, JSON.stringify({ response: value }), `/sessions/${id}/update`)).status,
+    ).toBe(400);
+    expect(generate).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(certificate).not.toHaveBeenCalled();
+  },
+);
+
+test('explicit hosts replace defaults and forwarded headers cannot bypass the boundary', async () => {
+  config.host = '0.0.0.0';
+  config.allowedHosts = ['api.example'];
+  const headers = { host: 'api.example:4000', 'content-type': 'application/json' };
+  expect(
+    (
+      await app.request('http://api.example:4000/sessions', {
+        method: 'POST',
+        headers,
+        body: '{}',
+      })
+    ).status,
+  ).toBe(200);
+  expect((await post()).status).toBe(403);
+  expect(
+    (
+      await app.request('http://evil.example:4000/sessions', {
+        method: 'POST',
+        headers: {
+          ...headers,
+          host: 'evil.example:4000',
+          'x-forwarded-host': 'api.example:4000',
+          forwarded: 'host=api.example:4000',
+        },
+        body: '{}',
+      })
+    ).status,
+  ).toBe(403);
+});

--- a/test/serve-session-concurrency.test.ts
+++ b/test/serve-session-concurrency.test.ts
@@ -37,6 +37,7 @@ const originalConfig = structuredClone(config);
 
 beforeEach(() => {
   config.users = {};
+  config.public = true;
   config.forcePrivacyMode = false;
 });
 
@@ -82,6 +83,7 @@ test('rejects a second challenge and allows a retry with its own initialization 
     expect(generateSpy).toHaveBeenCalledOnce();
 
     // Another user can use even the same session ID while this request is pending.
+    config.users['other-user'] = { name: 'other', clients: [] };
     openSession('session', 'other-user');
     expect((await request('generate-request', 'Aw==', 'session', 'other-user')).status).toBe(200);
   } finally {

--- a/test/serve-session-limits.test.ts
+++ b/test/serve-session-limits.test.ts
@@ -29,6 +29,7 @@ const credentials = new WidevineDeviceCredentials(
 beforeEach(() => {
   config.clients = ['test.wvd'];
   config.users = {};
+  config.public = true;
   config.forcePrivacyMode = false;
   config.sessionLimits = sessionLimitsSchema.parse({ maxSessions: 2, idleTimeoutMs: 1000 });
   clients.set(resolve('test.wvd'), credentials);

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -38,6 +38,7 @@ test.each([true, false])('binds using CLI overrides when supplied: %s', async (h
       clients: ['clients/client.wvd'],
       sessionLimits: { maxSessions: 3 },
       users: {},
+      public: true,
     }),
   );
 
@@ -118,6 +119,7 @@ test.each([false, true])(
           port: 0,
           clients: [clientPath],
           users: {},
+          public: true,
         }),
       );
       await serve({ config: configPath });
@@ -185,6 +187,25 @@ test.each([false, true])(
         }
       }
       vi.restoreAllMocks();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each([{}, { host: '0.0.0.0', public: true }, { host: '::', public: true }])(
+  'rejects unsafe startup before opening a socket: %j',
+  async (settings) => {
+    const directory = await mkdtemp(join(tmpdir(), 'okova-startup-'));
+    const path = join(directory, 'config.json');
+    const originalConfig = structuredClone(config);
+    const startServer = vi.mocked(nodeServer.serve);
+    startServer.mockClear();
+    try {
+      await writeFile(path, JSON.stringify(settings));
+      await expect(serve({ config: path })).rejects.toThrow();
+      expect(startServer).not.toHaveBeenCalled();
+    } finally {
+      Object.assign(config, originalConfig);
       await rm(directory, { recursive: true, force: true });
     }
   },

--- a/test/session-close.test.ts
+++ b/test/session-close.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import app from '../src/cli/commands/serve/api/session';
-import { sessions } from '../src/cli/commands/serve/state';
+import { config, sessions } from '../src/cli/commands/serve/state';
 import { Session } from '../src/lib/api';
 import { EccKey } from '../src/lib/crypto/ecc-key';
 import { Key } from '../src/lib/playready/key';
@@ -14,6 +14,8 @@ import {
   SignedDrmCertificate,
 } from '../src/lib/widevine/proto';
 import { WidevineSession } from '../src/lib/widevine/session';
+
+const originalConfig = structuredClone(config);
 
 const KEY_ID = '00112233445566778899aabbccddeeff';
 const KEY = 'ffeeddccbbaa99887766554433221100';
@@ -68,6 +70,7 @@ const createSession = (kind: string) => {
 
 afterEach(async () => {
   await sessions.clear();
+  Object.assign(config, structuredClone(originalConfig));
   vi.restoreAllMocks();
 });
 
@@ -76,6 +79,7 @@ for (const kind of ['widevine', 'playready']) {
     '%s releases a ' + kind + ' session and rejects subsequent HTTP operations',
     async (operation) => {
       const { session, native, engine } = createSession(kind);
+      config.users = { owner: { name: 'owner', clients: [] } };
       const sessionKey = `owner:${session.sessionId}`;
       sessions.set(sessionKey, session);
       const headers = { 'x-secret-key': 'owner', 'content-type': 'application/json' };


### PR DESCRIPTION
## Summary

- Bind the server to localhost by default and require explicit opt-in for public access.
- Validate hosts, origins, request bodies, content types, and base64 payloads at the request boundary.
- Add configuration controls and comprehensive hardening tests for authentication, limits, and startup safety.
- Update serve documentation and examples for the new access requirements.

## Testing

- Added and updated Vitest coverage for server hardening, configuration validation, request limits, host/origin checks, authentication, and session behavior.