### PR TITLE
fix(playready): support XML canonicalization

### DIFF
--- a/docs/playready-compatibility.md
+++ b/docs/playready-compatibility.md
@@ -20,29 +20,38 @@ The ExtData signature covers the complete HWID object, including its header and 
 
 `extdata.json` covers HWID lengths 0 through 4, including all padding lengths. Each size has a valid certificate and one with an altered ExtData signature. The outer certificate is signed after that alteration, so rejecting it proves that ExtData verification ran. Tests also require byte-for-byte certificate roundtrips and compare the reconstructed HWID signature payload to the independently built bytes. The PRD integration test covers the corrected layout with a locally provisioned certificate.
 
-## XML canonicalization investigation
+## XML canonicalization
 
-`PlayReadySession.#verifySignedLicenseResponse` hashes and verifies `XMLSerializer.serializeToString` output. The previous tests generated signatures through that same serializer. They could establish internal consistency but could not establish C14N interoperability.
+`PlayReadySession.#verifySignedLicenseResponse` now canonicalizes the attached `LicenseResponse` and `SignedInfo` subtrees before hashing and signature verification. Previously, it used `XMLSerializer.serializeToString`, and the tests generated signatures through that same serializer. Those tests established internal consistency but missed C14N interoperability defects.
 
 `xml-signatures.json` stores the input XML, independently canonicalized LicenseResponse and SignedInfo bytes, digest, and signature. The tests verify the stored bytes with Okova's real SHA-256 and ECDSA implementations before exercising `parseLicense`. Only certificate-chain resolution and trust are substituted with the synthetic public key. These tests do not establish Microsoft certificate-chain trust or production server compatibility.
 
 The fixtures use inclusive [Canonical XML 1.0 without comments](https://www.w3.org/TR/2001/REC-xml-c14n-20010315). That algorithm expands empty elements, sorts namespaces and attributes, includes in-scope namespaces, converts CDATA to text, and omits comments. Each case isolates one difference:
 
-| Case                        | Current result     | Cause                                                      |
-| --------------------------- | ------------------ | ---------------------------------------------------------- |
-| Canonical baseline          | Accepted           | Serialized bytes already match C14N                        |
-| Empty LicenseResponse child | Digest mismatch    | Serializer emits a self-closing element                    |
-| Attribute order             | Digest mismatch    | Serializer preserves input order                           |
-| Inherited default namespace | Digest mismatch    | Serializer appends the namespace after `Id`                |
-| Unused inherited namespace  | Digest mismatch    | Inclusive C14N includes the namespace; serializer omits it |
-| CDATA                       | Digest mismatch    | Serializer preserves the CDATA section                     |
-| Comment                     | Digest mismatch    | Serializer retains the comment                             |
-| Empty SignedInfo method     | Signature mismatch | Response digest passes; serializer self-closes the method  |
+| Case                        | Result   | Canonicalization behavior                              |
+| --------------------------- | -------- | ------------------------------------------------------ |
+| Canonical baseline          | Accepted | Bytes already match C14N                               |
+| Empty LicenseResponse child | Accepted | Expands self-closing elements                          |
+| Attribute order             | Accepted | Sorts attributes by namespace URI and local name       |
+| Inherited default namespace | Accepted | Emits namespace declarations before attributes         |
+| Unused inherited namespace  | Accepted | Includes all in-scope namespaces                       |
+| CDATA                       | Accepted | Emits escaped text                                     |
+| Comment                     | Accepted | Omits comments                                         |
+| Empty SignedInfo method     | Accepted | Canonicalizes SignedInfo before signature verification |
 
-Whitespace inside the baseline method elements prevents xmldom from self-closing them. The SignedInfo case removes that whitespace from one method before canonicalization and signing. All eight signatures are cryptographically valid over their recorded C14N bytes. The rejection assertions document the current compatibility limits, not desired long-term behavior.
+All eight signatures are cryptographically valid over their recorded C14N bytes and now pass `parseLicense`. Each fixture also checks rejection of altered response content and signature bytes. `test/playready-xml-c14n.test.ts` covers namespace resets and rebinding, inherited `xml:*` attributes, Unicode ordering, character escaping, line endings, processing instructions, and preservation of the input DOM.
 
-The generator materializes inherited namespaces by serializing and reparsing each subtree before C14N. With the installed libxml2 2.14.6, directly canonicalizing a nested subtree produced spurious `xmlns=""` declarations on deeper descendants. These fixtures have no inherited `xml:*` attributes; they do not test that separate C14N rule.
+The generator materializes inherited namespaces by serializing and reparsing each subtree before C14N. With the installed libxml2 2.14.6, directly canonicalizing a nested subtree produced spurious `xmlns=""` declarations on deeper descendants. These signed fixtures have no inherited `xml:*` attributes; the separate canonicalization tests cover that rule with expected bytes from the specification.
 
 The reference implementations do not resolve the standards question. `pyplayready/license/license.py` uses ElementTree serialization with `short_empty_elements=False`; `PlayreadyProxy2/jsplayready/cdm.js` constructs challenge XML strings. Neither provides an independent C14N verifier.
 
-The investigation confirms a response-verification compatibility gap. A follow-up implementation should select canonicalization from an explicitly supported algorithm, bind the Reference URI to the exact response being consumed, and apply the declared digest transforms. It should turn the documented rejection cases into acceptance tests while preserving tamper rejection. Blindly changing serialization or trying multiple byte representations would leave those protocol decisions unresolved. This change fixes ExtData and records the XML evidence; it does not add C14N support or establish canonicalization behavior for outgoing challenges.
+### Supported signature profile
+
+- `CanonicalizationMethod` must select inclusive C14N 1.0 without comments. Exclusive C14N, C14N 1.1, and variants with comments are rejected.
+- One `Reference` must identify the exact consumed `LicenseResponse` by its nonempty, document-unique `Id`. External, empty, mismatched, or ambiguous references are rejected.
+- An absent `Transforms` uses the XMLDSig default node-set conversion, C14N 1.0. One explicit C14N 1.0 transform is also supported. Other transforms, parameters, or transform sequences are rejected.
+- Digest verification supports SHA-256 through the PlayReady protocol URI or `http://www.w3.org/2001/04/xmlenc#sha256`. Signature verification supports ECDSA-SHA256 through the PlayReady protocol URI or `http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256`.
+- Signature fields must be direct children in the XMLDSig namespace. A present but incomplete signature is rejected. Responses with no signature retain the existing unsigned-response behavior.
+- Documents with a DTD are rejected because the parser does not provide the validating attribute and entity processing C14N requires. Relative namespace URIs are also rejected.
+
+Certificate-chain trust and XMR integrity verification remain in place. These offline fixtures establish canonicalization interoperability, not production server compatibility. Outgoing challenge generation is outside this change.

--- a/src/lib/playready/session.ts
+++ b/src/lib/playready/session.ts
@@ -40,6 +40,10 @@ import { InvalidLicense } from './exceptions';
 import { ServerException } from './exceptions';
 import { Pssh } from './pssh';
 import { WrmHeader } from './wrmheader';
+import { C14N_ALGORITHM, canonicalizeXml } from './xml-c14n';
+
+const XML_SIGNATURE_NAMESPACE = 'http://www.w3.org/2000/09/xmldsig#';
+const PLAYREADY_PROTOCOL = 'http://schemas.microsoft.com/DRM/2007/03/protocols';
 
 const DEFAULT_CLIENT_VERSION = '10.0.16384.10011';
 
@@ -65,6 +69,20 @@ const requireDirectChild = (parent: Element, localName: string) => {
     throw new InvalidLicense(`Expected one ${localName} in ${getLocalName(parent)}`);
   }
   return children[0]!;
+};
+
+const requireSignatureChild = (parent: Element, localName: string) => {
+  const child = requireDirectChild(parent, localName);
+  if (child.namespaceURI !== XML_SIGNATURE_NAMESPACE) {
+    throw new InvalidLicense(`Invalid namespace for ${localName}`);
+  }
+  return child;
+};
+
+const requireAlgorithm = (element: Element, algorithms: string[]) => {
+  if (!algorithms.includes(element.getAttribute('Algorithm') ?? '') || element.children.length) {
+    throw new InvalidLicense(`Unsupported ${getLocalName(element)} algorithm or parameters`);
+  }
 };
 
 type PlayReadySessionCredentials =
@@ -378,6 +396,7 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     } catch {
       throw new InvalidLicense('Invalid license response XML');
     }
+    if (xmlDoc.doctype) throw new InvalidLicense('License response DTD is not supported');
     this.#throwIfSoapFault(xmlDoc);
     let root = xmlDoc.documentElement;
     if (root && getLocalName(root) === 'Envelope') {
@@ -390,7 +409,7 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     const result = requireDirectChild(root, 'AcquireLicenseResult');
     const response = requireDirectChild(result, 'Response');
     const licenseResponse = requireDirectChild(response, 'LicenseResponse');
-    await this.#verifySignedLicenseResponse(response);
+    await this.#verifySignedLicenseResponse(response, licenseResponse);
     this.assertOpen();
     const licenses = findDirectChildByLocalName(licenseResponse, 'Licenses');
     const licenseElements = licenses
@@ -492,31 +511,64 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     throw new ServerException(faultString);
   }
 
-  async #verifySignedLicenseResponse(responseElement: Element) {
-    const licenseResponseElement = findDirectChildByLocalName(responseElement, 'LicenseResponse');
-    const signatureElement = findDirectChildByLocalName(responseElement, 'Signature');
-    if (!licenseResponseElement || !signatureElement) return;
-
-    const signingCertificateChainValue = findFirstDescendantByLocalName(
+  async #verifySignedLicenseResponse(responseElement: Element, licenseResponseElement: Element) {
+    if (!findDirectChildByLocalName(responseElement, 'Signature')) return;
+    const signatureElement = requireSignatureChild(responseElement, 'Signature');
+    const signedInfoElement = requireSignatureChild(signatureElement, 'SignedInfo');
+    requireAlgorithm(requireSignatureChild(signedInfoElement, 'CanonicalizationMethod'), [
+      C14N_ALGORITHM,
+    ]);
+    requireAlgorithm(requireSignatureChild(signedInfoElement, 'SignatureMethod'), [
+      `${PLAYREADY_PROTOCOL}#ecdsa-sha256`,
+      'http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256',
+    ]);
+    const reference = requireSignatureChild(signedInfoElement, 'Reference');
+    const responseId = licenseResponseElement.getAttribute('Id');
+    const matchingIds = Array.from(
+      licenseResponseElement.ownerDocument?.getElementsByTagName('*') ?? [],
+    ).filter((element) =>
+      Array.from(element.attributes).some(
+        (attribute) =>
+          attribute.localName?.toLowerCase() === 'id' && attribute.value === responseId,
+      ),
+    );
+    if (
+      !responseId ||
+      reference.getAttribute('URI') !== `#${responseId}` ||
+      matchingIds.length !== 1 ||
+      matchingIds[0] !== licenseResponseElement
+    ) {
+      throw new InvalidLicense('Reference must identify the unique LicenseResponse Id');
+    }
+    requireAlgorithm(requireSignatureChild(reference, 'DigestMethod'), [
+      `${PLAYREADY_PROTOCOL}#sha256`,
+      'http://www.w3.org/2001/04/xmlenc#sha256',
+    ]);
+    // A same-document reference is a node-set. XMLDSig defaults its conversion
+    // to C14N 1.0; an explicit transform must select that same supported algorithm.
+    if (findDirectChildByLocalName(reference, 'Transforms')) {
+      const transforms = requireSignatureChild(reference, 'Transforms');
+      const transform = requireSignatureChild(transforms, 'Transform');
+      if (transforms.children.length !== 1) {
+        throw new InvalidLicense('Unsupported digest transform sequence');
+      }
+      requireAlgorithm(transform, [C14N_ALGORITHM]);
+    }
+    const signingCertificateChainValue = requireDirectChild(
       licenseResponseElement,
       'SigningCertificateChain',
-    )?.textContent?.trim();
-    const signedInfoElement = findFirstDescendantByLocalName(signatureElement, 'SignedInfo');
-    const digestValue = findFirstDescendantByLocalName(
-      signatureElement,
-      'DigestValue',
-    )?.textContent?.trim();
-    const signatureValue = findFirstDescendantByLocalName(
+    ).textContent?.trim();
+    const digestValue = requireSignatureChild(reference, 'DigestValue').textContent?.trim();
+    const signatureValue = requireSignatureChild(
       signatureElement,
       'SignatureValue',
-    )?.textContent?.trim();
-
-    if (!signingCertificateChainValue || !signedInfoElement || !digestValue || !signatureValue) {
-      return;
+    ).textContent?.trim();
+    if (!signingCertificateChainValue || !digestValue || !signatureValue) {
+      throw new InvalidLicense('Incomplete license response signature');
     }
 
-    const serializedLicenseResponse = this.serializer.serializeToString(licenseResponseElement);
-    const responseHash = await createSha256(fromText(serializedLicenseResponse).toBuffer());
+    const canonicalLicenseResponse = canonicalizeXml(licenseResponseElement);
+    const responseHash = await createSha256(fromText(canonicalLicenseResponse).toBuffer());
     if (!compareArrays(responseHash, base64ToBytes(digestValue))) {
       throw new InvalidLicense('Digest mismatch in license');
     }
@@ -533,10 +585,10 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
     uncompressedPublicKey[0] = 0x04;
     uncompressedPublicKey.set(signingKey, 1);
 
-    const serializedSignedInfo = this.serializer.serializeToString(signedInfoElement);
+    const canonicalSignedInfo = canonicalizeXml(signedInfoElement);
     const isValidSignature = await ecc256Verify(
       uncompressedPublicKey,
-      fromText(serializedSignedInfo).toBuffer(),
+      fromText(canonicalSignedInfo).toBuffer(),
       base64ToBytes(signatureValue),
     );
 

--- a/src/lib/playready/xml-c14n.ts
+++ b/src/lib/playready/xml-c14n.ts
@@ -1,0 +1,111 @@
+import type { Attr, Element, Node } from '@xmldom/xmldom';
+import { InvalidLicense } from './exceptions';
+
+export const C14N_ALGORITHM = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
+const XML_NAMESPACE = 'http://www.w3.org/XML/1998/namespace';
+const XMLNS_NAMESPACE = 'http://www.w3.org/2000/xmlns/';
+
+const isElement = (node: Node): node is Element => node.nodeType === 1;
+
+// C14N orders by Unicode code point, without locale collation or UTF-16 ordering.
+const compareNames = (left: string, right: string) => {
+  const leftPoints = Array.from(left, (char) => char.codePointAt(0)!);
+  const rightPoints = Array.from(right, (char) => char.codePointAt(0)!);
+  for (let index = 0; index < Math.min(leftPoints.length, rightPoints.length); index++) {
+    const difference = leftPoints[index]! - rightPoints[index]!;
+    if (difference) return difference;
+  }
+  return leftPoints.length - rightPoints.length;
+};
+
+const escapeText = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('\r', '&#xD;');
+
+const escapeAttribute = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\t', '&#x9;')
+    .replaceAll('\n', '&#xA;')
+    .replaceAll('\r', '&#xD;');
+
+/** Inclusive C14N 1.0 without comments for a complete element subtree.
+ * Keep the element attached so ancestor namespaces and xml:* attributes are available.
+ * DTD-dependent documents are unsupported by the license parser.
+ */
+export const canonicalizeXml = (root: Element) => {
+  const ancestors: Element[] = [];
+  for (let parent = root.parentNode; parent && isElement(parent); parent = parent.parentNode) {
+    ancestors.unshift(parent);
+  }
+  const inheritedNamespaces = new Map<string, string>();
+  const inheritedAttributes = new Map<string, Attr>();
+  for (const ancestor of ancestors) {
+    for (const attribute of Array.from(ancestor.attributes)) {
+      if (attribute.namespaceURI === XMLNS_NAMESPACE) {
+        inheritedNamespaces.set(
+          attribute.name === 'xmlns' ? '' : attribute.localName!,
+          attribute.value,
+        );
+      } else if (attribute.namespaceURI === XML_NAMESPACE) {
+        inheritedAttributes.set(attribute.name, attribute);
+      }
+    }
+  }
+
+  const render = (
+    element: Element,
+    parentNamespaces: Map<string, string>,
+    renderedNamespaces: Map<string, string>,
+  ): string => {
+    const namespaces = new Map(parentNamespaces);
+    const attributes = element === root ? new Map(inheritedAttributes) : new Map<string, Attr>();
+    for (const attribute of Array.from(element.attributes)) {
+      if (attribute.namespaceURI === XMLNS_NAMESPACE) {
+        namespaces.set(attribute.name === 'xmlns' ? '' : attribute.localName!, attribute.value);
+      } else {
+        attributes.set(attribute.name, attribute);
+      }
+    }
+    let output = `<${element.tagName}`;
+    for (const [prefix, uri] of [...namespaces].sort((left, right) =>
+      compareNames(left[0], right[0]),
+    )) {
+      if (prefix === 'xml') continue;
+      if (uri && !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(uri)) {
+        throw new InvalidLicense('Relative namespace URI is not supported by C14N');
+      }
+      if (uri === (renderedNamespaces.get(prefix) ?? '')) continue;
+      output += ` ${prefix ? `xmlns:${prefix}` : 'xmlns'}="${escapeAttribute(uri)}"`;
+    }
+    const sortedAttributes = [...attributes.values()].sort(
+      (left, right) =>
+        compareNames(left.namespaceURI ?? '', right.namespaceURI ?? '') ||
+        compareNames(left.localName ?? left.name, right.localName ?? right.name),
+    );
+    for (const attribute of sortedAttributes) {
+      output += ` ${attribute.name}="${escapeAttribute(attribute.value)}"`;
+    }
+    output += '>';
+    for (const child of Array.from(element.childNodes)) {
+      if (isElement(child)) {
+        output += render(child, namespaces, namespaces);
+      } else if (child.nodeType === 3 || child.nodeType === 4) {
+        output += escapeText(child.nodeValue ?? '');
+      } else if (child.nodeType === 7) {
+        const data = (child.nodeValue ?? '').replaceAll('\r', '&#xD;');
+        output += `<?${child.nodeName}${data ? ` ${data}` : ''}?>`;
+      } else if (child.nodeType !== 8) {
+        throw new InvalidLicense('Unsupported XML node in C14N');
+      }
+    }
+    return `${output}</${element.tagName}>`;
+  };
+
+  return render(root, inheritedNamespaces, new Map());
+};

--- a/test/playready-compatibility.test.ts
+++ b/test/playready-compatibility.test.ts
@@ -1,4 +1,4 @@
-import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import { afterEach, assert, expect, test, vi } from 'vitest';
 import { createSha256, ecc256Verify } from '../src/lib/crypto/common';
 import { EccKey } from '../src/lib/crypto/ecc-key';
@@ -9,6 +9,8 @@ import {
   ExtDataHwidRecord,
 } from '../src/lib/playready/bcert';
 import { PlayReadySession } from '../src/lib/playready/session';
+import { InvalidLicense } from '../src/lib/playready/exceptions';
+import { C14N_ALGORITHM, canonicalizeXml } from '../src/lib/playready/xml-c14n';
 import extdata from './fixtures/playready/extdata.json';
 import signatures from './fixtures/playready/xml-signatures.json';
 
@@ -37,6 +39,27 @@ test.each(extdata.cases)(
   },
 );
 
+const createSignedSession = () => {
+  const chain = new CertificateChain({
+    signature: new TextEncoder().encode('CHAI'),
+    version: 1,
+    total_length: 20,
+    flags: 0,
+    certificate_count: 0,
+    certificates: [],
+  });
+  vi.spyOn(chain, 'verify').mockResolvedValue(true);
+  const certificate = Certificate.loads(Buffer.from(extdata.cases[0]!.certificate, 'base64'));
+  vi.spyOn(certificate, 'getKeyByUsage').mockReturnValue(Buffer.from(signatures.publicKey, 'hex'));
+  vi.spyOn(chain, 'get').mockReturnValue(certificate);
+  vi.spyOn(CertificateChain, 'from').mockReturnValue(chain);
+  return new PlayReadySession('temporary', {
+    certificateChain: new Uint8Array(),
+    encryptionKey: EccKey.generate().dumps(),
+    signingKey: EccKey.generate().dumps(),
+  });
+};
+
 test.each(signatures.cases)('independent C14N signature: $name', async (fixture) => {
   const publicKey = Buffer.from(signatures.publicKey, 'hex');
   // Verify the stored lxml canonical bytes using real SHA-256 and ECDSA in Okova.
@@ -53,43 +76,121 @@ test.each(signatures.cases)('independent C14N signature: $name', async (fixture)
     ),
   ).resolves.toBe(true);
 
-  const chain = new CertificateChain({
-    signature: new TextEncoder().encode('CHAI'),
-    version: 1,
-    total_length: 20,
-    flags: 0,
-    certificate_count: 0,
-    certificates: [],
-  });
-  vi.spyOn(chain, 'verify').mockResolvedValue(true);
-  const certificate = Certificate.loads(Buffer.from(extdata.cases[0]!.certificate, 'base64'));
-  vi.spyOn(certificate, 'getKeyByUsage').mockReturnValue(publicKey);
-  vi.spyOn(chain, 'get').mockReturnValue(certificate);
-  vi.spyOn(CertificateChain, 'from').mockReturnValue(chain);
-  const session = new PlayReadySession('temporary', {
-    certificateChain: new Uint8Array(),
-    encryptionKey: EccKey.generate().dumps(),
-    signingKey: EccKey.generate().dumps(),
-  });
+  const session = createSignedSession();
   const document = new DOMParser().parseFromString(fixture.xml, 'application/xml');
-  const serializer = new XMLSerializer();
   const response = document.getElementsByTagName('LicenseResponse')[0]!;
   const signedInfo = document.getElementsByTagName('SignedInfo')[0]!;
 
-  // Characterize the current compatibility boundary. These are valid C14N signatures;
-  // serializer-only verification rejects the cases that require canonicalization.
-  if (fixture.name === 'canonical') {
-    expect(serializer.serializeToString(response)).toBe(fixture.canonicalResponse);
-    expect(serializer.serializeToString(signedInfo)).toBe(fixture.canonicalSignedInfo);
-    await expect(session.parseLicense(fixture.xml)).resolves.toEqual([]);
-  } else if (fixture.name === 'signed-info-empty-element') {
-    expect(serializer.serializeToString(response)).toBe(fixture.canonicalResponse);
-    expect(serializer.serializeToString(signedInfo)).not.toBe(fixture.canonicalSignedInfo);
-    await expect(session.parseLicense(fixture.xml)).rejects.toThrow(
-      'Signature mismatch in license',
-    );
-  } else {
-    expect(serializer.serializeToString(response)).not.toBe(fixture.canonicalResponse);
-    await expect(session.parseLicense(fixture.xml)).rejects.toThrow('Digest mismatch in license');
-  }
+  expect(canonicalizeXml(response)).toBe(fixture.canonicalResponse);
+  expect(canonicalizeXml(signedInfo)).toBe(fixture.canonicalSignedInfo);
+  await expect(session.parseLicense(fixture.xml)).resolves.toEqual([]);
+  await expect(
+    session.parseLicense(fixture.xml.replace('<Version>', '<Version>2')),
+  ).rejects.toThrow('Digest mismatch in license');
+  await expect(
+    session.parseLicense(
+      fixture.xml.replace(fixture.signature, Buffer.alloc(64).toString('base64')),
+    ),
+  ).rejects.toThrow('Signature mismatch in license');
+});
+
+const baseline = signatures.cases[0]!;
+
+test.each([
+  ['canonicalization algorithm', 'CanonicalizationMethod', 'Algorithm', 'urn:unsupported'],
+  ['signature algorithm', 'SignatureMethod', 'Algorithm', 'urn:unsupported'],
+  ['digest algorithm', 'DigestMethod', 'Algorithm', 'urn:unsupported'],
+  ['wrong reference', 'Reference', 'URI', '#Other'],
+  ['external reference', 'Reference', 'URI', 'https://example.invalid/license'],
+  ['empty reference', 'Reference', 'URI', ''],
+  ['missing response Id', 'LicenseResponse', 'Id', ''],
+])('rejects %s', async (_name, tag, attribute, value) => {
+  const document = new DOMParser().parseFromString(baseline.xml, 'application/xml');
+  document.getElementsByTagName(tag)[0]!.setAttribute(attribute, value);
+  await expect(createSignedSession().parseLicense(document.toString())).rejects.toThrow(
+    InvalidLicense,
+  );
+});
+
+test.each([
+  [
+    'duplicate Id',
+    baseline.xml.replace('<Version>', '<Version Id="SignedData">'),
+    'Reference must identify',
+  ],
+  [
+    'duplicate signature',
+    baseline.xml.replace(
+      '</Response>',
+      baseline.xml.match(/<Signature .*?<\/Signature>/)![0] + '</Response>',
+    ),
+    'Expected one Signature',
+  ],
+  [
+    'duplicate reference',
+    baseline.xml.replace(
+      '</SignedInfo>',
+      baseline.xml.match(/<Reference .*?<\/Reference>/)![0] + '</SignedInfo>',
+    ),
+    'Expected one Reference',
+  ],
+  [
+    'missing method',
+    baseline.xml.replace(/<CanonicalizationMethod .*?<\/CanonicalizationMethod>/, ''),
+    'Expected one CanonicalizationMethod',
+  ],
+  [
+    'missing signature value',
+    baseline.xml.replace(/<SignatureValue>.*?<\/SignatureValue>/, ''),
+    'Expected one SignatureValue',
+  ],
+  [
+    'missing certificate chain',
+    baseline.xml.replace(/<SigningCertificateChain>.*?<\/SigningCertificateChain>/, ''),
+    'Expected one SigningCertificateChain',
+  ],
+  [
+    'empty signature value',
+    baseline.xml.replace(baseline.signature, ''),
+    'Incomplete license response signature',
+  ],
+  [
+    'wrong signature namespace',
+    baseline.xml.replace('http://www.w3.org/2000/09/xmldsig#', 'urn:wrong'),
+    'Invalid namespace',
+  ],
+  [
+    'unsupported transform',
+    baseline.xml.replace(
+      '<DigestMethod',
+      '<Transforms><Transform Algorithm="urn:unsupported"/></Transforms><DigestMethod',
+    ),
+    'Unsupported Transform',
+  ],
+  [
+    'empty transforms',
+    baseline.xml.replace('<DigestMethod', '<Transforms/><DigestMethod'),
+    'Expected one Transform',
+  ],
+  [
+    'transform parameters',
+    baseline.xml.replace(
+      '<DigestMethod',
+      `<Transforms><Transform Algorithm="${C14N_ALGORITHM}"><Parameter/></Transform></Transforms><DigestMethod`,
+    ),
+    'Unsupported Transform',
+  ],
+  [
+    'multiple transforms',
+    baseline.xml.replace(
+      '<DigestMethod',
+      `<Transforms><Transform Algorithm="${C14N_ALGORITHM}"/><Transform Algorithm="${C14N_ALGORITHM}"/></Transforms><DigestMethod`,
+    ),
+    'Expected one Transform',
+  ],
+  ['DTD', '<!DOCTYPE AcquireLicenseResponse>' + baseline.xml, 'DTD is not supported'],
+])('rejects %s before certificate verification', async (_name, xml, error) => {
+  const session = createSignedSession();
+  await expect(session.parseLicense(xml)).rejects.toThrow(error);
+  expect(CertificateChain.from).not.toHaveBeenCalled();
 });

--- a/test/playready-xml-c14n.test.ts
+++ b/test/playready-xml-c14n.test.ts
@@ -1,0 +1,60 @@
+import { DOMParser } from '@xmldom/xmldom';
+import { expect, test } from 'vitest';
+import { canonicalizeXml } from '../src/lib/playready/xml-c14n';
+
+// Expected bytes follow the rules and examples in W3C Canonical XML 1.0, sections 2 and 3.
+test.each([
+  {
+    name: 'namespace and attribute ordering by URI, then local name',
+    xml: '<root xmlns:z="urn:a" xmlns:a="urn:z"><target a:a="1" z:z="2" z:a="3" b="4" a="5"/></root>',
+    expected:
+      '<target xmlns:a="urn:z" xmlns:z="urn:a" a="5" b="4" z:a="3" z:z="2" a:a="1"></target>',
+  },
+  {
+    name: 'namespace reset, prefix rebinding, and sibling scope',
+    xml: '<root xmlns="urn:root" xmlns:p="urn:p"><target><empty xmlns=""/><p:child xmlns:p="urn:child"/><p:child/><same xmlns="urn:root"/></target></root>',
+    expected:
+      '<target xmlns="urn:root" xmlns:p="urn:p"><empty xmlns=""></empty><p:child xmlns:p="urn:child"></p:child><p:child></p:child><same></same></target>',
+  },
+  {
+    name: 'inherited xml attributes use nearest ancestor and root overrides',
+    xml: '<root xml:lang="en" xml:space="preserve" xml:base="https://example.org/"><inner xml:lang="de"><target xml:space="default"><child/></target></inner></root>',
+    expected:
+      '<target xml:base="https://example.org/" xml:lang="de" xml:space="default"><child></child></target>',
+  },
+  {
+    name: 'character references, CDATA, and XML line endings',
+    xml: '<target attr="&quot;&amp;&lt;>&#x9;&#xA;&#xD;\t\r\n">&lt;&amp;&gt;&#xD;\r\n<![CDATA[<&>]]></target>',
+    expected:
+      '<target attr="&quot;&amp;&lt;>&#x9;&#xA;&#xD;  ">&lt;&amp;&gt;&#xD;\n&lt;&amp;&gt;</target>',
+  },
+  {
+    name: 'comments omitted, processing instructions and whitespace preserved',
+    xml: '<target> \n<!--comment--><?empty?><?data hello?> text </target>',
+    expected: '<target> \n<?empty?><?data hello?> text </target>',
+  },
+  {
+    name: 'empty default namespace and explicit xml namespace are omitted',
+    xml: '<root xmlns="urn:root"><target xmlns="" xmlns:xml="http://www.w3.org/XML/1998/namespace"/></root>',
+    expected: '<target></target>',
+  },
+  {
+    name: 'namespace URIs sorted by Unicode code points',
+    xml: '<target xmlns:a="urn:\u{10000}" xmlns:b="urn:\uE000" a:a="1" b:b="2"/>',
+    expected: '<target xmlns:a="urn:\u{10000}" xmlns:b="urn:\uE000" b:b="2" a:a="1"></target>',
+  },
+])('$name', ({ xml, expected }) => {
+  const document = new DOMParser().parseFromString(xml, 'application/xml');
+  const target = document.getElementsByTagName('target')[0]!;
+  const original = document.toString();
+  expect(canonicalizeXml(target)).toBe(expected);
+  expect(document.toString()).toBe(original);
+});
+
+test('rejects relative namespace URIs', () => {
+  const document = new DOMParser().parseFromString(
+    '<target xmlns:p="relative"/>',
+    'application/xml',
+  );
+  expect(() => canonicalizeXml(document.documentElement!)).toThrow('Relative namespace URI');
+});

--- a/test/playready.test.ts
+++ b/test/playready.test.ts
@@ -11,6 +11,7 @@ import { InvalidLicense, ServerException, TooManySessions } from '../src/lib/pla
 import { Key } from '../src/lib/playready/key';
 import { DEFAULT_REVOCATION_LIST_IDS } from '../src/lib/playready/revocation-info';
 import { PlayReadySession } from '../src/lib/playready/session';
+import { canonicalizeXml, C14N_ALGORITHM } from '../src/lib/playready/xml-c14n';
 import { XmrLicense } from '../src/lib/playready/xmr-license';
 
 afterEach(() => {
@@ -62,18 +63,25 @@ const buildSignedLicenseResponse = async (
   options: {
     digestValue?: string;
     signatureValue?: string;
+    transform?: string;
   } = {},
 ) => {
   const xml = [
     '<AcquireLicenseResponse xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols">',
     '<AcquireLicenseResult><Response>',
-    '<LicenseResponse>',
+    '<LicenseResponse Id="SignedData">',
     '<Version>1</Version>',
     '<SigningCertificateChain>AA==</SigningCertificateChain>',
     '</LicenseResponse>',
     '<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">',
     '<SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">',
+    `<CanonicalizationMethod Algorithm="${C14N_ALGORITHM}"/>`,
+    '<SignatureMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#ecdsa-sha256"/>',
     '<Reference URI="#SignedData">',
+    options.transform
+      ? `<Transforms><Transform Algorithm="${options.transform}"/></Transforms>`
+      : '',
+    '<DigestMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#sha256"/>',
     '<DigestValue></DigestValue>',
     '</Reference>',
     '</SignedInfo>',
@@ -94,9 +102,7 @@ const buildSignedLicenseResponse = async (
   const digestValue =
     options.digestValue ??
     serializeToBase64(
-      await common.createSha256(
-        new TextEncoder().encode(serializer.serializeToString(licenseResponseElement)),
-      ),
+      await common.createSha256(new TextEncoder().encode(canonicalizeXml(licenseResponseElement))),
     );
   digestValueElement.textContent = digestValue;
 
@@ -106,7 +112,7 @@ const buildSignedLicenseResponse = async (
       (
         await common.ecc256Sign(
           signingKey.privateKey,
-          new TextEncoder().encode(serializer.serializeToString(signedInfoElement)),
+          new TextEncoder().encode(canonicalizeXml(signedInfoElement)),
         )
       ).toCompactRawBytes(),
     );
@@ -369,24 +375,27 @@ test('playready parseLicense raises server exceptions for SOAP faults', async ()
   ).rejects.toThrowError(new ServerException('License server failure'));
 });
 
-test('playready parseLicense verifies signed license responses before key extraction', async () => {
-  const session = new PlayReadySession('temporary', {
-    certificateChain: new Uint8Array(),
-    encryptionKey: EccKey.generate().dumps(),
-    signingKey: EccKey.generate().dumps(),
-  });
-  const responseSigningKey = EccKey.generate();
-  const certificateChainSpy = vi.spyOn(CertificateChain, 'from').mockReturnValue({
-    verify: vi.fn().mockResolvedValue(true),
-    get: vi.fn().mockReturnValue({
-      getKeyByUsage: vi.fn().mockReturnValue(responseSigningKey.publicBytes()),
-    }),
-  } as unknown as CertificateChain);
-  const licenseResponse = await buildSignedLicenseResponse(responseSigningKey);
+test.each([undefined, C14N_ALGORITHM])(
+  'playready verifies signed responses with transform %s',
+  async (transform) => {
+    const session = new PlayReadySession('temporary', {
+      certificateChain: new Uint8Array(),
+      encryptionKey: EccKey.generate().dumps(),
+      signingKey: EccKey.generate().dumps(),
+    });
+    const responseSigningKey = EccKey.generate();
+    const certificateChainSpy = vi.spyOn(CertificateChain, 'from').mockReturnValue({
+      verify: vi.fn().mockResolvedValue(true),
+      get: vi.fn().mockReturnValue({
+        getKeyByUsage: vi.fn().mockReturnValue(responseSigningKey.publicBytes()),
+      }),
+    } as unknown as CertificateChain);
+    const licenseResponse = await buildSignedLicenseResponse(responseSigningKey, { transform });
 
-  await expect(session.parseLicense(licenseResponse)).resolves.toEqual([]);
-  expect(certificateChainSpy).toHaveBeenCalledTimes(1);
-});
+    await expect(session.parseLicense(licenseResponse)).resolves.toEqual([]);
+    expect(certificateChainSpy).toHaveBeenCalledTimes(1);
+  },
+);
 
 test('playready parseLicense rejects signed license responses with digest mismatches', async () => {
   const session = new PlayReadySession('temporary', {


### PR DESCRIPTION
## Summary

- Add inclusive XML C14N 1.0 canonicalization for PlayReady license response signatures.
- Validate signature algorithms, references, transforms, namespaces, DTDs, and response IDs.
- Expand compatibility documentation and add canonicalization, interoperability, and tamper-resistance coverage.

## Testing

- Added PlayReady XML canonicalization and signed-license compatibility tests.
- Added coverage for namespace handling, attribute ordering, escaping, transforms, malformed signatures, DTDs, and tampering.
- Not run.