### PR TITLE
fix(cli): harden license and server reliability

### DIFF
--- a/src/cli/commands/license/help.ts
+++ b/src/cli/commands/license/help.ts
@@ -11,7 +11,7 @@ export const help = () => {
   console.log(`Flags:`);
   console.log(
     col(`-H, --header`) +
-      'headers to send with license request, compatible with curl (e.g. -H "Authorization: Bearer ...")',
+      'unique HTTP headers to send with the license request (e.g. -H "Authorization: Bearer ...")',
   );
   console.log(col(`-p, --pssh`) + 'Widevine or PlayReady PSSH data in Base64');
   console.log(
@@ -20,7 +20,7 @@ export const help = () => {
   );
   console.log(
     col(`-e, --encrypt`) +
-      'encrypt Widevine client ID using a service certificate from the license URL',
+      'encrypt Widevine client ID using a service certificate from the license URL; shares the 30-second acquisition deadline',
   );
   console.log(col(`-h, --help`) + 'display this menu and exit');
 };

--- a/src/cli/commands/license/license.ts
+++ b/src/cli/commands/license/license.ts
@@ -1,3 +1,4 @@
+import { validateHeaderValue } from 'node:http';
 import { help } from './help';
 import { importClientCredentials } from '../../utils';
 import { fetchDecryptionKeys, PlayReady, Widevine, toBufferSource } from '../../../lib';
@@ -12,24 +13,38 @@ type LicenseCommandParams = {
 };
 
 export const license = async (params: LicenseCommandParams) => {
-  const headers = Object.fromEntries(
-    params.headers?.map((header) => {
-      const separator = header.indexOf(':');
-      if (separator === -1) return [header.trim()];
-      return [header.slice(0, separator).trim(), header.slice(separator + 1).trim()];
-    }) || [],
-  );
+  const parsedHeaders = new Headers();
+  for (const [index, header] of (params.headers ?? []).entries()) {
+    const separator = header.indexOf(':');
+    const name = header.slice(0, separator).trim();
+    if (separator < 1 || !name || /[\r\n\0]/.test(header)) {
+      throw new Error(`Invalid header argument ${index + 1}: expected Name: value`);
+    }
+    try {
+      if (parsedHeaders.has(name)) {
+        throw new Error('duplicate');
+      }
+      const value = header.slice(separator + 1).trim();
+      validateHeaderValue(name, value);
+      parsedHeaders.set(name, value);
+    } catch {
+      throw new Error(`Invalid or duplicate header name in argument ${index + 1}`);
+    }
+  }
+  const headers = Object.fromEntries(parsedHeaders);
   const credentials = await importClientCredentials(params.credentialsPath || process.cwd());
   const cdm =
     credentials instanceof WidevineClientCredentials
       ? new Widevine({ clientCredentials: credentials })
       : new PlayReady({ clientCredentials: credentials });
+  const signal = AbortSignal.timeout(30_000);
   if (params.encrypt) {
     if (!(cdm instanceof Widevine)) {
       throw new Error('--encrypt is supported only for Widevine');
     }
     const response = await fetch(params.url, {
       method: 'POST',
+      signal,
       headers,
       body: toBufferSource(new Uint8Array([0x08, 0x04])),
     });
@@ -44,6 +59,7 @@ export const license = async (params: LicenseCommandParams) => {
     cdm,
     pssh: params.pssh,
     server: params.url,
+    signal,
     headers,
   });
   for (const [keyId, key] of keys) {

--- a/src/cli/commands/serve/api/session.ts
+++ b/src/cli/commands/serve/api/session.ts
@@ -1,3 +1,11 @@
+import { SessionInputError } from '../../../../lib/session-input-error';
+import {
+  InvalidPssh,
+  InvalidInitData,
+  InvalidWrmHeader,
+  InvalidLicense,
+  ServerException,
+} from '../../../../lib/playready/exceptions';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { Hono } from 'hono';
@@ -16,6 +24,33 @@ import { WidevineSession } from '../../../../lib/widevine/session';
 const app = new Hono();
 const SESSION_MESSAGE_TIMEOUT_MS = 5_000;
 const SESSION_UPDATE_SYNC_TIMEOUT_MS = 250;
+
+const sessionFailure = (error: unknown) => {
+  if (
+    error instanceof SessionInputError ||
+    error instanceof InvalidPssh ||
+    error instanceof InvalidInitData ||
+    error instanceof InvalidWrmHeader ||
+    error instanceof InvalidLicense
+  ) {
+    return { error: 'Invalid session input', status: 400 as const };
+  }
+  if (error instanceof ServerException) {
+    return { error: 'License server rejected the request', status: 502 as const };
+  }
+  if (error instanceof DOMException && error.name === 'TimeoutError') {
+    return { error: 'Timed out waiting for a session message', status: 504 as const };
+  }
+  console.error('Session operation failed', {
+    errorType: error instanceof Error ? error.name : 'Unknown',
+  });
+  return { error: 'Internal session error', status: 500 as const };
+};
+
+app.onError((error, c) => {
+  const failure = sessionFailure(error);
+  return c.json({ error: failure.error }, failure.status);
+});
 
 const secretKeyMiddleware = createMiddleware(async (c, next) => {
   const secretKey = c.req.header('x-secret-key');
@@ -187,7 +222,7 @@ app.post(
   zValidator(
     'json',
     z.object({
-      initDataType: z.string().optional(),
+      initDataType: z.literal('cenc').optional(),
       initData: base64,
       serverCertificate: base64.optional(),
     }),
@@ -208,7 +243,7 @@ app.post(
         );
         if (!accepted) return c.json({ error: 'Server certificates are unsupported' }, 400);
       } catch (error) {
-        return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+        return c.json({ error: 'Invalid server certificate' }, 400);
       }
     }
     if (config.forcePrivacyMode) {
@@ -250,26 +285,33 @@ app.post(
 
       session.addEventListener('message', handler);
       const timeout = setTimeout(() => {
-        fail(
-          new Error(
-            `Timed out after ${SESSION_MESSAGE_TIMEOUT_MS}ms waiting for a session message`,
-          ),
-        );
+        fail(new DOMException('Timed out waiting for a session message', 'TimeoutError'));
       }, SESSION_MESSAGE_TIMEOUT_MS);
       rejectNextMessage = fail;
     });
 
     try {
-      await session.generateRequest(initDataType, initData);
+      // Observe both promises immediately; the message deadline also bounds a stalled generator.
+      const [, message] = await Promise.all([
+        session.generateRequest(initDataType, initData),
+        nextMessage,
+      ]);
+      return c.json({
+        message: Buffer.from(new Uint8Array(message.message)).toString('base64'),
+        messageType: message.messageType,
+        serverCertificateAccepted: serverCertificate !== undefined,
+      });
     } catch (error) {
       rejectNextMessage?.(error);
+      sessions.delete(sessionKey);
+      try {
+        await session.close();
+      } catch {
+        console.error('Failed to close session after generation failure');
+      }
+      const failure = sessionFailure(error);
+      return c.json({ error: failure.error }, failure.status);
     }
-    const message = await nextMessage;
-    return c.json({
-      message: Buffer.from(new Uint8Array(message.message)).toString('base64'),
-      messageType: message.messageType,
-      serverCertificateAccepted: serverCertificate !== undefined,
-    });
   },
 );
 
@@ -323,10 +365,10 @@ app.post(
       await session.update(response);
       await synchronization;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error('Failed to update remote CDM session', error);
-      return c.json({ error: `Failed to update remote CDM session: ${message}` }, 502);
+      const failure = sessionFailure(error);
+      return c.json({ error: failure.error }, failure.status);
     } finally {
+      settleSynchronization();
       session.removeEventListener('message', handleMessage);
       session.removeEventListener('keystatuseschange', handleKeyStatusesChange);
     }

--- a/src/cli/commands/serve/serve.ts
+++ b/src/cli/commands/serve/serve.ts
@@ -1,5 +1,5 @@
 import { readdir } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { extname, resolve } from 'node:path';
 import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import { secureHeaders } from 'hono/secure-headers';
@@ -19,22 +19,50 @@ type ServeOptions = {
   public?: boolean;
 };
 
+const describeCredentials = (path: string) => {
+  const format = extname(path).toLowerCase();
+  const drm = { '.wvd': 'Widevine', '.prd': 'PlayReady' }[format] ?? 'unknown DRM';
+  return `${resolve(path)} (${drm}, based on file extension)`;
+};
+
 export const serve = async (options: ServeOptions = {}) => {
   await loadConfig(options.config);
   if (options.credentials) config.credentials.push(options.credentials);
   if (!config.credentials.length) {
-    const files = await readdir(process.cwd());
-    const credentialsPath = files.find((file) => file.endsWith('.wvd'));
+    const files = await readdir(process.cwd(), { withFileTypes: true });
+    const candidates = files
+      .filter((file) => file.isFile() && /\.(wvd|prd)$/.test(file.name))
+      .map((file) => file.name)
+      .sort();
+    if (candidates.length > 1) {
+      console.warn(
+        'Multiple credential files found. Selecting the first filename in sorted order.',
+      );
+    }
+    const credentialsPath = candidates[0];
     if (credentialsPath) config.credentials.push(credentialsPath);
+  }
+  if (!options.credentials && config.credentials[0]) {
+    console.warn(
+      `Default credentials: ${describeCredentials(config.credentials[0])}. ` +
+        'Using the first configured file. Use --credentials to choose credentials explicitly.',
+    );
   }
   if (options.secret) {
     const anonymousUser = { name: 'anonymous', credentials: [] };
     const user = Object.hasOwn(config.users, options.secret)
       ? config.users[options.secret]!
       : anonymousUser;
-    const credentialsPath = options.credentials ?? config.credentials.at(-1);
-    if (!user.credentials.length && credentialsPath)
+    const credentialsPath = options.credentials ?? config.credentials[0];
+    if (!user.credentials.length && credentialsPath) {
       user.credentials.push(resolve(credentialsPath));
+      if (!options.credentials) {
+        console.warn(
+          `Granted --secret access to ${describeCredentials(credentialsPath)}. ` +
+            'Use --credentials to choose a different grant.',
+        );
+      }
+    }
     config.users = { ...config.users, [options.secret]: user };
   }
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -8,49 +8,55 @@ export const importClientCredentials = async (input: string, output?: string) =>
   const isDir = inputStat.isDirectory();
 
   if (isDir) {
-    const entries = isDir ? await readdir(input) : [];
-
-    const find = (query: string) => entries.find((entry) => entry.includes(query));
-    const endsWith = (query: string) => entries.find((entry) => entry.endsWith(query));
-
-    const widevineIdFile = find('client_id');
-    const widevineKeyFile = find('private_key');
-    const wvdFile = endsWith('.wvd');
-
-    const isWidevine =
-      (!!(widevineIdFile && widevineKeyFile) || !!wvdFile) && !output?.endsWith('.prd');
-
-    const playreadyCertificateFile = find('bgroupcert');
-    const playreadyKeyFile = find('zgpriv');
-    const prdFile = endsWith('.prd');
-
-    const isPlayReady =
-      (!!(playreadyCertificateFile && playreadyKeyFile) || !!prdFile) && !output?.endsWith('.wvd');
-
-    if (isWidevine) {
-      if (wvdFile) {
-        const wvd = await readFile(join(input, wvdFile));
-        return await WidevineClientCredentials.from({ wvd });
-      } else {
-        const id = await readFile(join(input, widevineIdFile!));
-        const key = await readFile(join(input, widevineKeyFile!));
-        return WidevineClientCredentials.from({ id, key });
+    const entries = (await readdir(input, { withFileTypes: true }))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name);
+    const candidates: (() => Promise<WidevineClientCredentials | PlayReadyClientCredentials>)[] =
+      [];
+    const addRaw = (
+      firstQuery: string,
+      secondQuery: string,
+      load: (
+        first: Buffer,
+        second: Buffer,
+      ) => Promise<WidevineClientCredentials | PlayReadyClientCredentials>,
+    ) => {
+      const first = entries.filter((entry) => entry.includes(firstQuery));
+      const second = entries.filter((entry) => entry.includes(secondQuery));
+      if (!first.length || !second.length) return;
+      if (first.length > 1 || second.length > 1 || first[0] === second[0]) {
+        throw new Error(`Ambiguous raw credential files in ${input}`);
       }
-    } else if (isPlayReady) {
-      if (prdFile) {
-        const prd = await readFile(join(input, prdFile));
-        return await PlayReadyClientCredentials.from({ prd });
-      } else {
-        const certificate = await readFile(join(input, playreadyCertificateFile!));
-        const key = await readFile(join(input, playreadyKeyFile!));
-        return PlayReadyClientCredentials.from({
-          groupCertificate: certificate,
-          groupKey: key,
-        });
+      candidates.push(async () =>
+        load(await readFile(join(input, first[0]!)), await readFile(join(input, second[0]!))),
+      );
+    };
+    if (!output?.endsWith('.prd')) {
+      for (const file of entries.filter((entry) => entry.endsWith('.wvd'))) {
+        candidates.push(async () =>
+          WidevineClientCredentials.from({ wvd: await readFile(join(input, file)) }),
+        );
       }
-    } else {
-      throw new Error(`Unable to find credential files in ${input}`);
+      addRaw('client_id', 'private_key', (id, key) => WidevineClientCredentials.from({ id, key }));
     }
+    if (!output?.endsWith('.wvd')) {
+      for (const file of entries.filter((entry) => entry.endsWith('.prd'))) {
+        candidates.push(async () =>
+          PlayReadyClientCredentials.from({ prd: await readFile(join(input, file)) }),
+        );
+      }
+      addRaw('bgroupcert', 'zgpriv', (groupCertificate, groupKey) =>
+        PlayReadyClientCredentials.from({ groupCertificate, groupKey }),
+      );
+    }
+    if (candidates.length > 1) {
+      throw new Error(
+        `Ambiguous credential files in ${input}. Specify a packed file or a directory containing one credential set.`,
+      );
+    }
+    const load = candidates[0];
+    if (!load) throw new Error(`Unable to find credential files in ${input}`);
+    return load();
   } else if (input.endsWith('.wvd')) {
     const wvd = await readFile(input);
     return await WidevineClientCredentials.from({ wvd });

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -166,6 +166,7 @@ const fetchDecryptionKeys = async (params: FetchDecryptionKeysParams) => {
 export { fetchDecryptionKeys };
 export * from './utils';
 export * from './api';
+export * from './session-input-error';
 export * from './decrypt';
 export * from './pssh';
 export * from './widevine/engine';

--- a/src/lib/playready/session.ts
+++ b/src/lib/playready/session.ts
@@ -1,3 +1,4 @@
+import { SessionInputError } from '../session-input-error';
 import { DOMParser, XMLSerializer, type Document, type Element } from '@xmldom/xmldom';
 import { z } from 'zod';
 import * as utils from '@noble/curves/utils.js';
@@ -299,6 +300,9 @@ export class PlayReadySession extends BaseMediaKeysEngineSession {
 
   async generateRequest(initData: Uint8Array, initDataType: string = 'cenc') {
     this.assertOpen();
+    if (initDataType !== 'cenc') {
+      throw new SessionInputError('PlayReady supports only cenc init data');
+    }
     this.initData = initData;
     this.initDataType = initDataType;
     const pssh = new Pssh(initData);

--- a/src/lib/session-input-error.ts
+++ b/src/lib/session-input-error.ts
@@ -1,0 +1,2 @@
+// Marks rejected session input separately from engine or credential failures.
+export class SessionInputError extends Error {}

--- a/src/lib/widevine/session.ts
+++ b/src/lib/widevine/session.ts
@@ -1,3 +1,4 @@
+import { SessionInputError } from '../session-input-error';
 import { z } from 'zod';
 import type { MediaKeyMessageEventInit, MediaKeysEngineSession } from '../api';
 import { BaseMediaKeysEngineSession } from '../api';
@@ -153,7 +154,15 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     const resolvedInitDataType =
       typeof first === 'string' ? first : typeof second === 'string' ? second : 'cenc';
 
-    const pssh = createPssh(initData);
+    if (resolvedInitDataType !== 'cenc') {
+      throw new SessionInputError('Widevine supports only cenc init data');
+    }
+    let pssh: PSSH;
+    try {
+      pssh = createPssh(initData);
+    } catch (error) {
+      throw new SessionInputError('Invalid Widevine init data', { cause: error });
+    }
     const licenseRequest = await this.#createLicenseRequest(pssh);
     const message = await this.#signMessage(
       licenseRequest.bytes,
@@ -249,9 +258,10 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     try {
       type = getMessageType(response);
     } catch (error) {
-      this.log.error('Unable to parse license - check protobufs');
-      this.log.debug(fromBuffer(response).toText());
-      throw error;
+      throw new SessionInputError(
+        error instanceof Error ? error.message : 'Unable to parse Widevine response',
+        { cause: error },
+      );
     }
     if (type === SignedMessage.MessageType.SERVICE_CERTIFICATE) {
       await this.#setServiceCertificate(response);
@@ -261,7 +271,7 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     }
     if (type !== SignedMessage.MessageType.LICENSE) {
       const name = SignedMessage.MessageType[type] ?? type;
-      throw new Error(
+      throw new SessionInputError(
         `Unexpected Widevine response message type: ${name}; expected LICENSE or SERVICE_CERTIFICATE`,
       );
     }
@@ -270,27 +280,27 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     try {
       signedLicense = SignedMessage.decode(response);
     } catch (error) {
-      this.log.error('Unable to parse license - check protobufs');
-      this.log.debug(fromBuffer(response).toText());
-      throw new Error('Unable to parse license - check protobufs', { cause: error });
+      throw new SessionInputError('Unable to parse license - check protobufs', { cause: error });
     }
 
     let license: License;
     try {
       license = License.decode(signedLicense.msg);
     } catch (error) {
-      throw new Error('Failed to parse Widevine license payload', { cause: error });
+      throw new SessionInputError('Failed to parse Widevine license payload', { cause: error });
     }
     if (!license.id) {
-      throw new Error('Invalid Widevine license ID: missing id');
+      throw new SessionInputError('Invalid Widevine license ID: missing id');
     }
     if (!license.id.requestId?.length) {
-      throw new Error('Invalid Widevine license ID: missing or empty requestId');
+      throw new SessionInputError('Invalid Widevine license ID: missing or empty requestId');
     }
     const requestId = fromBuffer(license.id.requestId).toHex();
     const context = this.contexts.get(requestId);
     if (!context) {
-      throw new Error(`Failed to find context to decrypt keys, requestId: ${requestId}`);
+      throw new SessionInputError(
+        `Failed to find context to decrypt keys, requestId: ${requestId}`,
+      );
     }
 
     const sessionKey = await this.clientCredentials.decryptWithKey(signedLicense.sessionKey);
@@ -303,7 +313,7 @@ export class WidevineSession extends BaseMediaKeysEngineSession {
     if (!success) {
       this.log.debug(`Calculated signature: ${signature.calculated}`);
       this.log.debug(`Actual signature: ${signature.actual}`);
-      throw new Error('Signature mismatch on license message, rejecting license');
+      throw new SessionInputError('Signature mismatch on license message, rejecting license');
     }
 
     for (const keyContainer of license.key) {

--- a/test/cli-license.test.ts
+++ b/test/cli-license.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { license } from '../src/cli/commands/license/license';
+import { importClientCredentials } from '../src/cli/utils';
+import { fetchDecryptionKeys, Widevine } from '../src/lib';
+import { WidevineClientCredentials } from '../src/lib/widevine/client-credentials';
+import { ClientIdentification } from '../src/lib/widevine/proto';
+
+vi.mock('../src/cli/utils', async (original) => ({
+  ...(await original<typeof import('../src/cli/utils')>()),
+  importClientCredentials: vi.fn(),
+}));
+vi.mock('../src/lib', async (original) => ({
+  ...(await original<typeof import('../src/lib')>()),
+  fetchDecryptionKeys: vi.fn(async () => new Map<string, string>()),
+}));
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+test.each([
+  ['Authorization'],
+  [': value'],
+  ['bad name: value'],
+  ['X: a\x01b'],
+  ['X: a\r\nb'],
+  ['X: a\0b'],
+  ['X: a', 'x: b'],
+])('rejects invalid headers before importing credentials: %j', async (...headers) => {
+  await expect(license({ url: 'https://example.test', pssh: 'AQ==', headers })).rejects.toThrow(
+    /header/i,
+  );
+  expect(importClientCredentials).not.toHaveBeenCalled();
+});
+
+test('normalizes valid headers and shares the certificate deadline with acquisition', async () => {
+  vi.mocked(importClientCredentials).mockResolvedValue(
+    new WidevineClientCredentials(ClientIdentification.create({})),
+  );
+  vi.spyOn(Widevine.prototype, 'setServerCertificate').mockResolvedValue(true);
+  const fetch = vi.fn(async () => new Response(new Uint8Array([1])));
+  vi.stubGlobal('fetch', fetch);
+  await license({
+    url: 'https://example.test',
+    pssh: 'AQ==',
+    encrypt: true,
+    headers: [' X-Test : a:b ', 'X-Empty:'],
+  });
+  const options = vi.mocked(fetchDecryptionKeys).mock.calls[0][0];
+  expect(options.headers).toEqual({ 'x-test': 'a:b', 'x-empty': '' });
+  expect(fetch).toHaveBeenCalledWith(
+    'https://example.test',
+    expect.objectContaining({ signal: options.signal }),
+  );
+  expect(options.signal).toBeInstanceOf(AbortSignal);
+});
+
+test.each(['headers', 'body'])('aborts a stalled certificate response %s', async (stage) => {
+  vi.mocked(importClientCredentials).mockResolvedValue(
+    new WidevineClientCredentials(ClientIdentification.create({})),
+  );
+  const controller = new AbortController();
+  vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+  const started = Promise.withResolvers<void>();
+  const stalled = () =>
+    new Promise<never>((_, reject) => {
+      controller.signal.addEventListener('abort', () => reject(controller.signal.reason), {
+        once: true,
+      });
+      started.resolve();
+    });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => (stage === 'headers' ? stalled() : { ok: true, arrayBuffer: stalled })),
+  );
+  const pending = license({ url: 'https://example.test', pssh: 'AQ==', encrypt: true });
+  const rejected = expect(pending).rejects.toThrow('deadline');
+  await started.promise;
+  controller.abort(new DOMException('deadline', 'TimeoutError'));
+  await rejected;
+  expect(AbortSignal.timeout).toHaveBeenCalledWith(30_000);
+  expect(fetchDecryptionKeys).not.toHaveBeenCalled();
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -288,3 +288,21 @@ test.each(['../../escaped', '..\\..\\escaped', '/tmp/escaped', 'C:\\temp\\escape
     );
   },
 );
+
+test('rejects ambiguous directory credentials', async () => {
+  const cwd = await mkdtemp(join(directory, 'ambiguous-'));
+  await writeFile(join(cwd, 'first.wvd'), wvd);
+  await writeFile(join(cwd, 'second.wvd'), wvd);
+  expect(run(['credentials', 'info', cwd]).stderr).toContain('Ambiguous');
+  expect(run(['credentials', 'info', join(cwd, 'first.wvd')]).status).toBe(0);
+});
+
+test('rejects packed/raw and duplicate raw credential candidates', async () => {
+  const cwd = await mkdtemp(join(directory, 'raw-ambiguous-'));
+  expect(run(['credentials', 'unpack', input, cwd]).status).toBe(0);
+  await writeFile(join(cwd, 'copy.wvd'), wvd);
+  expect(run(['credentials', 'info', cwd]).stderr).toContain('Ambiguous');
+  const rawKey = (await readdir(cwd)).find((file) => file.includes('private_key'))!;
+  await writeFile(join(cwd, 'other_private_key'), await readFile(join(cwd, rawKey)));
+  expect(run(['credentials', 'pack', cwd, '--format', 'wvd']).stderr).toContain('Ambiguous raw');
+});

--- a/test/serve-hardening.test.ts
+++ b/test/serve-hardening.test.ts
@@ -331,3 +331,24 @@ test.each([
     ).status,
   ).toBe(403);
 });
+
+test('maps malformed Widevine license bytes to 400 and keeps the session available', async () => {
+  const { id } = await (await post()).json();
+  const result = await post({}, JSON.stringify({ response: 'AQ==' }), `/sessions/${id}/update`);
+  expect(result.status).toBe(400);
+  expect(await result.json()).toEqual({ error: 'Invalid session input' });
+  expect(sessions.has(`:${id}`)).toBe(true);
+});
+
+test('removes a real Widevine session when a malformed PSSH fails generation', async () => {
+  config.forcePrivacyMode = false;
+  const { id } = await (await post()).json();
+  const malformedBox = Buffer.from('000000207073736800000000', 'hex').toString('base64');
+  const result = await post(
+    {},
+    JSON.stringify({ initData: malformedBox }),
+    `/sessions/${id}/generate-request`,
+  );
+  expect(result.status).toBe(400);
+  expect(sessions.has(`:${id}`)).toBe(false);
+});

--- a/test/serve-session-concurrency.test.ts
+++ b/test/serve-session-concurrency.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import sessionApi from '../src/cli/commands/serve/api/session';
+import { SessionInputError } from '../src/lib/session-input-error';
+import { InvalidLicense, ServerException } from '../src/lib/playready/exceptions';
 import { config, sessions } from '../src/cli/commands/serve/state';
 import { BaseMediaKeysEngine, BaseMediaKeysEngineSession, Session } from '../src/lib/api';
 
@@ -147,7 +149,9 @@ test('releases mutation ownership after a failed challenge or invalid request', 
   vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.spyOn(native, 'generateRequest').mockRejectedValueOnce(new Error('Challenge failed'));
   expect((await request('generate-request')).status).toBe(500);
-  expect((await request('generate-request')).status).toBe(200);
+  expect(sessions.has(':session')).toBe(false);
+  expect((await request('generate-request')).status).toBe(400);
+  openSession();
   const invalid = await sessionApi.request('/session/update', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -156,3 +160,61 @@ test('releases mutation ownership after a failed challenge or invalid request', 
   expect(invalid.status).toBe(400);
   expect((await request('update')).status).toBe(200);
 });
+
+test('rejects unsupported init data before mutating the session and permits retry', async () => {
+  const { native } = openSession();
+  const generate = vi.spyOn(native, 'generateRequest');
+  const result = await sessionApi.request('/session/generate-request', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ initDataType: 'webm', initData: 'AQ==' }),
+  });
+  expect(result.status).toBe(400);
+  expect(generate).not.toHaveBeenCalled();
+  expect((await request('generate-request')).status).toBe(200);
+});
+
+test.each([
+  new SessionInputError('private input'),
+  new InvalidLicense('private license'),
+  new ServerException('private fault'),
+  new Error('private internal'),
+])('maps update errors without exposing payloads: %s', async (error) => {
+  const { native } = openSession();
+  const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(native, 'update').mockRejectedValueOnce(error);
+  const result = await request('update');
+  expect(result.status).toBe(
+    error instanceof ServerException ? 502 : error.constructor === Error ? 500 : 400,
+  );
+  expect(JSON.stringify(await result.json())).not.toContain('private');
+  expect(JSON.stringify(log.mock.calls)).not.toContain('private');
+  expect((await request('update')).status).toBe(200);
+});
+
+test.each([false, true])(
+  'closes generation after a message deadline, stalled generator: %s',
+  async (stalled) => {
+    vi.useFakeTimers();
+    try {
+      const { native } = openSession();
+      const started = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      vi.spyOn(native, 'generateRequest').mockImplementationOnce(async () => {
+        started.resolve();
+        if (stalled) await resume.promise;
+      });
+      const close = vi.spyOn(native, 'close');
+      const pending = request('generate-request');
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await pending;
+      expect(result.status).toBe(504);
+      expect(sessions.has(':session')).toBe(false);
+      expect(close).toHaveBeenCalledOnce();
+      resume.resolve();
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -210,3 +210,82 @@ test.each([{}, { host: '0.0.0.0', public: true }, { host: '::', public: true }])
     }
   },
 );
+
+test.each(['discovered', 'configured', 'explicit', 'existing grant'])(
+  'starts with multiple credentials and reports automatic selection: %s',
+  async (mode) => {
+    const directory = await mkdtemp(join(tmpdir(), 'okova-selection-'));
+    const configPath = join(directory, 'config.json');
+    const first = join(directory, 'a.prd');
+    const last = join(directory, 'z.wvd');
+    const originalConfig = structuredClone(config);
+    const originalListeners = {
+      SIGINT: process.listeners('SIGINT'),
+      SIGTERM: process.listeners('SIGTERM'),
+    };
+    const startServer = vi.mocked(nodeServer.serve);
+    startServer.mockClear();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process, 'cwd').mockReturnValue(directory);
+    try {
+      await writeFile(last, 'WVD');
+      await writeFile(first, 'PRD');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          port: 0,
+          credentials: mode === 'discovered' ? [] : [last, first],
+          users:
+            mode === 'existing grant'
+              ? { 'private-secret': { name: 'test', credentials: [first] } }
+              : {},
+        }),
+      );
+      await serve({
+        config: configPath,
+        secret: 'private-secret',
+        ...(mode === 'explicit' ? { credentials: first } : {}),
+      });
+      const server = startServer.mock.results[0]?.value;
+      assert(server);
+      if (!server.listening) await once(server, 'listening');
+      expect(server.address()).toMatchObject({ address: '127.0.0.1' });
+      const selected = mode === 'configured' ? last : first;
+      expect(config.users['private-secret']?.credentials).toEqual([selected]);
+      const output = warning.mock.calls.flat().join('\n');
+      expect(output).not.toContain('private-secret');
+      if (mode === 'explicit') {
+        expect(warning).not.toHaveBeenCalled();
+      } else {
+        expect(output).toContain(mode === 'discovered' ? first : last);
+        expect(output).toContain(mode === 'discovered' ? 'PlayReady' : 'Widevine');
+        expect(output).toContain('--credentials');
+        if (mode === 'existing grant') {
+          expect(output).not.toContain('Granted');
+        } else {
+          expect(output).toContain(`Granted --secret access to ${selected}`);
+        }
+      }
+      if (mode === 'discovered') {
+        expect(config.credentials).toEqual(['a.prd']);
+        expect(output).toContain('Multiple credential files');
+      }
+    } finally {
+      const server = startServer.mock.results[0]?.value;
+      if (server?.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error?: Error) => (error ? reject(error) : resolve()));
+        });
+      }
+      for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+        for (const listener of process.listeners(signal)) {
+          if (!originalListeners[signal].includes(listener))
+            process.removeListener(signal, listener);
+        }
+      }
+      Object.assign(config, originalConfig);
+      vi.restoreAllMocks();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Validate license headers and enforce a shared 30-second request deadline.
- Harden credential discovery and reject ambiguous credential files.
- Improve serve session cleanup, input validation, timeout handling, and error responses.
- Document current PlayReady signature compatibility limits.

## Testing

- Added and updated CLI, serve, session concurrency, PlayReady, and compatibility tests.
- Verified credential selection, header validation, session failures, and timeout behavior.