### PR TITLE
feat(extension): add site filter for keys history, improve UI

### DIFF
--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -38,9 +38,9 @@ export const Cell: Component<CellProps> = (props) => {
         props.variant === 'warning' && 'text-[#d07200] dark:text-orange-400',
         props.disabled && 'cursor-default pointer-events-none opacity-70',
         props.size === 'sm' &&
-          'text-[13px] font-medium hover:bg-transparent dark:hover:bg-transparent hover:opacity-80 min-h-4 py-1',
+          'text-[13px] font-medium hover:bg-transparent dark:hover:bg-transparent hover:opacity-80 min-h-4 py-1 px-1',
         props.size === 'xs' &&
-          'text-[10px] font-medium bg-transparent dark:bg-transparent hover:bg-neutral-100 hover:dark:bg-neutral-800 min-h-4 py-0 px-1.5',
+          'text-[10px] rounded-md font-medium bg-transparent dark:bg-transparent hover:bg-neutral-200/80 hover:dark:bg-neutral-800 min-h-4 py-0 px-1',
         props.class,
       )}
       title={props.title}

--- a/src/extension/entrypoints/popup/components/header.tsx
+++ b/src/extension/entrypoints/popup/components/header.tsx
@@ -15,7 +15,7 @@ export const Header: Component<HeaderProps> = (props) => {
   return (
     <div
       class={cn(
-        'text-base font-bold flex gap-3 items-center min-h-11',
+        'text-base font-bold flex gap-2 items-center min-h-11',
         '-mt-4 py-1 mb-3',
         'px-4',
         'rounded-b-lg',

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -1,7 +1,6 @@
 import { Accessor, Component, JSX, batch, createComputed, untrack } from 'solid-js';
 import { createStore, reconcile } from 'solid-js/store';
 import { Cell } from './cell';
-import { DeleteKeys } from './delete-keys';
 import { keyRecordToken, KeyInfo } from '@/utils/storage';
 import { List } from './list';
 import { Section } from './section';
@@ -9,11 +8,12 @@ import { KeySettings } from '../routes/key-settings';
 import { formatRelativeTime } from '../utils/date';
 import { captureHistoryScroll, reconcileHistoryRows, type HistoryRow } from '../utils/history-rows';
 import { TbOutlineSearch } from 'solid-icons/tb';
+import { cn } from '../utils/cn';
 
 type KeysListProps = {
   keys: Accessor<KeyInfo[]>;
   allKeys?: Accessor<KeyInfo[]>;
-  selectable?: boolean;
+  selection?: { tokens: string[]; onChange: (tokens: string[]) => void };
   search?: { value: string; onChange: (value: string) => void };
   controls?: JSX.Element;
   header?: JSX.Element;
@@ -26,14 +26,9 @@ export const KeysList: Component<KeysListProps> = (props) => {
   const [rows, setRows] = createStore<HistoryRow[]>([]);
   const [openedIdentity, setOpenedIdentity] = createSignal<number | null>(null);
   const openedKey = createMemo(() => rows.find((row) => row.identity === openedIdentity())?.key);
-  const [selected, setSelected] = createSignal<string[]>([]);
-  const selectedRecords = createMemo(() =>
-    props.keys().filter((key) => selected().includes(keyRecordToken(key))),
-  );
-  createEffect(() => {
-    const visible = new Set(props.keys().map(keyRecordToken));
-    setSelected((tokens) => tokens.filter((token) => visible.has(token)));
-  });
+  const [isSearchExpanded, setIsSearchExpanded] = createSignal(false);
+  let searchInput: HTMLInputElement | undefined;
+  let searchButton: HTMLButtonElement | undefined;
   let nextIdentity = 0;
   let list: HTMLDivElement | undefined;
 
@@ -55,70 +50,79 @@ export const KeysList: Component<KeysListProps> = (props) => {
 
   return (
     <>
-      <Show when={props.search || (props.selectable && props.keys().length)}>
-        <Section
-          footer={
-            props.search ? (
-              <span role="status">
-                {selectedRecords().length} selected / {props.keys().length} filtered /{' '}
-                {(props.allKeys ?? props.keys)().length} total
-              </span>
-            ) : undefined
-          }
-        >
-          <Show when={props.search}>
-            {(search) => (
-              <Cell class="w-full" before={<TbOutlineSearch class="text-neutral-500" />}>
-                <input
-                  type="search"
-                  aria-label="Search"
-                  class="outline-none bg-transparent border-none w-full"
-                  placeholder="Search..."
-                  value={search().value}
-                  onInput={(event) => search().onChange(event.currentTarget.value)}
-                />
-              </Cell>
-            )}
-          </Show>
-          <Show when={props.selectable && props.keys().length}>
-            <Cell
-              selection={{
-                label: 'Select All Results',
-                checked: selectedRecords().length === props.keys().length,
-                indeterminate:
-                  selectedRecords().length > 0 && selectedRecords().length < props.keys().length,
-                onChange: (checked) => setSelected(checked ? props.keys().map(keyRecordToken) : []),
-              }}
-              onClick={() =>
-                setSelected(
-                  selectedRecords().length === props.keys().length
-                    ? []
-                    : props.keys().map(keyRecordToken),
-                )
-              }
-            >
-              Select All Results
-            </Cell>
-          </Show>
-        </Section>
-      </Show>
       <div ref={list}>
         <Show when={props.keys().length > 0 || props.search}>
           <List>
             <Section
-              header={props.header}
+              header={
+                <>
+                  {props.header}{' '}
+                  <span
+                    role="status"
+                    aria-label={`${props.selection?.tokens.length ?? 0} selected / ${(props.allKeys ?? props.keys)().length} total`}
+                  >
+                    ({props.selection?.tokens.length ? `${props.selection.tokens.length}/` : ''}
+                    {(props.allKeys ?? props.keys)().length})
+                  </span>
+                </>
+              }
               headerControls={
                 <>
-                  <Show when={selectedRecords().length}>
-                    <DeleteKeys
-                      label="Delete Selected"
-                      scope={{ kind: 'selected', records: selectedRecords() }}
-                      size="xs"
-                      disabled={!selectedRecords().length}
-                      onDeleted={() => setSelected([])}
-                    />
+                  <div class={isSearchExpanded() ? 'hidden' : 'flex items-center gap-0.5'}>
+                    {props.controls}
+                  </div>
+                  <Show when={props.search}>
+                    {(search) => (
+                      <>
+                        <button
+                          ref={searchButton}
+                          type="button"
+                          aria-label="Search"
+                          aria-expanded={isSearchExpanded()}
+                          title={search().value.trim() ? `Search: ${search().value}` : 'Search'}
+                          class={cn(
+                            'size-4 items-center justify-center rounded-md cursor-pointer hover:bg-slate-200/80 dark:hover:bg-neutral-800 focus-visible:outline-2',
+                            isSearchExpanded() ? 'hidden' : 'inline-flex',
+                            search().value.trim() &&
+                              'bg-blue-100 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400',
+                          )}
+                          onClick={() => {
+                            setIsSearchExpanded(true);
+                            searchInput?.focus();
+                          }}
+                        >
+                          <TbOutlineSearch aria-hidden="true" class="size-2.5" />
+                        </button>
+                        <div
+                          class={cn(
+                            'relative items-center',
+                            isSearchExpanded() ? 'inline-flex' : 'hidden',
+                          )}
+                        >
+                          <TbOutlineSearch
+                            aria-hidden="true"
+                            class="pointer-events-none absolute left-1 size-2.5"
+                          />
+                          <input
+                            ref={searchInput}
+                            type="search"
+                            aria-label="Search"
+                            class="min-h-4 w-56 rounded-md pl-5 pr-1 font-normal outline-none bg-slate-200/80 dark:bg-neutral-800 focus-visible:outline-2"
+                            placeholder="Search..."
+                            value={search().value}
+                            onInput={(event) => search().onChange(event.currentTarget.value)}
+                            onBlur={() => setIsSearchExpanded(false)}
+                            onKeyDown={(event) => {
+                              if (event.key !== 'Escape') return;
+                              event.preventDefault();
+                              setIsSearchExpanded(false);
+                              searchButton?.focus();
+                            }}
+                          />
+                        </div>
+                      </>
+                    )}
                   </Show>
-                  {props.controls}
                 </>
               }
               footer={props.footer}
@@ -130,16 +134,18 @@ export const KeysList: Component<KeysListProps> = (props) => {
                       class="group min-w-0"
                       onClick={() => setOpenedIdentity(row.identity)}
                       selection={
-                        props.selectable
+                        props.selection
                           ? {
                               label: `Select record ${row.key.id} from ${row.key.url}`,
-                              checked: selected().includes(keyRecordToken(row.key)),
+                              checked: props.selection.tokens.includes(keyRecordToken(row.key)),
                               onChange: (checked) => {
                                 const token = keyRecordToken(row.key);
-                                setSelected((tokens) =>
+                                const selection = props.selection;
+                                if (!selection) return;
+                                selection.onChange(
                                   checked
-                                    ? [...tokens, token]
-                                    : tokens.filter((item) => item !== token),
+                                    ? [...selection.tokens, token]
+                                    : selection.tokens.filter((item) => item !== token),
                                 );
                               },
                             }

--- a/src/extension/entrypoints/popup/components/select.tsx
+++ b/src/extension/entrypoints/popup/components/select.tsx
@@ -1,0 +1,25 @@
+import { splitProps, type Component, type JSX } from 'solid-js';
+import { TbOutlineChevronDown } from 'solid-icons/tb';
+import { cn } from '../utils/cn';
+
+export type SelectProps = JSX.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select: Component<SelectProps> = (props) => {
+  const [local, rest] = splitProps(props, ['class']);
+
+  return (
+    <span class="relative inline-flex items-center">
+      <select
+        {...rest}
+        class={cn(
+          'min-h-4 [field-sizing:content] appearance-none pl-1 pr-3.5 outline-none font-normal rounded-md bg-transparent hover:bg-slate-200/80 hover:dark:bg-neutral-800 cursor-pointer dark:[color-scheme:dark] focus-visible:outline-2 disabled:cursor-default disabled:opacity-50',
+          local.class,
+        )}
+      />
+      <TbOutlineChevronDown
+        aria-hidden="true"
+        class="pointer-events-none absolute right-0.5 size-2.5"
+      />
+    </span>
+  );
+};

--- a/src/extension/entrypoints/popup/routes/dashboard.tsx
+++ b/src/extension/entrypoints/popup/routes/dashboard.tsx
@@ -31,11 +31,6 @@ export const Dashboard = () => {
   const activeDomainRecentKeys = createMemo(() => {
     return getRecentKeysForUrl(activeTabUrl(), recentKeysByDomain(), recentKeys());
   });
-  const recentKeysHeader = createMemo(() =>
-    activeDomain()
-      ? `Recent Keys for ${activeDomain()} (${activeDomainRecentKeys().length})`
-      : 'Recent Keys',
-  );
 
   return (
     <Layout>
@@ -64,11 +59,7 @@ export const Dashboard = () => {
 
         <KeysList
           keys={activeDomainRecentKeys}
-          header={
-            <div class="block truncate" title={recentKeysHeader()}>
-              {recentKeysHeader()}
-            </div>
-          }
+          header="Recent Keys"
           controls={
             <Show when={activeDomain()}>
               {(domain) => (

--- a/src/extension/entrypoints/popup/routes/keys.tsx
+++ b/src/extension/entrypoints/popup/routes/keys.tsx
@@ -4,24 +4,42 @@ import { DeleteKeys } from '../components/delete-keys';
 import { Layout } from '../components/layout';
 import { Header } from '../components/header';
 import { Cell } from '../components/cell';
-import { KeyInfo } from '@/utils/storage';
+import { KeyInfo, keyRecordToken } from '@/utils/storage';
 import { KeysList } from '../components/keys-list';
 import { NoKeys } from '../components/no-keys';
 import { Section } from '../components/section';
+import { Select } from '../components/select';
 import { serializeHistory, type HistoryExportFormat } from '../utils/history-export';
 import { saveFile } from '../utils/file';
-import { filterHistory, type HistoryFilters } from '../utils/history-filters';
+import { filterHistory, getHistorySites, type HistoryFilters } from '../utils/history-filters';
 
 export const Keys = () => {
   const [keys, setKeys] = createSignal<KeyInfo[]>([]);
   const [search, setSearch] = createSignal('');
+  const [site, setSite] = createSignal('');
+  const sites = createMemo(() => getHistorySites(keys()));
+  createEffect(() => {
+    if (site() && !sites().includes(site())) setSite('');
+  });
   const [drm, setDrm] = createSignal<HistoryFilters['drm']>('all');
   const [order, setOrder] = createSignal<HistoryFilters['order']>('newest');
   const filteredKeys = createMemo(() =>
-    filterHistory(keys(), { search: search(), drm: drm(), order: order() }),
+    filterHistory(keys(), { search: search(), site: site(), drm: drm(), order: order() }),
   );
+  const [selected, setSelected] = createSignal<string[]>([]);
+  const selectedRecords = createMemo(() =>
+    filteredKeys().filter((key) => selected().includes(keyRecordToken(key))),
+  );
+  const isAllSelected = createMemo(
+    () => filteredKeys().length > 0 && selectedRecords().length === filteredKeys().length,
+  );
+  createEffect(() => {
+    const visible = new Set(filteredKeys().map(keyRecordToken));
+    setSelected((tokens) => tokens.filter((token) => visible.has(token)));
+  });
   const clearFilters = () => {
     setSearch('');
+    setSite('');
     setDrm('all');
   };
   const [isExporting, setIsExporting] = createSignal(false);
@@ -63,7 +81,41 @@ export const Keys = () => {
 
   return (
     <Layout>
-      <Header backHref="/">Keys</Header>
+      <Header
+        backHref="/"
+        actions={
+          <>
+            <DeleteKeys
+              size="sm"
+              class="w-auto shrink-0"
+              label={
+                selectedRecords().length
+                  ? `Delete Selected (${selectedRecords().length})`
+                  : 'Delete All'
+              }
+              scope={
+                selectedRecords().length
+                  ? { kind: 'selected', records: selectedRecords() }
+                  : { kind: 'all' }
+              }
+              disabled={!keys().length}
+              onDeleted={() => setSelected([])}
+            />
+            <Cell
+              component="button"
+              variant="primary"
+              size="sm"
+              class="w-auto shrink-0"
+              disabled={!filteredKeys().length}
+              onClick={() => setSelected(isAllSelected() ? [] : filteredKeys().map(keyRecordToken))}
+            >
+              {isAllSelected() ? 'Deselect All' : 'Select All'}
+            </Cell>
+          </>
+        }
+      >
+        Keys
+      </Header>
       <div class="flex flex-col gap-3">
         <Section
           header="Actions"
@@ -93,7 +145,6 @@ export const Keys = () => {
           >
             Export Results as TXT
           </Cell>
-          <DeleteKeys label="Delete All" scope={{ kind: 'all' }} />
         </Section>
         <KeysList
           keys={filteredKeys}
@@ -102,9 +153,18 @@ export const Keys = () => {
           search={{ value: search(), onChange: setSearch }}
           controls={
             <>
-              <select
+              <Select
+                aria-label="Site"
+                class="max-w-[150px] truncate"
+                title={site() || 'All sites'}
+                value={site()}
+                onChange={(event) => setSite(event.currentTarget.value)}
+              >
+                <option value="">All sites</option>
+                <For each={sites()}>{(site) => <option value={site}>{site}</option>}</For>
+              </Select>
+              <Select
                 aria-label="DRM"
-                class="min-w-[105px] min-h-4 px-0.5 outline-none font-normal rounded-md bg-transparent hover:bg-neutral-100 hover:dark:bg-neutral-800 hover:cursor-pointer dark:[color-scheme:dark]"
                 value={drm()}
                 onChange={(event) => {
                   const value = event.currentTarget.value;
@@ -123,10 +183,9 @@ export const Keys = () => {
                 <option value="P">PlayReady</option>
                 <option value="C">ClearKey</option>
                 <option value="unknown">Unknown</option>
-              </select>
-              <select
+              </Select>
+              <Select
                 aria-label="Order"
-                class="min-w-[82px] min-h-4 px-0.5 outline-none font-normal rounded-md bg-transparent hover:bg-neutral-100 hover:dark:bg-neutral-800 hover:cursor-pointer dark:[color-scheme:dark]"
                 value={order()}
                 onChange={(event) => {
                   const value = event.currentTarget.value;
@@ -135,10 +194,10 @@ export const Keys = () => {
               >
                 <option value="newest">Newest first</option>
                 <option value="oldest">Oldest first</option>
-              </select>
+              </Select>
             </>
           }
-          selectable
+          selection={{ tokens: selectedRecords().map(keyRecordToken), onChange: setSelected }}
         />
         <Show when={!filteredKeys().length}>
           <Show when={keys().length} fallback={<NoKeys />}>

--- a/src/extension/entrypoints/popup/utils/history-filters.ts
+++ b/src/extension/entrypoints/popup/utils/history-filters.ts
@@ -1,9 +1,19 @@
-import type { KeyInfo } from '@/utils/storage';
+import { getWebsiteDomain, type KeyInfo } from '@/utils/storage';
 
 export type HistoryFilters = {
   search: string;
+  site: string;
   drm: 'all' | 'unknown' | NonNullable<KeyInfo['drmSystem']>;
   order: 'newest' | 'oldest';
+};
+
+export const getHistorySites = (records: readonly KeyInfo[]) => {
+  const sites = new Set<string>();
+  for (const key of records) {
+    const site = getWebsiteDomain(key.url);
+    if (site) sites.add(site);
+  }
+  return [...sites].sort();
 };
 
 export const filterHistory = (records: readonly KeyInfo[], filters: HistoryFilters): KeyInfo[] => {
@@ -20,7 +30,8 @@ export const filterHistory = (records: readonly KeyInfo[], filters: HistoryFilte
         (kidQuery.length > 0 && key.id.toLowerCase().replaceAll('-', '').includes(kidQuery)) ||
         key.url.toLowerCase().includes(query) ||
         key.mpd?.toLowerCase().includes(query);
-      return matchesDrm && matchesSearch;
+      const matchesSite = !filters.site || getWebsiteDomain(key.url) === filters.site;
+      return matchesDrm && matchesSearch && matchesSite;
     })
     .sort((left, right) =>
       filters.order === 'newest'

--- a/test/e2e/history-filters.test.ts
+++ b/test/e2e/history-filters.test.ts
@@ -59,18 +59,17 @@ test('filters and ordering control visible history and both export formats', asy
       await expect.poll(visible).toEqual([...records].reverse().map(pair));
       await popup.getByLabel('Order', { exact: true }).selectOption('oldest');
       await expect.poll(visible).toEqual(records.map(pair));
+      await popup.getByRole('button', { name: 'Search', exact: true }).click();
       await popup.getByRole('searchbox').fill('WATCH.EXAMPLE');
+      await popup.getByRole('searchbox').press('Tab');
       await popup.getByLabel('DRM', { exact: true }).selectOption('W');
       await expect.poll(visible).toEqual([records[0]!, records[2]!].map(pair));
-      await popup.getByRole('checkbox', { name: 'Select All Results', exact: true }).check();
-      await expect
-        .poll(() => popup.getByRole('status').textContent())
-        .toBe('2 selected / 2 filtered / 3 total');
+      await popup.getByRole('button', { name: 'Select All', exact: true }).click();
+      await expect.poll(() => popup.getByRole('status').textContent()).toBe('(2/3)');
+      await popup.getByRole('button', { name: 'Search', exact: true }).click();
       await popup.getByRole('searchbox').fill('first');
       await expect.poll(visible).toEqual([pair(records[0]!)]);
-      await expect
-        .poll(() => popup.getByRole('status').textContent())
-        .toBe('1 selected / 1 filtered / 3 total');
+      await expect.poll(() => popup.getByRole('status').textContent()).toBe('(1/3)');
       for (const format of ['JSON', 'TXT']) {
         const downloaded = popup.waitForEvent('download');
         await popup.getByRole('button', { name: `Export Results as ${format}` }).click();
@@ -97,7 +96,7 @@ test('filters and ordering control visible history and both export formats', asy
       expect(
         await popup.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
       ).toBe(true);
-      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      await popup.getByRole('button', { name: /^Delete Selected \(/ }).click();
       await expect.poll(() => popup.getByRole('dialog').isVisible()).toBe(true);
       await popup.getByRole('button', { name: 'Cancel', exact: true }).click();
       await popup.getByLabel('DRM', { exact: true }).selectOption('C');
@@ -114,7 +113,9 @@ test('filters and ordering control visible history and both export formats', asy
       await expect
         .poll(visible)
         .toEqual([records[0]!, records[3]!, records[1]!, records[2]!].map(pair));
-      expect(await popup.getByRole('searchbox').inputValue()).toBe('');
+      expect(
+        await popup.getByRole('button', { name: 'Search', exact: true }).getAttribute('title'),
+      ).toBe('Search');
       expect(await popup.getByLabel('DRM', { exact: true }).inputValue()).toBe('all');
       expect(await popup.getByLabel('Order', { exact: true }).inputValue()).toBe('oldest');
     } finally {

--- a/test/e2e/key-search.test.ts
+++ b/test/e2e/key-search.test.ts
@@ -40,9 +40,17 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
       const popup = await context.newPage();
       await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
       await popup.getByRole('link', { name: 'Keys', exact: true }).click();
+      const searchButton = popup.getByRole('button', { name: 'Search', exact: true });
       const search = popup.getByRole('searchbox', { name: 'Search' });
+      expect(await search.isVisible()).toBe(false);
+      await searchButton.click();
+      expect(await search.evaluate((input) => input === document.activeElement)).toBe(true);
+      expect(await popup.getByLabel('DRM', { exact: true }).isVisible()).toBe(false);
+      expect(await popup.getByLabel('Site', { exact: true }).isVisible()).toBe(false);
+      expect(await popup.getByLabel('Order', { exact: true }).isVisible()).toBe(false);
       const count = popup.getByRole('status');
-      await expect.poll(() => count.textContent()).toBe('0 selected / 2 filtered / 2 total');
+      await expect.poll(() => count.textContent()).toBe('(2)');
+      await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(2);
       for (const query of [
         'aabbccdd-1122-3344-5566-77889900aabb',
         ' DD-1122 ',
@@ -52,19 +60,33 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
         'MANIFEST.MPD',
       ]) {
         await search.fill(query);
-        await expect.poll(() => count.textContent()).toBe('0 selected / 1 filtered / 2 total');
+        await expect.poll(() => count.textContent()).toBe('(2)');
+        await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(1);
         expect(await popup.locator('code').allTextContents()).toEqual([
           `${keys[0]!.id}:${keys[0]!.value}`,
         ]);
       }
+      await search.press('Tab');
+      expect(await search.isVisible()).toBe(false);
+      expect(await searchButton.getAttribute('title')).toBe('Search: MANIFEST.MPD');
+      expect(await searchButton.getAttribute('class')).toContain('text-blue-600');
+      expect(await popup.getByLabel('DRM', { exact: true }).isVisible()).toBe(true);
+      expect(await popup.getByLabel('Site', { exact: true }).isVisible()).toBe(true);
+      expect(await popup.getByLabel('Order', { exact: true }).isVisible()).toBe(true);
+      await expect.poll(() => count.textContent()).toBe('(2)');
+      await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(1);
+      await searchButton.click();
+      expect(await search.inputValue()).toBe('MANIFEST.MPD');
       await search.fill('5678ABCDEF90');
-      await expect.poll(() => count.textContent()).toBe('0 selected / 1 filtered / 2 total');
+      await expect.poll(() => count.textContent()).toBe('(2)');
+      await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(1);
       expect(await popup.locator('code').allTextContents()).toEqual([
         `${keys[1]!.id}:${keys[1]!.value}`,
       ]);
       for (const query of ['missing.example', '---', keys[0]!.value]) {
         await search.fill(query);
-        await expect.poll(() => count.textContent()).toBe('0 selected / 0 filtered / 2 total');
+        await expect.poll(() => count.textContent()).toBe('(2)');
+        await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(0);
         expect(await popup.getByRole('heading', { name: 'No matching keys' }).isVisible()).toBe(
           true,
         );
@@ -73,18 +95,27 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
       await mkdir(resolve('output/playwright/key-search'), { recursive: true });
       await popup.screenshot({ path: resolve('output/playwright/key-search/no-matches.png') });
       await popup.getByRole('button', { name: 'Clear filters', exact: true }).click();
-      await expect.poll(() => count.textContent()).toBe('0 selected / 2 filtered / 2 total');
+      await expect.poll(() => count.textContent()).toBe('(2)');
+      await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(2);
+      expect(await searchButton.getAttribute('title')).toBe('Search');
+      await searchButton.click();
       expect(await search.inputValue()).toBe('');
       await search.fill('   ');
-      await expect.poll(() => count.textContent()).toBe('0 selected / 2 filtered / 2 total');
+      await expect.poll(() => count.textContent()).toBe('(2)');
+      await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(2);
       await search.fill('');
+      await search.press('Escape');
+      expect(await search.isVisible()).toBe(false);
+      expect(await searchButton.evaluate((button) => button === document.activeElement)).toBe(true);
+      expect(await searchButton.getAttribute('class')).not.toContain('text-blue-600');
       await popup.screenshot({ path: resolve('output/playwright/key-search/all-keys.png') });
       await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
       await popup
         .getByRole('dialog')
         .getByRole('button', { name: 'Delete 2 records', exact: true })
         .click();
-      await expect.poll(() => count.textContent()).toBe('0 selected / 0 filtered / 0 total');
+      await expect.poll(() => count.textContent()).toBe('(0)');
+      await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(0);
       expect(await popup.getByRole('heading', { name: 'Keys will appear here' }).isVisible()).toBe(
         true,
       );

--- a/test/e2e/live-history.test.ts
+++ b/test/e2e/live-history.test.ts
@@ -32,10 +32,11 @@ test('history updates preserve search, visible rows, and live details', async ()
       const popup = await context.newPage();
       await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
       await popup.getByRole('link', { name: 'Keys', exact: true }).click();
-      const search = popup.getByRole('searchbox');
+      const search = popup.getByRole('searchbox', { includeHidden: true });
+      await popup.getByRole('button', { name: 'Search', exact: true }).click();
       await search.fill('history.example');
       const count = popup.getByRole('status');
-      await expect.poll(() => count.textContent()).toBe('0 selected / 60 filtered / 60 total');
+      await expect.poll(() => count.textContent()).toBe('(60)');
       const root = popup.locator('#root');
       await root.evaluate((element) => {
         element.scrollTop = 1100;
@@ -47,7 +48,7 @@ test('history updates preserve search, visible rows, and live details', async ()
       const before = await stableAnchor.evaluate((element) => element.getBoundingClientRect().top);
       records = [{ ...records[0]!, id: 'new-record' }, ...records];
       await save();
-      await expect.poll(() => count.textContent()).toBe('0 selected / 61 filtered / 61 total');
+      await expect.poll(() => count.textContent()).toBe('(61)');
       await expect
         .poll(async () =>
           Math.abs(
@@ -58,7 +59,7 @@ test('history updates preserve search, visible rows, and live details', async ()
         .toBeLessThanOrEqual(1);
       records = records.slice(6);
       await save();
-      await expect.poll(() => count.textContent()).toBe('0 selected / 55 filtered / 55 total');
+      await expect.poll(() => count.textContent()).toBe('(55)');
       await expect
         .poll(async () =>
           Math.abs(
@@ -93,7 +94,9 @@ test('history updates preserve search, visible rows, and live details', async ()
       expect(await details.evaluate((element) => element.scrollTop)).toBe(detailsScroll);
       await details.locator('svg').first().click();
       await expect.poll(() => popup.getByText('Key Details', { exact: true }).count()).toBe(0);
-      expect(await search.isVisible()).toBe(true);
+      expect(await popup.getByRole('button', { name: 'Search', exact: true }).isVisible()).toBe(
+        true,
+      );
       expect(
         Math.abs(
           (await stableAnchor.evaluate((element) => element.getBoundingClientRect().top)) - before,
@@ -111,15 +114,17 @@ test('history updates preserve search, visible rows, and live details', async ()
       records = records.filter((record) => record.id !== selected.id);
       await save();
       await expect.poll(() => popup.getByText('Key Details', { exact: true }).count()).toBe(0);
-      expect(await search.isVisible()).toBe(true);
+      expect(await popup.getByRole('button', { name: 'Search', exact: true }).isVisible()).toBe(
+        true,
+      );
       expect(await search.inputValue()).toBe('history.example');
       await worker.evaluate(async () => {
         await browser.storage.local.remove('all-keys');
       });
-      await expect.poll(() => count.textContent()).toBe('0 selected / 0 filtered / 0 total');
+      await expect.poll(() => count.textContent()).toBe('(0)');
       records = [captured];
       await save();
-      await expect.poll(() => count.textContent()).toBe('0 selected / 1 filtered / 1 total');
+      await expect.poll(() => count.textContent()).toBe('(1)');
     } finally {
       await context.close();
     }

--- a/test/e2e/manifest.test.ts
+++ b/test/e2e/manifest.test.ts
@@ -27,6 +27,12 @@ test('built content bridge associates DASH and reads playback configuration thro
     });
     try {
       const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+      // Let first-install initialization finish before replacing the default settings.
+      await expect
+        .poll(() =>
+          worker.evaluate(async () => (await browser.storage.local.get('settings')).settings),
+        )
+        .toBeTruthy();
       await worker.evaluate(async () => {
         await browser.storage.local.set({
           settings: JSON.stringify({

--- a/test/e2e/popup-record-deletion.test.ts
+++ b/test/e2e/popup-record-deletion.test.ts
@@ -56,7 +56,7 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await popup.locator('code').first().click();
       await popup.getByRole('button', { name: 'Delete Key', exact: true }).click();
       await expect.poll(() => popup.locator('code').count()).toBe(1);
-      expect(await popup.getByRole('status').innerText()).toBe('0 selected / 1 filtered / 1 total');
+      expect(await popup.getByRole('status').innerText()).toBe('(1)');
       await expect.poll(() => dashboard.locator('code').count()).toBe(1);
       expect(await popup.locator('#root > main').isVisible()).toBe(true);
       const readRecords = () =>
@@ -70,9 +70,7 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       });
       await dashboard.locator('code').click();
       await dashboard.getByRole('button', { name: 'Delete Key', exact: true }).click();
-      await expect
-        .poll(() => popup.getByRole('status').innerText())
-        .toBe('0 selected / 0 filtered / 0 total');
+      await expect.poll(() => popup.getByRole('status').innerText()).toBe('(0)');
       expect(await popup.locator('#root > main').isVisible()).toBe(true);
       expect(await readRecords()).toEqual({
         'all-keys': '[]',
@@ -100,22 +98,30 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await expect.poll(() => popup.locator('code').count()).toBe(3);
       const rowCheckboxes = popup.getByRole('checkbox', { name: /^Select record/ });
       await rowCheckboxes.first().check();
-      expect(
-        await popup
-          .getByRole('checkbox', { name: 'Select All Results' })
-          .evaluate((element: HTMLInputElement) => element.indeterminate),
-      ).toBe(true);
-      await expect
-        .poll(() => popup.getByRole('status').innerText())
-        .toBe('1 selected / 3 filtered / 3 total');
+      expect(await popup.getByRole('button', { name: 'Select All', exact: true }).isVisible()).toBe(
+        true,
+      );
+      await expect.poll(() => popup.getByRole('status').innerText()).toBe('(1/3)');
       expect(await popup.getByRole('heading', { name: 'Key Details' }).count()).toBe(0);
-      await popup.getByLabel('Search').fill('other.example');
-      await expect
-        .poll(() => popup.getByRole('status').innerText())
-        .toBe('0 selected / 1 filtered / 3 total');
-      await popup.getByLabel('Search').fill('example.com');
-      await popup.getByRole('checkbox', { name: 'Select All Results' }).check();
-      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      if (!(await popup.getByRole('searchbox').isVisible()))
+        await popup.getByRole('button', { name: 'Search', exact: true }).click();
+      await popup.getByRole('searchbox').fill('other.example');
+      await expect.poll(() => popup.getByRole('status').innerText()).toBe('(3)');
+      if (!(await popup.getByRole('searchbox').isVisible()))
+        await popup.getByRole('button', { name: 'Search', exact: true }).click();
+      await popup.getByRole('searchbox').fill('example.com');
+      await popup.getByRole('button', { name: 'Select All', exact: true }).click();
+      expect(
+        await rowCheckboxes.evaluateAll((boxes) =>
+          boxes.every((box) => box instanceof HTMLInputElement && box.checked),
+        ),
+      ).toBe(true);
+      await popup.getByRole('button', { name: 'Deselect All', exact: true }).click();
+      expect(await popup.getByRole('button', { name: 'Delete All', exact: true }).isVisible()).toBe(
+        true,
+      );
+      await popup.getByRole('button', { name: 'Select All', exact: true }).click();
+      await popup.getByRole('button', { name: /^Delete Selected \(/ }).click();
       const dialog = popup.getByRole('dialog');
       await expect.poll(() => dialog.isVisible()).toBe(true);
       expect(await dialog.getByRole('heading').innerText()).toBe('Delete 2 records?');
@@ -135,17 +141,13 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       // Let a mistakenly bubbled click finish preparing a second confirmation.
       await popup.waitForTimeout(150);
       expect(await dialog.count()).toBe(0);
-      await expect
-        .poll(() => popup.getByRole('status').innerText())
-        .toBe('2 selected / 2 filtered / 3 total');
-      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      await expect.poll(() => popup.getByRole('status').innerText()).toBe('(2/3)');
+      await popup.getByRole('button', { name: /^Delete Selected \(/ }).click();
       await dialog.waitFor({ state: 'visible' });
       await popup.keyboard.press('Escape');
       expect(await dialog.count()).toBe(0);
-      await expect
-        .poll(() => popup.getByRole('status').innerText())
-        .toBe('2 selected / 2 filtered / 3 total');
-      await popup.getByRole('button', { name: 'Delete Selected', exact: true }).click();
+      await expect.poll(() => popup.getByRole('status').innerText()).toBe('(2/3)');
+      await popup.getByRole('button', { name: /^Delete Selected \(/ }).click();
       const arriving = { ...key, url: 'https://example.com/new', createdAt: key.createdAt + 100 };
       await seed([...records, arriving]);
       expect(await dialog.getByRole('heading').innerText()).toBe('Delete 2 records?');
@@ -164,7 +166,9 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await popup.evaluate(() => document.documentElement.classList.remove('dark'));
       await expect.poll(() => popup.locator('code').count()).toBe(1);
       expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite, arriving]);
-      await popup.getByLabel('Search').fill('');
+      if (!(await popup.getByRole('searchbox').isVisible()))
+        await popup.getByRole('button', { name: 'Search', exact: true }).click();
+      await popup.getByRole('searchbox').fill('');
       await popup.screenshot({ path: resolve('output/playwright/bulk-deletion/selection.png') });
       await dashboard.getByRole('button', { name: 'Delete Site Keys', exact: true }).click();
       const siteDialog = dashboard.getByRole('dialog');
@@ -173,7 +177,9 @@ test('deletes individual records and confirms frozen selected, site, and all-rec
       await siteDialog.getByRole('button', { name: 'Delete 1 record', exact: true }).click();
       await expect.poll(() => popup.locator('code').count()).toBe(1);
       expect(JSON.parse(String((await readRecords())['all-keys']))).toEqual([otherSite]);
-      await popup.getByLabel('Search').fill('no-match');
+      if (!(await popup.getByRole('searchbox').isVisible()))
+        await popup.getByRole('button', { name: 'Search', exact: true }).click();
+      await popup.getByRole('searchbox').fill('no-match');
       await popup.getByRole('button', { name: 'Delete All', exact: true }).click();
       await expect.poll(() => dialog.isVisible()).toBe(true);
       expect(await dialog.innerText()).toContain(

--- a/test/extension-history-filters.test.ts
+++ b/test/extension-history-filters.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from 'vitest';
 import {
   filterHistory,
+  getHistorySites,
   type HistoryFilters,
 } from '../src/extension/entrypoints/popup/utils/history-filters';
 import type { KeyInfo } from '../src/extension/utils/storage';
 
-const defaults: HistoryFilters = { search: '', drm: 'all', order: 'newest' };
+const defaults: HistoryFilters = { search: '', site: '', drm: 'all', order: 'newest' };
 const record = (createdAt: string, drmSystem?: KeyInfo['drmSystem']): KeyInfo => ({
   id: 'aabbccdd11223344556677889900aabb',
   value: 'usable',
@@ -21,6 +22,29 @@ const records = [
   record('2026-03-09T00:00:00', 'C'),
   record('2026-03-07T23:59:59.999'),
 ];
+
+test('lists unique normalized sites and filters by the page site with DRM and search', () => {
+  const widevine = {
+    ...record('2026-03-08T00:00:00', 'W'),
+    url: 'https://www.watch.example/other',
+  };
+  const playready = record('2026-03-08T23:59:59.999', 'P');
+  const other = { ...record('2026-03-09T00:00:00', 'C'), url: 'https://other.example/show' };
+  const invalid = { ...record('2026-03-07T23:59:59.999'), url: 'invalid' };
+  const history = [widevine, playready, other, invalid];
+
+  expect(getHistorySites(history)).toEqual(['other.example', 'watch.example']);
+  expect(getHistorySites([])).toEqual([]);
+  expect(filterHistory(history, { ...defaults, site: 'watch.example' })).toEqual([
+    playready,
+    widevine,
+  ]);
+  expect(
+    filterHistory(history, { ...defaults, site: 'watch.example', drm: 'P', search: 'manifest' }),
+  ).toEqual([playready]);
+  expect(filterHistory(history, { ...defaults, site: 'cdn.example' })).toEqual([]);
+  expect(filterHistory(history, defaults)).toHaveLength(4);
+});
 
 test('combines DRM and normalized search', () => {
   for (const search of ['AABB-CCDD', ' WATCH.EXAMPLE ', 'MANIFEST.MPD']) {


### PR DESCRIPTION
## Summary

- Add site filtering and reusable select controls to key history.
- Collapse search into an accessible, focus-aware header control.
- Move selection and deletion actions into the keys header with filtered-result support.
- Update history, search, deletion, and manifest E2E coverage.

## Testing

- Updated E2E tests for history filters, key search, live history, record deletion, and manifest initialization.
- Not run locally.