### PR TITLE
feat(extension): add HLS & MSS manifest detection

### DIFF
--- a/src/extension/entrypoints/background.ts
+++ b/src/extension/entrypoints/background.ts
@@ -1,3 +1,4 @@
+import { getManifestMetadata } from '@/utils/manifest';
 import { getCredentialFingerprint } from '@/utils/credential-fingerprint';
 import {
   clearCaptureDiagnostics,
@@ -611,7 +612,7 @@ export default defineBackground({
               captureId: diagnostic?.captureId,
               drmSystem: system,
               url: message.url,
-              mpd: message.mpd,
+              ...getManifestMetadata(message),
               pssh: message.initData,
               createdAt: Date.now(),
             }));
@@ -650,7 +651,7 @@ export default defineBackground({
             id: fromBase64(id).toHex(),
             value: status,
             url: message.url,
-            mpd: message.mpd,
+            ...getManifestMetadata(message),
             pssh: message.initData,
             createdAt: new Date().getTime(),
           }));
@@ -821,7 +822,7 @@ export default defineBackground({
             id,
             value,
             url: message.url,
-            mpd: message.mpd,
+            ...getManifestMetadata(message),
             pssh: message.initData,
             createdAt: new Date().getTime(),
           }));

--- a/src/extension/entrypoints/popup/components/cell.tsx
+++ b/src/extension/entrypoints/popup/components/cell.tsx
@@ -20,6 +20,7 @@ interface CellProps {
   disabled?: boolean;
   'aria-expanded'?: boolean;
   'aria-controls'?: string;
+  'aria-pressed'?: boolean;
   onClick?: () => void;
 }
 
@@ -46,6 +47,7 @@ export const Cell: Component<CellProps> = (props) => {
       title={props.title}
       aria-expanded={props['aria-expanded']}
       aria-controls={props['aria-controls']}
+      aria-pressed={props['aria-pressed']}
       disabled={cellProps.component === 'button' ? props.disabled : undefined}
       onClick={props.onClick}
     >

--- a/src/extension/entrypoints/popup/components/keys-list.tsx
+++ b/src/extension/entrypoints/popup/components/keys-list.tsx
@@ -1,3 +1,4 @@
+import { isManifestUrl } from '@/utils/manifest';
 import { Accessor, Component, JSX, batch, createComputed, untrack } from 'solid-js';
 import { createStore, reconcile } from 'solid-js/store';
 import { Cell } from './cell';
@@ -130,49 +131,54 @@ export const KeysList: Component<KeysListProps> = (props) => {
               footer={props.footer}
             >
               <For each={rows.filter((row) => row.visible)}>
-                {(row) => (
-                  <div data-history-row={row.identity} class="[&>div]:rounded-[inherit]">
-                    <Cell
-                      class="group min-w-0"
-                      onClick={() => setOpenedIdentity(row.identity)}
-                      selection={
-                        props.selection
-                          ? {
-                              label: `Select record ${row.key.id} from ${row.key.url}`,
-                              checked: props.selection.tokens.includes(keyRecordToken(row.key)),
-                              onChange: (checked) => {
-                                const token = keyRecordToken(row.key);
-                                const selection = props.selection;
-                                if (!selection) return;
-                                selection.onChange(
-                                  checked
-                                    ? [...selection.tokens, token]
-                                    : selection.tokens.filter((item) => item !== token),
-                                );
-                              },
-                            }
-                          : undefined
-                      }
-                    >
-                      <code title="Click to copy" class="text-[13px] truncate flex w-full">
-                        <span class="w-1/2 truncate">{row.key.id}</span>:
-                        {/* value may be a status if Spoofing disabled */}
-                        <span class="w-1/2 truncate">{row.key.value}</span>
-                      </code>
-                      <div class="text-[10px] text-gray-500 flex justify-between dark:text-neutral-400">
-                        <a
-                          title={row.key.mpd || row.key.url}
-                          target="_blank"
-                          href={row.key.mpd || row.key.url}
-                          class="w-fit truncate hover:underline hover:text-blue-500 dark:hover:text-blue-400"
-                        >
-                          {shorten(row.key.mpd || row.key.url)}
-                        </a>
-                        <div>{formatRelativeTime(new Date(row.key.createdAt).toISOString())}</div>
-                      </div>
-                    </Cell>
-                  </div>
-                )}
+                {(row) => {
+                  const href = createMemo(() =>
+                    isManifestUrl(row.key.mpd) ? row.key.mpd : row.key.url,
+                  );
+                  return (
+                    <div data-history-row={row.identity} class="[&>div]:rounded-[inherit]">
+                      <Cell
+                        class="group min-w-0"
+                        onClick={() => setOpenedIdentity(row.identity)}
+                        selection={
+                          props.selection
+                            ? {
+                                label: `Select record ${row.key.id} from ${row.key.url}`,
+                                checked: props.selection.tokens.includes(keyRecordToken(row.key)),
+                                onChange: (checked) => {
+                                  const token = keyRecordToken(row.key);
+                                  const selection = props.selection;
+                                  if (!selection) return;
+                                  selection.onChange(
+                                    checked
+                                      ? [...selection.tokens, token]
+                                      : selection.tokens.filter((item) => item !== token),
+                                  );
+                                },
+                              }
+                            : undefined
+                        }
+                      >
+                        <code title="Click to copy" class="text-[13px] truncate flex w-full">
+                          <span class="w-1/2 truncate">{row.key.id}</span>:
+                          {/* value may be a status if Spoofing disabled */}
+                          <span class="w-1/2 truncate">{row.key.value}</span>
+                        </code>
+                        <div class="text-[10px] text-gray-500 flex justify-between dark:text-neutral-400">
+                          <a
+                            title={href()}
+                            target="_blank"
+                            href={href()}
+                            class="w-fit truncate hover:underline hover:text-blue-500 dark:hover:text-blue-400"
+                          >
+                            {shorten(href())}
+                          </a>
+                          <div>{formatRelativeTime(new Date(row.key.createdAt).toISOString())}</div>
+                        </div>
+                      </Cell>
+                    </div>
+                  );
+                }}
               </For>
             </Section>
           </List>

--- a/src/extension/entrypoints/popup/routes/key-settings.tsx
+++ b/src/extension/entrypoints/popup/routes/key-settings.tsx
@@ -1,6 +1,8 @@
+import { getManifestMetadata, isManifestUrl, manifestLabels } from '@/utils/manifest';
+import { CellCheckmark } from '../components/cell-checkmark';
 import { popupHistory } from '../utils/history';
 import { Component } from 'solid-js';
-import { TbOutlineClipboardText, TbOutlineTrash } from 'solid-icons/tb';
+import { TbOutlineClipboardText } from 'solid-icons/tb';
 import { getWebsiteDomain, KeyInfo } from '@/utils/storage';
 import { DeleteKeys } from '../components/delete-keys';
 import { Header } from '../components/header';
@@ -20,7 +22,25 @@ type KeySettingsProps = {
 export const KeySettings: Component<KeySettingsProps> = (props) => {
   const [isDeleting, setIsDeleting] = createSignal(false);
   const [deleteError, setDeleteError] = createSignal<string>();
-  const generatedCommand = createMemo(() => buildDownloadCommand(props.key));
+  const metadata = createMemo(() => getManifestMetadata(props.key));
+  const [manifestUrl, setManifestUrl] = createSignal(metadata().mpd ?? '');
+  let previousManifest = metadata().mpd ?? '';
+  createEffect(() => {
+    const nextManifest = metadata().mpd ?? '';
+    setManifestUrl((current) => (current === previousManifest ? nextManifest : current));
+    previousManifest = nextManifest;
+  });
+  const manifests = createMemo(() => {
+    const options = (metadata().manifests ?? []).map((manifest) => ({
+      url: manifest.url,
+      label: `${manifestLabels[manifest.kind]} · ${manifest.matched ? 'Matched' : 'Seen on page'}`,
+    }));
+    const saved = metadata().mpd;
+    if (saved && !options.some((option) => option.url === saved))
+      options.unshift({ url: saved, label: 'Saved manifest' });
+    return options;
+  });
+  const generatedCommand = createMemo(() => buildDownloadCommand(props.key, manifestUrl()) ?? '');
   const [command, setCommand] = createSignal(generatedCommand());
   let previousCommand = generatedCommand();
   createEffect(() => {
@@ -28,6 +48,11 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
     setCommand((current) => (current === previousCommand ? nextCommand : current));
     previousCommand = nextCommand;
   });
+
+  const chooseManifest = (url: string) => {
+    setManifestUrl(url);
+    setCommand(buildDownloadCommand(props.key, url) ?? '');
+  };
 
   const deleteRecord = async () => {
     if (isDeleting()) return;
@@ -114,19 +139,62 @@ export const KeySettings: Component<KeySettingsProps> = (props) => {
             )}
           </Show>
         </Section>
+        <Section
+          header="Manifest"
+          footer={
+            !isManifestUrl(manifestUrl())
+              ? 'Choose a detected manifest or enter an HTTP(S) URL to build a download command.'
+              : 'Matched manifests share initialization data with this capture. Other URLs were seen in the same page frame.'
+          }
+        >
+          <Show
+            when={manifests().length}
+            fallback={<Cell>No manifest detected for this capture</Cell>}
+          >
+            <For each={manifests()}>
+              {(manifest) => (
+                <Cell
+                  component="button"
+                  title={manifest.url}
+                  subtitle={manifest.url}
+                  aria-pressed={manifestUrl() === manifest.url}
+                  after={<CellCheckmark checked={manifestUrl() === manifest.url} />}
+                  onClick={() => chooseManifest(manifest.url)}
+                >
+                  {manifest.label}
+                </Cell>
+              )}
+            </For>
+          </Show>
+          <Cell>
+            <input
+              type="url"
+              aria-label="Manifest URL"
+              class="w-full outline-none bg-transparent font-mono text-xs"
+              placeholder="https://example.com/manifest.m3u8"
+              value={manifestUrl()}
+              onInput={(event) => chooseManifest(event.currentTarget.value)}
+              aria-invalid={Boolean(manifestUrl()) && !isManifestUrl(manifestUrl())}
+            />
+          </Cell>
+        </Section>
         <Section header="Command builder (Bash / Zsh)">
           <Cell class="w-full">
             <textarea
               class="font-mono outline-none bg-transparent border-none w-full"
-              placeholder="Enter command"
+              aria-label="Download command"
+              disabled={!isManifestUrl(manifestUrl())}
+              placeholder="Select a manifest first"
               value={command()}
               rows={6}
               onInput={(e) => setCommand(e.currentTarget.value)}
             />
           </Cell>
           <Cell
+            component="button"
             before={<TbOutlineClipboardText />}
             variant="primary"
+            disabled={!isManifestUrl(manifestUrl()) || !command().trim()}
             onClick={() => navigator.clipboard.writeText(command())}
           >
             Copy command

--- a/src/extension/entrypoints/popup/utils/command.ts
+++ b/src/extension/entrypoints/popup/utils/command.ts
@@ -1,7 +1,13 @@
+import { isManifestUrl } from '@/utils/manifest';
 import type { KeyInfo } from '@/utils/storage';
 
 // POSIX shell quoting: leave single quotes briefly to insert a literal apostrophe.
 const quoteShellArgument = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
 
-export const buildDownloadCommand = (key: Pick<KeyInfo, 'mpd' | 'id' | 'value'>) =>
-  `N_m3u8DL-RE ${quoteShellArgument(key.mpd ?? '')} --key ${quoteShellArgument(`${key.id}:${key.value}`)}`;
+export const buildDownloadCommand = (
+  key: Pick<KeyInfo, 'mpd' | 'id' | 'value'>,
+  manifestUrl = key.mpd,
+) => {
+  if (!isManifestUrl(manifestUrl)) return undefined;
+  return `N_m3u8DL-RE ${quoteShellArgument(manifestUrl)} --key ${quoteShellArgument(`${key.id}:${key.value}`)}`;
+};

--- a/src/extension/entrypoints/popup/utils/history-filters.ts
+++ b/src/extension/entrypoints/popup/utils/history-filters.ts
@@ -1,3 +1,4 @@
+import { getManifestMetadata } from '@/utils/manifest';
 import { getWebsiteDomain, type KeyInfo } from '@/utils/storage';
 
 export type HistoryFilters = {
@@ -29,7 +30,10 @@ export const filterHistory = (records: readonly KeyInfo[], filters: HistoryFilte
         !query ||
         (kidQuery.length > 0 && key.id.toLowerCase().replaceAll('-', '').includes(kidQuery)) ||
         key.url.toLowerCase().includes(query) ||
-        key.mpd?.toLowerCase().includes(query);
+        key.mpd?.toLowerCase().includes(query) ||
+        getManifestMetadata(key).manifests?.some((manifest) =>
+          manifest.url.toLowerCase().includes(query),
+        );
       const matchesSite = !filters.site || getWebsiteDomain(key.url) === filters.site;
       return matchesDrm && matchesSearch && matchesSite;
     })

--- a/src/extension/utils/drm-playback.ts
+++ b/src/extension/utils/drm-playback.ts
@@ -1,4 +1,4 @@
-import { findManifest } from '@/utils/manifest';
+import { getManifestCapture } from '@/utils/manifest';
 import { z } from 'zod';
 import { CLIENT_KEY_SYSTEMS, type ClientKeySystem } from '@okova/lib/key-system';
 import { toBytes, bytesToBase64, fromHex, fromBase64 } from '@okova/lib/utils';
@@ -78,7 +78,7 @@ export const installDrmPlayback = () => {
           initDataType: 'cenc',
           initData,
           serverCertificate,
-          mpd: findManifest(initData),
+          ...getManifestCapture(initData),
         });
       const dispatchChallenge = (challenge: ArrayBuffer) => {
         // Deliver as a task, after generateRequest or update has resolved.

--- a/src/extension/utils/eme-interception.ts
+++ b/src/extension/utils/eme-interception.ts
@@ -1,4 +1,4 @@
-import { findManifest } from '@/utils/manifest';
+import { getManifestCapture } from '@/utils/manifest';
 import { toBytes, bytesToBase64, fromBase64 } from '@okova/lib/utils';
 import { sendDrmMessage } from '@/utils/drm-bridge';
 import { playbackSessions } from '@/utils/playback-sessions';
@@ -99,7 +99,7 @@ export const installEmeInterception = () => {
         keySystem: getKeySystem(session),
         initData: session._initData,
         initDataType: session.initDataType,
-        mpd: findManifest(session._initData),
+        ...getManifestCapture(session._initData),
         keyStatuses,
       });
       return;
@@ -176,7 +176,7 @@ export const installEmeInterception = () => {
         initDataType: session.initDataType,
         message,
         messageBase64,
-        mpd: findManifest(session._initData),
+        ...getManifestCapture(session._initData),
       });
 
       if (result?.keys) {

--- a/src/extension/utils/manifest-inspection.ts
+++ b/src/extension/utils/manifest-inspection.ts
@@ -140,11 +140,15 @@ export const installManifestInspection = () => {
   try {
     if (!(window.MANIFEST_LIST instanceof Map)) window.MANIFEST_LIST = new Map();
   } catch {
-    Object.defineProperty(window, 'MANIFEST_LIST', {
-      value: new Map(),
-      writable: true,
-      configurable: true,
-    });
+    try {
+      Object.defineProperty(window, 'MANIFEST_LIST', {
+        value: new Map(),
+        writable: true,
+        configurable: true,
+      });
+    } catch {
+      // A non-configurable page property must not prevent listener registration.
+    }
   }
 
   window.addEventListener('message', (event: MessageEvent<unknown>) => {

--- a/src/extension/utils/manifest-inspection.ts
+++ b/src/extension/utils/manifest-inspection.ts
@@ -1,15 +1,23 @@
 import { z } from 'zod/mini';
-import { isManifestUrl, splitPssh, MAX_MANIFESTS, type Manifest } from '@/utils/manifest';
+import {
+  isManifestUrl,
+  splitPssh,
+  MAX_MANIFESTS,
+  MAX_CHILD_PLAYLISTS,
+  MAX_INIT_DATA_ENTRIES,
+  MAX_MANIFEST_REQUEST_URLS,
+  parseDetectedManifest,
+  type DetectedManifest,
+} from '@/utils/manifest';
 
 const DASH_NAMESPACE = 'urn:mpeg:dash:schema:mpd:2011';
 const CENC_NAMESPACE = 'urn:mpeg:cenc:2013';
-const MAX_CHILD_PLAYLISTS = 50;
-const MAX_INIT_DATA_ENTRIES = 50;
 const responseSchema = z.object({
   namespace: z.literal('okova:network'),
   method: z.literal('response'),
   params: z.object({
     url: z.string().check(z.refine(isManifestUrl)),
+    requestUrl: z.optional(z.string().check(z.maxLength(8192), z.refine(isManifestUrl))),
     text: z.string().check(z.maxLength(1024 * 1024)),
   }),
 });
@@ -17,14 +25,9 @@ const responseSchema = z.object({
 declare global {
   interface Window {
     MPD_LIST: Map<string, string>;
-    MANIFEST_LIST: Map<string, DetectedManifest>;
+    MANIFEST_LIST: Map<string, unknown>;
   }
 }
-
-type DetectedManifest = Pick<Manifest, 'url' | 'kind'> & {
-  initData: string[];
-  children: string[];
-};
 
 // Smooth Streaming carries a raw PlayReady Object; EME usually wraps it in a PSSH.
 const playreadyInitData = (value: string) => {
@@ -140,11 +143,15 @@ export const installManifestInspection = () => {
     if (event.source !== window) return;
     const parsed = responseSchema.safeParse(event.data);
     if (!parsed.success) return;
-    const { url, text } = parsed.data.params;
+    const { url, text, requestUrl } = parsed.data.params;
     try {
       const manifest = inspectManifest(url, text);
       if (!manifest) return;
       manifest.initData = [...new Set(manifest.initData)].slice(0, MAX_INIT_DATA_ENTRIES);
+      const previous = parseDetectedManifest(window.MANIFEST_LIST.get(url));
+      manifest.requestUrls = [
+        ...new Set([...(requestUrl ? [requestUrl] : []), ...(previous?.requestUrls ?? [])]),
+      ].slice(0, MAX_MANIFEST_REQUEST_URLS);
       window.MANIFEST_LIST.delete(url);
       window.MANIFEST_LIST.set(url, manifest);
       while (window.MANIFEST_LIST.size > MAX_MANIFESTS) {

--- a/src/extension/utils/manifest-inspection.ts
+++ b/src/extension/utils/manifest-inspection.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod/mini';
-import { isManifestUrl, splitPssh } from '@/utils/manifest';
+import { isManifestUrl, splitPssh, MAX_MANIFESTS, type Manifest } from '@/utils/manifest';
 
 const DASH_NAMESPACE = 'urn:mpeg:dash:schema:mpd:2011';
 const CENC_NAMESPACE = 'urn:mpeg:cenc:2013';
+const MAX_CHILD_PLAYLISTS = 50;
+const MAX_INIT_DATA_ENTRIES = 50;
 const responseSchema = z.object({
   namespace: z.literal('okova:network'),
   method: z.literal('response'),
@@ -15,11 +17,124 @@ const responseSchema = z.object({
 declare global {
   interface Window {
     MPD_LIST: Map<string, string>;
+    MANIFEST_LIST: Map<string, DetectedManifest>;
   }
 }
 
+type DetectedManifest = Pick<Manifest, 'url' | 'kind'> & {
+  initData: string[];
+  children: string[];
+};
+
+// Smooth Streaming carries a raw PlayReady Object; EME usually wraps it in a PSSH.
+const playreadyInitData = (value: string) => {
+  try {
+    const binary = atob(value.replace(/\s/g, ''));
+    if (!binary.length) return [];
+    const box = new Uint8Array(32 + binary.length);
+    const view = new DataView(box.buffer);
+    view.setUint32(0, box.length);
+    box.set([0x70, 0x73, 0x73, 0x68], 4);
+    box.set(
+      [
+        0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86, 0xab, 0x92, 0xe6, 0x5b, 0xe0, 0x88, 0x5f,
+        0x95,
+      ],
+      12,
+    );
+    view.setUint32(28, binary.length);
+    for (let index = 0; index < binary.length; index++) box[32 + index] = binary.charCodeAt(index);
+    return [btoa(binary), btoa(Array.from(box, (byte) => String.fromCharCode(byte)).join(''))];
+  } catch {
+    return [];
+  }
+};
+
+const hlsAttributes = (line: string) =>
+  new Map(
+    Array.from(
+      line
+        .slice(line.indexOf(':') + 1)
+        .matchAll(/(?:^|,)([A-Z0-9-]+)=(?:"([^"\r\n]*)"|([^,\r\n]*))/g),
+      (match) => [match[1], match[2] ?? match[3]],
+    ),
+  );
+
+const inspectManifest = (url: string, text: string): DetectedManifest | undefined => {
+  const initData: string[] = [];
+  if (/^#EXTM3U(?:\r?\n|$)/.test(text.trimStart())) {
+    const children: string[] = [];
+    let isMaster = false;
+    let nextIsPlaylist = false;
+    for (const rawLine of text.trimStart().split(/\r?\n/)) {
+      const line = rawLine.trim();
+      const attributes = hlsAttributes(line);
+      if (line.startsWith('#EXT-X-SESSION-KEY:')) isMaster = true;
+      if (/^#EXT-X-(?:SESSION-KEY|KEY):/.test(line) && attributes.get('METHOD') !== 'NONE') {
+        const uri = attributes.get('URI');
+        const data = uri?.match(/^data:[^,]*;base64,(.*)$/i)?.[1];
+        if (data) {
+          try {
+            const decoded = decodeURIComponent(data);
+            initData.push(...splitPssh(decoded));
+            if (attributes.get('KEYFORMAT') === 'com.microsoft.playready')
+              initData.push(...playreadyInitData(decoded));
+          } catch {
+            // Ignore malformed embedded data without losing the playlist URL.
+          }
+        }
+      }
+      let child: string | undefined;
+      if (line.startsWith('#EXT-X-STREAM-INF:')) {
+        isMaster = true;
+        nextIsPlaylist = true;
+      } else if (/^#EXT-X-(?:MEDIA|I-FRAME-STREAM-INF):/.test(line)) {
+        isMaster = true;
+        child = attributes.get('URI');
+      } else if (nextIsPlaylist && line && !line.startsWith('#')) {
+        child = line;
+        nextIsPlaylist = false;
+      }
+      if (child && children.length < MAX_CHILD_PLAYLISTS) {
+        try {
+          const resolved = new URL(child, url).href;
+          if (isManifestUrl(resolved)) children.push(resolved);
+        } catch {
+          // Invalid playlist references do not affect other variants.
+        }
+      }
+    }
+    return { url, kind: isMaster ? 'hls-master' : 'hls-media', initData, children };
+  }
+  const document = new DOMParser().parseFromString(text, 'text/xml');
+  if (document.getElementsByTagNameNS('*', 'parsererror').length) return;
+  const root = document.documentElement;
+  if (root?.localName === 'MPD' && root.namespaceURI === DASH_NAMESPACE) {
+    for (const protection of Array.from(
+      document.getElementsByTagNameNS(DASH_NAMESPACE, 'ContentProtection'),
+    )) {
+      for (const child of Array.from(protection.getElementsByTagNameNS(CENC_NAMESPACE, 'pssh'))) {
+        if (child.parentNode === protection) initData.push(...splitPssh(child.textContent ?? ''));
+      }
+    }
+    return { url, kind: 'dash', initData, children: [] };
+  }
+  if (root?.localName === 'SmoothStreamingMedia' && !root.namespaceURI) {
+    for (const header of Array.from(document.getElementsByTagName('ProtectionHeader'))) {
+      const systemId = header.getAttribute('SystemID')?.replace(/[{}-]/g, '').toLowerCase();
+      if (
+        header.parentNode?.nodeName === 'Protection' &&
+        systemId === '9a04f07998404286ab92e65be0885f95'
+      )
+        initData.push(...playreadyInitData(header.textContent ?? ''));
+    }
+    return { url, kind: 'mss', initData, children: [] };
+  }
+};
+
 export const installManifestInspection = () => {
   if (!(window.MPD_LIST instanceof Map)) window.MPD_LIST = new Map();
+  if (!(window.MANIFEST_LIST instanceof Map)) window.MANIFEST_LIST = new Map();
 
   window.addEventListener('message', (event: MessageEvent<unknown>) => {
     if (event.source !== window) return;
@@ -27,25 +142,20 @@ export const installManifestInspection = () => {
     if (!parsed.success) return;
     const { url, text } = parsed.data.params;
     try {
-      const mpd = new DOMParser().parseFromString(text, 'text/xml');
-      if (mpd.getElementsByTagNameNS('*', 'parsererror').length) return;
-      if (
-        mpd.documentElement?.localName !== 'MPD' ||
-        mpd.documentElement.namespaceURI !== DASH_NAMESPACE
-      )
-        return;
-      for (const protection of Array.from(
-        mpd.getElementsByTagNameNS(DASH_NAMESPACE, 'ContentProtection'),
-      )) {
-        for (const child of Array.from(protection.getElementsByTagNameNS(CENC_NAMESPACE, 'pssh'))) {
-          if (child.parentNode !== protection) continue;
-          for (const pssh of splitPssh(child.textContent ?? '')) {
-            window.MPD_LIST.set(pssh, url);
-            while (window.MPD_LIST.size > 1_000) {
-              const oldest = window.MPD_LIST.keys().next();
-              if (!oldest.done) window.MPD_LIST.delete(oldest.value);
-            }
-          }
+      const manifest = inspectManifest(url, text);
+      if (!manifest) return;
+      manifest.initData = [...new Set(manifest.initData)].slice(0, MAX_INIT_DATA_ENTRIES);
+      window.MANIFEST_LIST.delete(url);
+      window.MANIFEST_LIST.set(url, manifest);
+      while (window.MANIFEST_LIST.size > MAX_MANIFESTS) {
+        const oldest = window.MANIFEST_LIST.keys().next();
+        if (!oldest.done) window.MANIFEST_LIST.delete(oldest.value);
+      }
+      for (const data of manifest.initData) {
+        window.MPD_LIST.set(data, url);
+        while (window.MPD_LIST.size > 1_000) {
+          const oldest = window.MPD_LIST.keys().next();
+          if (!oldest.done) window.MPD_LIST.delete(oldest.value);
         }
       }
     } catch {

--- a/src/extension/utils/manifest-inspection.ts
+++ b/src/extension/utils/manifest-inspection.ts
@@ -137,7 +137,15 @@ const inspectManifest = (url: string, text: string): DetectedManifest | undefine
 
 export const installManifestInspection = () => {
   if (!(window.MPD_LIST instanceof Map)) window.MPD_LIST = new Map();
-  if (!(window.MANIFEST_LIST instanceof Map)) window.MANIFEST_LIST = new Map();
+  try {
+    if (!(window.MANIFEST_LIST instanceof Map)) window.MANIFEST_LIST = new Map();
+  } catch {
+    Object.defineProperty(window, 'MANIFEST_LIST', {
+      value: new Map(),
+      writable: true,
+      configurable: true,
+    });
+  }
 
   window.addEventListener('message', (event: MessageEvent<unknown>) => {
     if (event.source !== window) return;

--- a/src/extension/utils/manifest.ts
+++ b/src/extension/utils/manifest.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod/mini';
 
 export const MAX_MANIFESTS = 50;
+export const MAX_CHILD_PLAYLISTS = 50;
+export const MAX_INIT_DATA_ENTRIES = 50;
+export const MAX_MANIFEST_REQUEST_URLS = 50;
+export const MAX_MANIFEST_METADATA_BYTES = 16 * 1024;
 export const manifestLabels = {
   dash: 'DASH',
   'hls-master': 'HLS master',
@@ -8,30 +12,73 @@ export const manifestLabels = {
   mss: 'MSS',
 };
 
+const manifestUrlSchema = z.string().check(
+  z.maxLength(8192),
+  z.refine((value) => isManifestUrl(value)),
+);
+const manifestKindSchema = z.enum(['dash', 'hls-master', 'hls-media', 'mss']);
 const manifestSchema = z.object({
-  url: z.string().check(
-    z.maxLength(8192),
-    z.refine((value) => isManifestUrl(value)),
-  ),
-  kind: z.enum(['dash', 'hls-master', 'hls-media', 'mss']),
+  url: manifestUrlSchema,
+  kind: manifestKindSchema,
   matched: z.boolean(),
 });
 export type Manifest = z.infer<typeof manifestSchema>;
 
-// Page messages and old history records both cross this boundary.
+const detectedManifestSchema = z.object({
+  url: manifestUrlSchema,
+  kind: manifestKindSchema,
+  initData: z
+    .array(z.string().check(z.maxLength(1024 * 1024)))
+    .check(z.maxLength(MAX_INIT_DATA_ENTRIES)),
+  children: z.array(manifestUrlSchema).check(z.maxLength(MAX_CHILD_PLAYLISTS)),
+  requestUrls: z.optional(z.array(manifestUrlSchema).check(z.maxLength(MAX_MANIFEST_REQUEST_URLS))),
+});
+export type DetectedManifest = z.infer<typeof detectedManifestSchema>;
+
+export const parseDetectedManifest = (value: unknown) => {
+  try {
+    const result = detectedManifestSchema.safeParse(value);
+    return result.success ? result.data : undefined;
+  } catch {
+    // Page-owned properties can throw from getters. Manifest discovery must not stop EME.
+    return undefined;
+  }
+};
+
+const encoder = new TextEncoder();
+const serializedSize = (value: unknown) => encoder.encode(JSON.stringify(value)).byteLength;
+
+// Bound the complete serialized metadata, including the duplicated preferred URL.
+// Keep URLs intact; truncating a signed URL would make it unusable.
 export const getManifestMetadata = (record: { mpd?: unknown; manifests?: unknown }) => {
-  const manifests: Manifest[] = [];
+  const preferred = manifestUrlSchema.safeParse(record.mpd);
+  let mpd = preferred.success ? preferred.data : undefined;
+  let sizeBytes = serializedSize({ mpd, manifests: [] });
+  if (sizeBytes > MAX_MANIFEST_METADATA_BYTES) {
+    mpd = undefined;
+    sizeBytes = serializedSize({ manifests: [] });
+  }
+  const candidates: Manifest[] = [];
   if (Array.isArray(record.manifests)) {
     for (const value of record.manifests.slice(0, MAX_MANIFESTS)) {
       const result = manifestSchema.safeParse(value);
-      if (result.success && !manifests.some((item) => item.url === result.data.url))
-        manifests.push(result.data);
+      if (result.success && !candidates.some((item) => item.url === result.data.url))
+        candidates.push(result.data);
     }
   }
-  return {
-    mpd: isManifestUrl(record.mpd) ? record.mpd : undefined,
-    ...(manifests.length ? { manifests } : {}),
-  };
+  candidates.sort(
+    (left, right) =>
+      Number(right.url === mpd) - Number(left.url === mpd) ||
+      Number(right.matched) - Number(left.matched),
+  );
+  const manifests: Manifest[] = [];
+  for (const candidate of candidates) {
+    const addedBytes = serializedSize(candidate) + (manifests.length ? 1 : 0);
+    if (sizeBytes + addedBytes > MAX_MANIFEST_METADATA_BYTES) continue;
+    manifests.push(candidate);
+    sizeBytes += addedBytes;
+  }
+  return { mpd, ...(manifests.length ? { manifests } : {}) };
 };
 
 // Match the original box bytes without decoding DRM-specific payloads.
@@ -89,7 +136,14 @@ export const findManifest = (initData: string | undefined) => {
 
 export const getManifestCapture = (initData: string | undefined) => {
   const tokens = new Set(initData ? [initData, ...splitPssh(initData)] : []);
-  const detected = window.MANIFEST_LIST instanceof Map ? [...window.MANIFEST_LIST.values()] : [];
+  const detected: DetectedManifest[] = [];
+  if (window.MANIFEST_LIST instanceof Map) {
+    for (const value of window.MANIFEST_LIST.values()) {
+      if (detected.length === MAX_MANIFESTS) break;
+      const manifest = parseDetectedManifest(value);
+      if (manifest) detected.push(manifest);
+    }
+  }
   const directUrls = new Set(
     detected
       .filter((item) => item.initData.some((data) => tokens.has(data)))
@@ -101,6 +155,9 @@ export const getManifestCapture = (initData: string | undefined) => {
     const previousSize = matchedUrls.size;
     for (const item of detected) {
       if (item.children.some((url) => matchedUrls.has(url))) matchedUrls.add(item.url);
+      if (matchedUrls.has(item.url)) {
+        for (const requestUrl of item.requestUrls ?? []) matchedUrls.add(requestUrl);
+      }
     }
     if (previousSize === matchedUrls.size) break;
   }

--- a/src/extension/utils/manifest.ts
+++ b/src/extension/utils/manifest.ts
@@ -1,3 +1,39 @@
+import { z } from 'zod/mini';
+
+export const MAX_MANIFESTS = 50;
+export const manifestLabels = {
+  dash: 'DASH',
+  'hls-master': 'HLS master',
+  'hls-media': 'HLS media',
+  mss: 'MSS',
+};
+
+const manifestSchema = z.object({
+  url: z.string().check(
+    z.maxLength(8192),
+    z.refine((value) => isManifestUrl(value)),
+  ),
+  kind: z.enum(['dash', 'hls-master', 'hls-media', 'mss']),
+  matched: z.boolean(),
+});
+export type Manifest = z.infer<typeof manifestSchema>;
+
+// Page messages and old history records both cross this boundary.
+export const getManifestMetadata = (record: { mpd?: unknown; manifests?: unknown }) => {
+  const manifests: Manifest[] = [];
+  if (Array.isArray(record.manifests)) {
+    for (const value of record.manifests.slice(0, MAX_MANIFESTS)) {
+      const result = manifestSchema.safeParse(value);
+      if (result.success && !manifests.some((item) => item.url === result.data.url))
+        manifests.push(result.data);
+    }
+  }
+  return {
+    mpd: isManifestUrl(record.mpd) ? record.mpd : undefined,
+    ...(manifests.length ? { manifests } : {}),
+  };
+};
+
 // Match the original box bytes without decoding DRM-specific payloads.
 export const splitPssh = (initData: string): string[] => {
   try {
@@ -28,6 +64,8 @@ export const splitPssh = (initData: string): string[] => {
   }
 };
 
+// This validates the URL scheme. Response inspection identifies the manifest format;
+// extensionless and signed endpoints must also work in the manual command builder.
 export const isManifestUrl = (value: unknown): value is string => {
   if (typeof value !== 'string') return false;
   try {
@@ -47,4 +85,37 @@ export const findManifest = (initData: string | undefined) => {
     if (isManifestUrl(url)) return url;
   }
   return undefined;
+};
+
+export const getManifestCapture = (initData: string | undefined) => {
+  const tokens = new Set(initData ? [initData, ...splitPssh(initData)] : []);
+  const detected = window.MANIFEST_LIST instanceof Map ? [...window.MANIFEST_LIST.values()] : [];
+  const directUrls = new Set(
+    detected
+      .filter((item) => item.initData.some((data) => tokens.has(data)))
+      .map((item) => item.url),
+  );
+  const matchedUrls = new Set(directUrls);
+  // A master playlist can identify the capture through an observed child playlist.
+  for (let pass = 0; pass < detected.length; pass++) {
+    const previousSize = matchedUrls.size;
+    for (const item of detected) {
+      if (item.children.some((url) => matchedUrls.has(url))) matchedUrls.add(item.url);
+    }
+    if (previousSize === matchedUrls.size) break;
+  }
+  const priority = (manifest: Manifest) => {
+    if (!manifest.matched) return 0;
+    if (directUrls.has(manifest.url) && manifest.kind !== 'hls-media') return 3;
+    // Prefer an HLS master to its media playlist, but keep direct DASH/MSS matches first.
+    return manifest.kind === 'hls-master' ? 2 : 1;
+  };
+  const manifests = detected
+    .map(({ url, kind }) => ({ url, kind, matched: matchedUrls.has(url) }))
+    .sort((left, right) => priority(right) - priority(left));
+  const preferred = manifests.find((item) => item.matched);
+  return getManifestMetadata({
+    mpd: preferred?.url ?? findManifest(initData),
+    manifests,
+  });
 };

--- a/src/extension/utils/network-interception.ts
+++ b/src/extension/utils/network-interception.ts
@@ -1,6 +1,17 @@
 export const installNetworkInterception = () => {
   const MAX_SIZE = 1024 * 1024 * 1; // 1 MB
 
+  const getRequestUrl = (resource: URL | RequestInfo) => {
+    try {
+      return new URL(
+        resource instanceof Request ? resource.url : resource,
+        globalThis.document?.baseURI,
+      ).href;
+    } catch {
+      return undefined;
+    }
+  };
+
   const filterHead = (url: string, headers: Record<string, string>) => {
     const size = headers['content-length'];
     const isSizeOk = Number(size) < MAX_SIZE;
@@ -33,17 +44,22 @@ export const installNetworkInterception = () => {
     return isManifest;
   };
 
-  const postMessage = (url: string, headers: Record<string, string>, text: string) => {
+  const postMessage = (
+    url: string,
+    headers: Record<string, string>,
+    text: string,
+    requestUrl?: string,
+  ) => {
     const message = {
       namespace: 'okova:network',
       method: 'response',
-      params: { url, text, headers },
+      params: { url, text, headers, ...(requestUrl ? { requestUrl } : {}) },
       id: Date.now(),
     };
     window.postMessage(message, '*');
   };
 
-  const inspectFetchResponse = async (response: Response) => {
+  const inspectFetchResponse = async (response: Response, requestUrl: string | undefined) => {
     const url = response.url;
     const headers = Object.fromEntries(response.headers.entries());
     if (!filterHead(url, headers)) return;
@@ -69,15 +85,16 @@ export const installNetworkInterception = () => {
     } finally {
       reader.releaseLock();
     }
-    if (filterData(url, text)) postMessage(url, headers, text);
+    if (filterData(url, text)) postMessage(url, headers, text, requestUrl);
   };
 
   const patchFetch = () => {
     if (typeof fetch === 'function') {
       const originalFetch = fetch;
       const cachedFetch = async function fetch(resource: URL | RequestInfo, options?: RequestInit) {
+        const requestUrl = getRequestUrl(resource);
         const response = await originalFetch(resource, options);
-        void inspectFetchResponse(response).catch((error) => {
+        void inspectFetchResponse(response, requestUrl).catch((error) => {
           console.warn('[okova] Fetch response inspection failed', error);
         });
         return response;
@@ -98,6 +115,27 @@ export const installNetworkInterception = () => {
 
   const patchXmlHttpRequest = () => {
     class PatchedXHR extends XMLHttpRequest {
+      #requestUrl: string | undefined;
+
+      open(method: string, url: string | URL): void;
+      open(
+        method: string,
+        url: string | URL,
+        async: boolean,
+        username?: string | null,
+        password?: string | null,
+      ): void;
+      open(
+        method: string,
+        url: string | URL,
+        async = true,
+        username?: string | null,
+        password?: string | null,
+      ) {
+        this.#requestUrl = getRequestUrl(url);
+        super.open(method, url, async, username, password);
+      }
+
       constructor() {
         super();
         this.addEventListener('load', () => {
@@ -109,6 +147,7 @@ export const installNetworkInterception = () => {
 
       async #handleResponse() {
         const url = this.responseURL;
+        const requestUrl = this.#requestUrl;
         const headersString = this.getAllResponseHeaders();
         const headersArray = headersString.trim().split(/[\r\n]+/);
         const headers: Record<string, string> = {};
@@ -148,7 +187,7 @@ export const installNetworkInterception = () => {
         // Reject long strings before allocating a UTF-8 copy for the byte check.
         if (text.length >= MAX_SIZE || new TextEncoder().encode(text).byteLength >= MAX_SIZE)
           return;
-        if (filterData(url, text)) postMessage(url, headers, text);
+        if (filterData(url, text)) postMessage(url, headers, text, requestUrl);
       }
     }
     window.XMLHttpRequest = PatchedXHR;

--- a/src/extension/utils/network-interception.ts
+++ b/src/extension/utils/network-interception.ts
@@ -6,16 +6,30 @@ export const installNetworkInterception = () => {
     const isSizeOk = Number(size) < MAX_SIZE;
     if (size && !isSizeOk) return false;
 
-    const type = headers['content-type'];
+    const type = headers['content-type']?.toLowerCase();
     const isTypeOk =
-      type?.includes('xml') || type?.includes('dash') || type?.includes('octet-stream');
-    if (!isTypeOk) return false;
+      type?.includes('xml') ||
+      type?.includes('dash') ||
+      type?.includes('octet-stream') ||
+      type?.includes('mpegurl') ||
+      type?.includes('vnd.ms-sstr') ||
+      type?.includes('text/plain');
+    let isManifestPath = false;
+    try {
+      isManifestPath = /\.(?:mpd|m3u8?|ismc)$|\.ism\/manifest(?:\([^/]*\))?$/i.test(
+        new URL(url).pathname,
+      );
+    } catch {
+      // Synthetic responses may have no URL; their content type can still be inspected.
+    }
+    if (!isTypeOk && !isManifestPath) return false;
 
     return true;
   };
 
   const filterData = (url: string, text: string) => {
-    const isManifest = text.trimStart().startsWith('<');
+    const start = text.trimStart();
+    const isManifest = start.startsWith('<') || /^#EXTM3U(?:\r?\n|$)/.test(start);
     return isManifest;
   };
 

--- a/src/extension/utils/storage/settings.ts
+++ b/src/extension/utils/storage/settings.ts
@@ -26,7 +26,7 @@ export const defaultSettings: Settings = {
   emeInterception: true,
   spoofing: false,
   clientPlayback: false,
-  requestInterception: false,
+  requestInterception: true,
   theme: 'auto',
 };
 

--- a/src/extension/utils/storage/storage.ts
+++ b/src/extension/utils/storage/storage.ts
@@ -1,3 +1,4 @@
+import { getManifestMetadata, type Manifest } from '../manifest';
 import type { Credentials } from '../../../lib/credentials';
 import { browser, storage } from '#imports';
 import { z } from 'zod';
@@ -19,14 +20,25 @@ export type KeyInfo = {
   id: string;
   value: string;
   url: string;
+  /** Preferred URL. The legacy field name also supports HLS and MSS. */
   mpd?: string;
+  manifests?: Manifest[];
   pssh: string;
   createdAt: number;
 };
 
 // Include the capture time so a later capture of the same key survives confirmation.
 export const keyRecordToken = (key: KeyInfo) =>
-  JSON.stringify([key.id, key.value, key.url, key.pssh, key.createdAt, key.mpd, key.drmSystem]);
+  JSON.stringify([
+    key.id,
+    key.value,
+    key.url,
+    key.pssh,
+    key.createdAt,
+    key.mpd,
+    key.drmSystem,
+    key.manifests,
+  ]);
 
 export type KeyDeletionScope =
   | { kind: 'all' }
@@ -75,7 +87,12 @@ const retainNewest = <T>(records: T[], createdAt: (record: T) => number): T[] =>
   return records.filter((_, index) => !removed.has(index));
 };
 
-const retainKeys = (keys: KeyInfo[]) => retainNewest(keys, (key) => key.createdAt);
+const sanitizeManifestMetadata = (key: KeyInfo): KeyInfo => {
+  const metadata = getManifestMetadata(key);
+  return { ...key, ...metadata, manifests: metadata.manifests };
+};
+const retainKeys = (keys: KeyInfo[]) =>
+  retainNewest(keys, (key) => key.createdAt).map(sanitizeManifestMetadata);
 
 // The domain cache has one shared record budget, not 1,000 records per domain.
 const retainDomains = (domains: RecentKeysByDomain): RecentKeysByDomain => {
@@ -87,7 +104,7 @@ const retainDomains = (domains: RecentKeysByDomain): RecentKeysByDomain => {
   const result: RecentKeysByDomain = Object.create(null);
   for (const { domain, key } of retained) {
     const keys = (result[domain] ??= []);
-    if (key) keys.push(key);
+    if (key) keys.push(sanitizeManifestMetadata(key));
   }
   return result;
 };

--- a/test/download-command.test.ts
+++ b/test/download-command.test.ts
@@ -5,21 +5,22 @@ import { buildDownloadCommand } from '../src/extension/entrypoints/popup/utils/c
 test.each([
   { id: '0123456789abcdef', value: 'abcdef0123456789' },
   { id: '0123456789abcdef', value: 'abcdef0123456789', mpd: undefined },
-])('builds an editable command without a manifest URL: %j', (key) => {
-  expect(buildDownloadCommand(key)).toBe(
-    "N_m3u8DL-RE '' --key '0123456789abcdef:abcdef0123456789'",
-  );
+])('does not build a command without a manifest URL: %j', (key) => {
+  expect(buildDownloadCommand(key)).toBeUndefined();
 });
 
 test
   .skipIf(process.platform === 'win32')
   .each([
     'https://example.com/manifest.mpd',
+    'https://example.com/',
+    'https://example.com/playback?token=abc&format=hls',
     'https://example.com/$0manifest.mpd?first=1&second=2',
     'https://example.com/a b/"quoted"/it\'s.mpd',
     'https://example.com/$(printf expanded)/`printf expanded`/manifest.mpd',
     'https://example.com/back\\slash;*?[x]\nmanifest.mpd',
-    '',
+    'https://example.com/master.m3u8?token=abc',
+    'https://example.com/video.ism/Manifest',
   ])('preserves download arguments in Bash: %j', (mpd) => {
   const key = { mpd, id: '0123456789abcdef', value: 'abcdef0123456789' };
   const command = buildDownloadCommand(key);
@@ -30,4 +31,20 @@ test
     { encoding: 'utf8' },
   );
   expect(output.split('\0')).toEqual([mpd, '--key', `${key.id}:${key.value}`, '']);
+});
+
+test.each(['', 'javascript:alert(1)', 'data:text/plain,test', '/manifest.mpd'])(
+  'rejects invalid downloader URLs: %s',
+  (mpd) => {
+    expect(buildDownloadCommand({ mpd, id: 'id', value: 'key' })).toBeUndefined();
+  },
+);
+
+test('uses the selected manifest instead of the saved default', () => {
+  expect(
+    buildDownloadCommand(
+      { mpd: 'https://example.com/old.mpd', id: 'id', value: 'key' },
+      'https://example.com/new.m3u8',
+    ),
+  ).toBe("N_m3u8DL-RE 'https://example.com/new.m3u8' --key 'id:key'");
 });

--- a/test/drm-playback.test.ts
+++ b/test/drm-playback.test.ts
@@ -94,7 +94,8 @@ const mockSessionBridge = ({
 beforeEach(() => {
   vi.useFakeTimers();
   vi.stubGlobal('navigator', { requestMediaKeySystemAccess: nativeRequest });
-  vi.stubGlobal('window', { MPD_LIST: new Map() });
+  // Playback bridge requests must survive a page-owned malformed manifest entry.
+  vi.stubGlobal('window', { MPD_LIST: new Map(), MANIFEST_LIST: new Map([['page-entry', {}]]) });
   vi.stubGlobal('MediaKeySystemAccess', NativeAccess);
   vi.stubGlobal('MediaKeys', NativeKeys);
   vi.stubGlobal('MediaKeySession', NativeSession);

--- a/test/e2e/key-search.test.ts
+++ b/test/e2e/key-search.test.ts
@@ -51,6 +51,24 @@ test('saved keys filter immediately by KID, page URL, and manifest URL', async (
       const count = popup.getByRole('status');
       await expect.poll(() => count.textContent()).toBe('(2)');
       await expect.poll(() => popup.locator('[data-history-row]').count()).toBe(2);
+      const manifestLink = popup
+        .locator('[data-history-row]')
+        .filter({ hasText: keys[0]!.id })
+        .locator('a');
+      for (const mpd of [
+        'https://cdn.example/updated.m3u8',
+        'javascript:alert(1)',
+        keys[0]!.mpd!,
+      ]) {
+        const updated = [{ ...keys[0]!, mpd }, keys[1]!];
+        await worker.evaluate(async (records) => {
+          await browser.storage.local.set({ 'all-keys': JSON.stringify(records) });
+        }, updated);
+        const href = mpd.startsWith('javascript:') ? keys[0]!.url : mpd;
+        await expect.poll(() => manifestLink.getAttribute('href')).toBe(href);
+        expect(await manifestLink.getAttribute('title')).toBe(href);
+        expect(await manifestLink.textContent()).toBe(href.replace('https://', ''));
+      }
       for (const query of [
         'aabbccdd-1122-3344-5566-77889900aabb',
         ' DD-1122 ',

--- a/test/e2e/live-history.test.ts
+++ b/test/e2e/live-history.test.ts
@@ -72,13 +72,21 @@ test('history updates preserve search, visible rows, and live details', async ()
 
       await stableAnchor.locator('code').click();
       const details = popup.locator('main').last();
-      const command = details.getByRole('textbox');
-      await expect.poll(() => command.inputValue()).toContain('usable');
+      const command = details.getByRole('textbox', { name: 'Download command' });
+      const manifestUrl = details.getByRole('textbox', { name: 'Manifest URL' });
+      const copyCommand = details.getByRole('button', { name: 'Copy command', exact: true });
+      expect(await command.inputValue()).toBe('');
+      expect(await command.isDisabled()).toBe(true);
+      expect(await copyCommand.isDisabled()).toBe(true);
       const selected = records.find((record) => record.id === anchorKid)!;
       const captured = { ...selected, value: 'a'.repeat(32), mpd: 'https://cdn.example/live.mpd' };
       records = records.map((record) => (record === selected ? captured : record));
       await save();
       await expect.poll(() => command.inputValue()).toContain(captured.value);
+      expect(await manifestUrl.inputValue()).toBe(captured.mpd);
+      expect(await command.inputValue()).toContain(captured.mpd);
+      expect(await command.isEnabled()).toBe(true);
+      expect(await copyCommand.isEnabled()).toBe(true);
       expect(await details.getByText(captured.value, { exact: true }).isVisible()).toBe(true);
       await command.fill('my custom command');
       await details.evaluate((element) => {

--- a/test/e2e/manifest.test.ts
+++ b/test/e2e/manifest.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { chromium } from 'playwright';
@@ -131,6 +131,167 @@ test('built content bridge associates DASH and reads playback configuration thro
       await context.close();
     }
   } finally {
+    await rm(profile, { recursive: true, force: true });
+  }
+});
+
+test('captures HLS/MSS choices through real EME and builds commands in the popup', async () => {
+  const profile = await mkdtemp(join(tmpdir(), 'okova-manifest-workflow-'));
+  const extension = resolve('.output/chrome-mv3');
+  const context = await chromium.launchPersistentContext(profile, {
+    channel: 'chromium',
+    headless: true,
+    viewport: { width: 500, height: 600 },
+    args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
+  });
+  try {
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
+    await expect
+      .poll(() =>
+        worker.evaluate(async () => (await browser.storage.local.get('settings')).settings),
+      )
+      .toBeTruthy();
+    await worker.evaluate(async () => {
+      await browser.storage.local.set({
+        settings: JSON.stringify({
+          spoofing: false,
+          emeInterception: true,
+          requestInterception: true,
+          theme: 'light',
+        }),
+      });
+    });
+    await expect
+      .poll(() =>
+        worker.evaluate(
+          async () =>
+            (
+              await browser.scripting.getRegisteredContentScripts({ ids: ['okova-interception'] })
+            )[0]?.js,
+        ),
+      )
+      .toEqual(['eme-bootstrap.js', 'network.js']);
+    const master = 'https://okova.test/master.m3u8?token=one';
+    const media = 'https://okova.test/media.m3u8?token=two';
+    const mss = 'https://okova.test/video.ism/Manifest';
+    await context.route('https://okova.test/**', async (route) => {
+      const url = route.request().url();
+      if (url === master)
+        await route.fulfill({
+          contentType: 'application/vnd.apple.mpegurl',
+          body: '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nmedia.m3u8?token=two',
+        });
+      else if (url === media)
+        await route.fulfill({ contentType: 'text/plain', body: '#EXTM3U\n#EXTINF:4,\nsegment.ts' });
+      else if (url === mss)
+        await route.fulfill({
+          contentType: 'application/vnd.ms-sstr+xml',
+          body: '<SmoothStreamingMedia MajorVersion="2" MinorVersion="1"/>',
+        });
+      else
+        await route.fulfill({
+          contentType: 'text/html',
+          body: '<!doctype html><title>Manifest workflow</title>',
+        });
+    });
+    const page = await context.newPage();
+    await page.goto('https://okova.test/watch');
+    await page.evaluate(
+      async ([master, media, mss]) => {
+        await fetch(master!);
+        await fetch(media!);
+        await new Promise<void>((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+          xhr.open('GET', mss!);
+          xhr.responseType = 'arraybuffer';
+          xhr.onload = () => resolve();
+          xhr.onerror = () => reject(new Error('MSS request failed'));
+          xhr.send();
+        });
+      },
+      [master, media, mss],
+    );
+    await expect.poll(() => page.evaluate(() => window.MANIFEST_LIST.size)).toBe(3);
+    await page.evaluate(async () => {
+      const access = await navigator.requestMediaKeySystemAccess('org.w3.clearkey', [
+        {
+          initDataTypes: ['keyids'],
+          videoCapabilities: [{ contentType: 'video/webm; codecs="vp8"' }],
+        },
+      ]);
+      const keys = await access.createMediaKeys();
+      const session = keys.createSession();
+      const message = new Promise<void>((resolve) =>
+        session.addEventListener('message', () => resolve(), { once: true }),
+      );
+      await session.generateRequest(
+        'keyids',
+        new TextEncoder().encode(JSON.stringify({ kids: ['AAECAwQFBgcICQoLDA0ODw'] })),
+      );
+      await message;
+      await session.update(
+        new TextEncoder().encode(
+          JSON.stringify({
+            keys: [{ kty: 'oct', kid: 'AAECAwQFBgcICQoLDA0ODw', k: 'tQ0bJVWb6b0KPL6KtZIy_A' }],
+          }),
+        ),
+      );
+    });
+    await expect
+      .poll(() =>
+        worker.evaluate(async () => {
+          const stored = (await browser.storage.local.get('all-keys'))['all-keys'];
+          return typeof stored === 'string'
+            ? JSON.parse(stored).filter(
+                (key: { value: string }) => key.value === 'b50d1b25559be9bd0a3cbe8ab59232fc',
+              ).length
+            : 0;
+        }),
+      )
+      .toBe(1);
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${new URL(worker.url()).hostname}/popup.html`);
+    await popup.getByRole('link', { name: 'Keys', exact: true }).click();
+    await popup.locator('[data-history-row]').first().click();
+    const choices = popup.locator('button[aria-pressed]');
+    const command = popup.getByRole('textbox', { name: 'Download command' });
+    const copy = popup.getByRole('button', { name: 'Copy command', exact: true });
+    await expect
+      .poll(() => choices.allTextContents())
+      .toEqual([
+        `HLS master · Seen on page${master}`,
+        `HLS media · Seen on page${media}`,
+        `MSS · Seen on page${mss}`,
+      ]);
+    expect(await copy.isDisabled()).toBe(true);
+    expect(await command.inputValue()).toBe('');
+    for (const url of [master, media, mss]) {
+      const choice = choices.filter({ hasText: url });
+      await choice.click();
+      expect(await choice.getAttribute('aria-pressed')).toBe('true');
+      expect(await popup.locator('button[aria-pressed="true"]').count()).toBe(1);
+      expect(await command.inputValue()).toBe(
+        `N_m3u8DL-RE '${url}' --key '000102030405060708090a0b0c0d0e0f:b50d1b25559be9bd0a3cbe8ab59232fc'`,
+      );
+      expect(await copy.isEnabled()).toBe(true);
+    }
+    await command.fill('edited command');
+    await choices.filter({ hasText: master }).click();
+    expect(await command.inputValue()).toContain(master);
+    await mkdir(resolve('output/playwright/manifest'), { recursive: true });
+    await copy.scrollIntoViewIfNeeded();
+    await popup.screenshot({ path: resolve('output/playwright/manifest/selected.png') });
+    const input = popup.getByRole('textbox', { name: 'Manifest URL', exact: true });
+    await input.fill('javascript:alert(1)');
+    expect(await copy.isDisabled()).toBe(true);
+    expect(await command.inputValue()).toBe('');
+    expect(await popup.locator('button[aria-pressed="true"]').count()).toBe(0);
+    await input.fill('https://okova.test/manual.m3u8');
+    expect(await command.inputValue()).toContain('https://okova.test/manual.m3u8');
+    await input.fill('');
+    await popup.screenshot({ path: resolve('output/playwright/manifest/missing.png') });
+  } finally {
+    await context.close();
     await rm(profile, { recursive: true, force: true });
   }
 });

--- a/test/e2e/manifest.test.ts
+++ b/test/e2e/manifest.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { chromium } from 'playwright';
@@ -144,6 +145,7 @@ test('captures HLS/MSS choices through real EME and builds commands in the popup
     viewport: { width: 500, height: 600 },
     args: [`--disable-extensions-except=${extension}`, `--load-extension=${extension}`],
   });
+  const server = createServer();
   try {
     const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
     await expect
@@ -171,31 +173,36 @@ test('captures HLS/MSS choices through real EME and builds commands in the popup
         ),
       )
       .toEqual(['eme-bootstrap.js', 'network.js']);
-    const master = 'https://okova.test/master.m3u8?token=one';
-    const media = 'https://okova.test/media.m3u8?token=two';
-    const mss = 'https://okova.test/video.ism/Manifest';
-    await context.route('https://okova.test/**', async (route) => {
-      const url = route.request().url();
-      if (url === master)
-        await route.fulfill({
-          contentType: 'application/vnd.apple.mpegurl',
-          body: '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nmedia.m3u8?token=two',
-        });
-      else if (url === media)
-        await route.fulfill({ contentType: 'text/plain', body: '#EXTM3U\n#EXTINF:4,\nsegment.ts' });
-      else if (url === mss)
-        await route.fulfill({
-          contentType: 'application/vnd.ms-sstr+xml',
-          body: '<SmoothStreamingMedia MajorVersion="2" MinorVersion="1"/>',
-        });
-      else
-        await route.fulfill({
-          contentType: 'text/html',
-          body: '<!doctype html><title>Manifest workflow</title>',
-        });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing test server address');
+    const origin = `http://127.0.0.1:${address.port}`;
+    const master = `${origin}/master.m3u8?token=one`;
+    const media = `${origin}/media.m3u8?token=two`;
+    const mss = `${origin}/video.ism/Manifest`;
+    const mediaRequest = `${origin}/request/media.m3u8`;
+    const mssRequest = `${origin}/request/video.ism/Manifest`;
+    server.on('request', (request, response) => {
+      const url = new URL(request.url!, origin).href;
+      if (url === mediaRequest || url === mssRequest) {
+        response.writeHead(302, { location: url === mediaRequest ? media : mss });
+        response.end();
+      } else if (url === master) {
+        response.setHeader('content-type', 'application/vnd.apple.mpegurl');
+        response.end('#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nrequest/media.m3u8');
+      } else if (url === media) {
+        response.setHeader('content-type', 'text/plain');
+        response.end('#EXTM3U\n#EXTINF:4,\nsegment.ts');
+      } else if (url === mss) {
+        response.setHeader('content-type', 'application/vnd.ms-sstr+xml');
+        response.end('<SmoothStreamingMedia MajorVersion="2" MinorVersion="1"/>');
+      } else {
+        response.setHeader('content-type', 'text/html');
+        response.end('<!doctype html><title>Manifest workflow</title>');
+      }
     });
     const page = await context.newPage();
-    await page.goto('https://okova.test/watch');
+    await page.goto(`${origin}/watch`);
     await page.evaluate(
       async ([master, media, mss]) => {
         await fetch(master!);
@@ -209,9 +216,22 @@ test('captures HLS/MSS choices through real EME and builds commands in the popup
           xhr.send();
         });
       },
-      [master, media, mss],
+      [master, mediaRequest, mssRequest],
     );
     await expect.poll(() => page.evaluate(() => window.MANIFEST_LIST.size)).toBe(3);
+    expect(
+      await page.evaluate(
+        ([media, mss]) =>
+          [media, mss].map((url) => {
+            const manifest = window.MANIFEST_LIST.get(url!);
+            return manifest && typeof manifest === 'object' && 'requestUrls' in manifest
+              ? manifest.requestUrls
+              : undefined;
+          }),
+        [media, mss],
+      ),
+    ).toEqual([[mediaRequest], [mssRequest]]);
+    await page.evaluate(() => window.MANIFEST_LIST.set('page-owned', {}));
     await page.evaluate(async () => {
       const access = await navigator.requestMediaKeySystemAccess('org.w3.clearkey', [
         {
@@ -292,6 +312,8 @@ test('captures HLS/MSS choices through real EME and builds commands in the popup
     await popup.screenshot({ path: resolve('output/playwright/manifest/missing.png') });
   } finally {
     await context.close();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
     await rm(profile, { recursive: true, force: true });
   }
 });

--- a/test/e2e/remote-credentials.test.ts
+++ b/test/e2e/remote-credentials.test.ts
@@ -133,6 +133,20 @@ test('first import on Credentials survives a failed write, repeated selection an
     const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
     const popup = await context.newPage();
     const popupUrl = `chrome-extension://${new URL(worker.url()).hostname}/popup.html`;
+    // Keep popup startup pending until the write-failure injection is installed.
+    await worker.evaluate(async () => {
+      await chrome.storage.local.remove('credentials-registry');
+      await new Promise<void>((locked) => {
+        void navigator.locks.request(
+          'okova:credentials',
+          () =>
+            new Promise<void>((release) => {
+              globalThis.addEventListener('release-test-lock', () => release(), { once: true });
+              locked();
+            }),
+        );
+      });
+    });
     await popup.goto(popupUrl);
     await popup.getByRole('link', { name: 'Credentials', exact: true }).click();
     const input = popup.locator('input[type=file]');
@@ -149,14 +163,16 @@ test('first import on Credentials survives a failed write, repeated selection an
         }),
       ),
     });
-    // Fail the actual popup write once, without changing another extension context.
+    // Fail the first-import transaction, not startup's separate settings or empty-registry writes.
     await popup.evaluate(() => {
       const set = chrome.storage.local.set.bind(chrome.storage.local);
-      chrome.storage.local.set = async () => {
+      chrome.storage.local.set = async (items) => {
+        if (!('credentials-registry' in items) || !('settings' in items)) return set(items);
         chrome.storage.local.set = set;
         throw new Error('Quota exceeded');
       };
     });
+    await worker.evaluate(() => globalThis.dispatchEvent(new Event('release-test-lock')));
     await input.setInputFiles(file('one'));
     await expect.poll(() => popup.getByRole('alert').textContent()).toBe('Quota exceeded');
     expect(await popup.getByText('Same label', { exact: true }).count()).toBe(0);

--- a/test/e2e/startup.test.ts
+++ b/test/e2e/startup.test.ts
@@ -49,12 +49,20 @@ test('document-start bootstrap handles CSP, Trusted Types, frames, and settings 
       )
       .toBeTruthy();
     await expect
-      .poll(() => worker.evaluate(() => browser.scripting.getRegisteredContentScripts()))
-      .not.toEqual([]);
+      .poll(() =>
+        worker.evaluate(
+          async () =>
+            (
+              await browser.scripting.getRegisteredContentScripts({ ids: ['okova-interception'] })
+            )[0]?.js,
+        ),
+      )
+      .toEqual(['eme-bootstrap.js', 'network.js']);
     const initial = await worker.evaluate(async () =>
       JSON.parse(String((await browser.storage.local.get('settings')).settings)),
     );
     expect(initial.emeInterception).toBe(true);
+    expect(initial.requestInterception).toBe(true);
     const errors: string[] = [];
     const page = await context.newPage();
     page.on('pageerror', (error) => errors.push(error.message));
@@ -87,7 +95,7 @@ test('document-start bootstrap handles CSP, Trusted Types, frames, and settings 
         fetch: fetch.toString().includes('[native code]'),
         xhr: XMLHttpRequest.toString().includes('[native code]'),
       })),
-    ).toEqual({ fetch: true, xhr: true });
+    ).toEqual({ fetch: false, xhr: false });
     for (const enabled of [true, false, true]) {
       await worker.evaluate(async (enabled) => {
         const stored = await browser.storage.local.get('settings');
@@ -95,18 +103,20 @@ test('document-start bootstrap handles CSP, Trusted Types, frames, and settings 
           settings: JSON.stringify({
             ...JSON.parse(String(stored.settings)),
             emeInterception: enabled,
+            requestInterception: enabled,
           }),
         });
       }, enabled);
       await expect
         .poll(() =>
-          worker.evaluate(async () =>
-            (await browser.scripting.getRegisteredContentScripts()).some((script) =>
-              script.js?.includes('eme-bootstrap.js'),
-            ),
+          worker.evaluate(
+            async () =>
+              (
+                await browser.scripting.getRegisteredContentScripts({ ids: ['okova-interception'] })
+              )[0]?.js ?? [],
           ),
         )
-        .toBe(enabled);
+        .toEqual(enabled ? ['eme-bootstrap.js', 'network.js'] : []);
       await page.goto('http://localhost/startup');
       await expect.poll(() => page.frames().length).toBe(3);
       for (const frame of page.frames()) {
@@ -116,6 +126,12 @@ test('document-start bootstrap handles CSP, Trusted Types, frames, and settings 
         expect(await frame.evaluate(() => typeof window.__okovaEmeInstaller)).toBe(
           enabled ? 'function' : 'undefined',
         );
+        expect(
+          await frame.evaluate(() => ({
+            fetch: fetch.toString().includes('[native code]'),
+            xhr: XMLHttpRequest.toString().includes('[native code]'),
+          })),
+        ).toEqual({ fetch: !enabled, xhr: !enabled });
       }
       // Changes are applied on the next load; existing pages keep their installed hooks.
       const before = await page.evaluate(() =>

--- a/test/extension-eme-sessions.test.ts
+++ b/test/extension-eme-sessions.test.ts
@@ -52,7 +52,8 @@ test.each(
     }
     vi.stubGlobal('MediaKeySession', NativeSession);
     vi.stubGlobal('MediaKeys', NativeKeys);
-    vi.stubGlobal('window', { MPD_LIST: new Map() });
+    // A page-owned cache entry must not block the bridge or native CDM update.
+    vi.stubGlobal('window', { MPD_LIST: new Map(), MANIFEST_LIST: new Map([['page-entry', {}]]) });
     const capture = Promise.withResolvers<unknown>();
     vi.mocked(sendDrmMessage).mockReturnValue(capture.promise);
     installEmeInterception();

--- a/test/extension-history-filters.test.ts
+++ b/test/extension-history-filters.test.ts
@@ -79,3 +79,13 @@ test('sorts timestamps in both directions without changing storage order and kee
   const ties = [record('2026-03-08T00:00:00', 'W'), record('2026-03-08T00:00:00', 'P')];
   expect(filterHistory(ties, defaults)).toEqual(ties);
 });
+
+test('searches alternate manifests as well as the preferred URL', () => {
+  const capture: KeyInfo = {
+    ...records[0]!,
+    manifests: [
+      { url: 'https://alternate.example/master.m3u8', kind: 'hls-master', matched: true },
+    ],
+  };
+  expect(filterHistory([capture], { ...defaults, search: 'ALTERNATE.EXAMPLE' })).toEqual([capture]);
+});

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -582,3 +582,33 @@ test('persists validated manifest choices across history and recent caches', asy
   expect(await appStorage.recentKeys.getValue()).toEqual([sanitized]);
   expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [sanitized] });
 });
+
+test('bounds manifest metadata when persisting a multi-key capture to all history stores', async () => {
+  const manifests = Array.from({ length: 50 }, (_, index) => ({
+    url: `https://example.com/${index}?signature=${'x'.repeat(8000)}`,
+    kind: 'dash' as const,
+    matched: true,
+  }));
+  const captured = Array.from({ length: 32 }, (_, index) => ({
+    ...key,
+    id: index.toString(16).padStart(32, '0'),
+    mpd: manifests[0]!.url,
+    manifests,
+  }));
+  await appStorage.allKeys.add(...captured);
+  await appStorage.recentKeys.setForUrl(key.url, captured);
+  const stores = [
+    await appStorage.allKeys.getValue(),
+    await appStorage.recentKeys.getValue(),
+    (await appStorage.recentKeysByDomain.getValue())?.['example.com'],
+  ];
+  for (const records of stores) {
+    expect(records).toHaveLength(32);
+    for (const record of records ?? []) {
+      expect(record.mpd).toBe(captured[0]!.mpd);
+      expect(
+        Buffer.byteLength(JSON.stringify({ mpd: record.mpd, manifests: record.manifests })),
+      ).toBeLessThanOrEqual(16 * 1024);
+    }
+  }
+});

--- a/test/extension-key-history.test.ts
+++ b/test/extension-key-history.test.ts
@@ -556,3 +556,29 @@ test('selected deletion freezes status variants and all deletion includes recent
   expect(await appStorage.recentKeys.getValue()).toEqual([]);
   expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [] });
 });
+
+test('persists validated manifest choices across history and recent caches', async () => {
+  const manifest = {
+    url: 'https://example.com/video.m3u8',
+    kind: 'hls-media',
+    matched: true,
+  } as const;
+  const capture = { ...key, mpd: manifest.url, manifests: [manifest] };
+  await appStorage.allKeys.add(capture);
+  await appStorage.recentKeys.setForUrl(key.url, [capture]);
+  expect(await appStorage.allKeys.getValue()).toEqual([capture]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([capture]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [capture] });
+
+  const unsafe = {
+    ...capture,
+    mpd: 'javascript:alert(1)',
+    manifests: [{ ...manifest, url: 'data:text/plain,test' }],
+  };
+  await appStorage.allKeys.setValue([unsafe]);
+  await appStorage.recentKeys.setForUrl(key.url, [unsafe]);
+  const sanitized = { ...key, mpd: undefined };
+  expect(await appStorage.allKeys.getValue()).toEqual([sanitized]);
+  expect(await appStorage.recentKeys.getValue()).toEqual([sanitized]);
+  expect(await appStorage.recentKeysByDomain.getValue()).toEqual({ 'example.com': [sanitized] });
+});

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -22,10 +22,14 @@ const mpd = (pssh: string, scheme: string = PSSH_SYSTEM_IDS.widevine) => `
       <other:pssh>\n ${pssh.slice(0, 16)}\n ${pssh.slice(16)} \n</other:pssh>
     </dash:ContentProtection></dash:AdaptationSet></dash:Period>
   </dash:MPD>`;
-const post = (text: string, manifestUrl = url) =>
+const post = (text: string, manifestUrl = url, requestUrl?: string) =>
   receive({
     source: window,
-    data: { namespace: 'okova:network', method: 'response', params: { url: manifestUrl, text } },
+    data: {
+      namespace: 'okova:network',
+      method: 'response',
+      params: { url: manifestUrl, text, requestUrl },
+    },
   });
 
 beforeEach(() => {
@@ -310,3 +314,93 @@ test.each(['dash', 'mss'] as const)(
     ]);
   },
 );
+
+test.each([
+  null,
+  undefined,
+  1,
+  {},
+  { url, kind: 'dash', initData: {}, children: [] },
+  { url, kind: 'dash', initData: [], children: null },
+  { url, kind: 'dash', initData: [widevine], children: [42] },
+  { url, kind: 'dash', initData: [42], children: [] },
+  { url: 'javascript:alert(1)', kind: 'dash', initData: [widevine], children: [] },
+  { url, kind: 'unknown', initData: [widevine], children: [] },
+  {
+    get url() {
+      throw new Error('Page-owned getter');
+    },
+  },
+])('ignores malformed page-owned entries while preserving valid captures: %#', (value) => {
+  post(mpd(widevine));
+  Reflect.set(
+    window,
+    'MANIFEST_LIST',
+    new Map<string, unknown>([['broken', value], ...window.MANIFEST_LIST]),
+  );
+  expect(getManifestCapture(widevine)).toEqual({
+    mpd: url,
+    manifests: [{ url, kind: 'dash', matched: true }],
+  });
+});
+
+test.each(['x', 'é"'])(
+  'bounds serialized per-key metadata with signed URL characters %j',
+  (character) => {
+    const manifests = Array.from({ length: 50 }, (_, index) => ({
+      url: `https://example.test/${index}?signature=${character.repeat(1700)}`,
+      kind: 'dash',
+      matched: index === 49,
+    }));
+    const preferred = manifests[49]!;
+    const metadata = getManifestMetadata({ mpd: preferred.url, manifests });
+    expect(Buffer.byteLength(JSON.stringify(metadata))).toBeLessThanOrEqual(16 * 1024);
+    expect(metadata.mpd).toBe(preferred.url);
+    expect(metadata.manifests?.[0]).toEqual(preferred);
+  },
+);
+
+test('matches a redirected HLS child and retains its original URL through refreshes', () => {
+  const master = 'https://example.test/master.m3u8';
+  const original = 'https://example.test/media.m3u8?token=one';
+  const final = 'https://cdn.example.test/live/media.m3u8?token=two';
+  post('#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nmedia.m3u8?token=one', master);
+  const media = `#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI="data:text/plain;base64,${widevine}"`;
+  post(media, final, original);
+  expect(getManifestCapture(widevine).mpd).toBe(master);
+  post(media, final);
+  expect(getManifestCapture(widevine).mpd).toBe(master);
+  expect(getManifestCapture(widevine).manifests).toEqual([
+    { url: master, kind: 'hls-master', matched: true },
+    { url: final, kind: 'hls-media', matched: true },
+  ]);
+});
+
+test('matches through nested redirected masters regardless of response order', () => {
+  const outer = 'https://example.test/outer.m3u8';
+  const inner = 'https://cdn.example.test/inner.m3u8';
+  const media = 'https://cdn.example.test/media.m3u8';
+  post('#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\ninner.m3u8', outer);
+  post(
+    '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nhttps://example.test/media.m3u8',
+    inner,
+    'https://example.test/inner.m3u8',
+  );
+  post(
+    `#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI="data:text/plain;base64,${widevine}"`,
+    media,
+    'https://example.test/media.m3u8',
+  );
+  expect(getManifestCapture(widevine).mpd).toBe(outer);
+  expect(getManifestCapture(widevine).manifests?.every((manifest) => manifest.matched)).toBe(true);
+});
+
+test('omits a single URL that exceeds the serialized budget instead of truncating it', () => {
+  const oversized = `https://example.test/${'漢'.repeat(7000)}`;
+  expect(
+    getManifestMetadata({
+      mpd: oversized,
+      manifests: [{ url: oversized, kind: 'dash', matched: true }],
+    }),
+  ).toEqual({ mpd: undefined });
+});

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -113,6 +113,20 @@ test('recovers manifest inspection from a throwing page-owned cache getter', () 
   });
 });
 
+test('registers the manifest listener when a page-owned cache cannot be replaced', () => {
+  Object.defineProperty(window, 'MANIFEST_LIST', {
+    configurable: false,
+    get() {
+      throw new Error('Page-owned getter');
+    },
+  });
+  const addEventListener = vi.spyOn(window, 'addEventListener');
+
+  expect(() => installManifestInspection()).not.toThrow();
+  expect(addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+  expect(() => post(mpd(widevine))).not.toThrow();
+});
+
 test.each([
   { pssh: widevine, scheme: PSSH_SYSTEM_IDS.widevine },
   { pssh: playready, scheme: PSSH_SYSTEM_IDS.playready },

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -1,7 +1,13 @@
 import { DOMParser } from '@xmldom/xmldom';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { installManifestInspection } from '../src/extension/utils/manifest-inspection';
-import { findManifest, splitPssh } from '../src/extension/utils/manifest';
+import {
+  findManifest,
+  getManifestCapture,
+  getManifestMetadata,
+  MAX_MANIFESTS,
+  splitPssh,
+} from '../src/extension/utils/manifest';
 import { createPsshBox, psshBoxToBase64, PSSH_SYSTEM_IDS } from '../src/lib/pssh';
 
 const widevine = psshBoxToBase64(createPsshBox({ systemId: PSSH_SYSTEM_IDS.widevine }));
@@ -156,3 +162,151 @@ test('bounds manifest associations and evicts the oldest entry', () => {
   expect(window.MPD_LIST.has('0')).toBe(false);
   expect(findManifest(widevine)).toBe(url);
 });
+
+test('retains multiple DASH URLs for a capture and unrelated manifests as explicit choices', () => {
+  post(mpd(widevine));
+  post(mpd(widevine), `${url}?alternate=1`);
+  post(mpd(playready), 'https://example.test/other.mpd');
+  const capture = getManifestCapture(widevine);
+  expect(capture.manifests).toEqual([
+    { url, kind: 'dash', matched: true },
+    { url: `${url}?alternate=1`, kind: 'dash', matched: true },
+    { url: 'https://example.test/other.mpd', kind: 'dash', matched: false },
+  ]);
+  expect(capture.mpd).toBe(url);
+  expect(getManifestCapture(undefined).mpd).toBeUndefined();
+});
+
+test.each(['KEY', 'SESSION-KEY'])(
+  'matches HLS EXT-X-%s embedded PSSH, including commas in quoted data URIs',
+  (tag) => {
+    post(
+      `#EXTM3U\n#EXT-X-${tag}:METHOD=SAMPLE-AES,URI="data:text/plain;base64,${widevine}",KEYFORMAT="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"\n#EXTINF:4,\nsegment.ts`,
+      'https://example.test/video.m3u8',
+    );
+    expect(getManifestCapture(combined)).toEqual({
+      mpd: 'https://example.test/video.m3u8',
+      manifests: [
+        {
+          url: 'https://example.test/video.m3u8',
+          kind: tag === 'SESSION-KEY' ? 'hls-master' : 'hls-media',
+          matched: true,
+        },
+      ],
+    });
+  },
+);
+
+test('prefers the observed HLS master when a relative child matches', () => {
+  const master = 'https://example.test/master.m3u8?masterToken=one';
+  post(
+    '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000,CODECS="avc1.4d401f,mp4a.40.2"\nvideo/media.m3u8?token=two',
+    master,
+  );
+  post(
+    `#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI="data:text/plain;base64,${widevine}"`,
+    'https://example.test/video/media.m3u8?token=two',
+  );
+  const capture = getManifestCapture(widevine);
+  expect(capture.mpd).toBe(master);
+  expect(capture.manifests?.map((manifest) => [manifest.kind, manifest.matched])).toEqual([
+    ['hls-master', true],
+    ['hls-media', true],
+  ]);
+});
+
+test('records plain HLS playlists without claiming a DRM association or capturing segment/key URLs', () => {
+  post(
+    '#EXTM3U\n#EXT-X-KEY:METHOD=AES-128,URI="secret.key"\n#EXTINF:10,\nsegment.ts',
+    'https://example.test/plain.m3u8',
+  );
+  expect(getManifestCapture(widevine)).toEqual({
+    mpd: undefined,
+    manifests: [{ url: 'https://example.test/plain.m3u8', kind: 'hls-media', matched: false }],
+  });
+  post('#EXTM3U-not-a-playlist', 'https://example.test/fake.m3u8');
+  expect(window.MANIFEST_LIST.size).toBe(1);
+});
+
+test('matches MSS ProtectionHeader as raw PlayReady data and as an EME PSSH', () => {
+  const data = Buffer.from('synthetic PlayReady Object');
+  const pssh = psshBoxToBase64(createPsshBox({ systemId: PSSH_SYSTEM_IDS.playready, data }));
+  const mss = 'https://example.test/video.ism/Manifest';
+  post(
+    `<SmoothStreamingMedia MajorVersion="2" MinorVersion="1"><Protection><ProtectionHeader SystemID="{9A04F079-9840-4286-AB92-E65BE0885F95}">${data.toString('base64')}</ProtectionHeader></Protection></SmoothStreamingMedia>`,
+    mss,
+  );
+  expect(getManifestCapture(pssh)).toEqual({
+    mpd: mss,
+    manifests: [{ url: mss, kind: 'mss', matched: true }],
+  });
+  expect(getManifestCapture(data.toString('base64')).mpd).toBe(mss);
+});
+
+test('ignores malformed protection data while keeping the detected manifest', () => {
+  post(
+    '<SmoothStreamingMedia><Protection><ProtectionHeader SystemID="9a04f079-9840-4286-ab92-e65be0885f95">%%%bad</ProtectionHeader></Protection></SmoothStreamingMedia>',
+  );
+  expect(getManifestCapture(widevine)).toEqual({
+    mpd: undefined,
+    manifests: [{ url, kind: 'mss', matched: false }],
+  });
+});
+
+test('deduplicates reloads and bounds detected manifests without storing response bodies', () => {
+  for (let index = 0; index < MAX_MANIFESTS + 1; index++)
+    post('#EXTM3U\n#EXTINF:4,\nsegment.ts', `${url}?index=${index}`);
+  post('#EXTM3U\n#EXTINF:5,\nnext.ts', `${url}?index=${MAX_MANIFESTS}`);
+  const manifests = getManifestCapture(undefined).manifests;
+  expect(manifests).toHaveLength(MAX_MANIFESTS);
+  expect(manifests?.some((item) => item.url === `${url}?index=0`)).toBe(false);
+  expect(manifests?.at(-1)).toEqual({
+    url: `${url}?index=${MAX_MANIFESTS}`,
+    kind: 'hls-media',
+    matched: false,
+  });
+});
+
+test('validates and bounds manifest metadata from page messages and old storage', () => {
+  const valid = { url, kind: 'dash', matched: true };
+  expect(
+    getManifestMetadata({
+      mpd: 'javascript:alert(1)',
+      manifests: [
+        valid,
+        valid,
+        { ...valid, url: 'file:///tmp/a' },
+        null,
+        { ...valid, kind: 'html' },
+      ],
+    }),
+  ).toEqual({ mpd: undefined, manifests: [valid] });
+  expect(getManifestMetadata({ mpd: url, manifests: 'not a list' })).toEqual({ mpd: url });
+});
+
+test.each(['dash', 'mss'] as const)(
+  'prefers a direct %s match over an HLS master matched through its child',
+  (kind) => {
+    const data = Buffer.from('shared PlayReady Object');
+    const pssh = psshBoxToBase64(createPsshBox({ systemId: PSSH_SYSTEM_IDS.playready, data }));
+    const master = 'https://example.test/master.m3u8';
+    post('#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1280000\nmedia.m3u8', master);
+    post(
+      `#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI="data:text/plain;base64,${pssh}"`,
+      'https://example.test/media.m3u8',
+    );
+    const direct = `https://example.test/${kind}`;
+    const body =
+      kind === 'dash'
+        ? mpd(pssh, PSSH_SYSTEM_IDS.playready)
+        : `<SmoothStreamingMedia><Protection><ProtectionHeader SystemID="9a04f079-9840-4286-ab92-e65be0885f95">${data.toString('base64')}</ProtectionHeader></Protection></SmoothStreamingMedia>`;
+    post(body, direct);
+    const capture = getManifestCapture(pssh);
+    expect(capture.mpd).toBe(direct);
+    expect(capture.manifests).toEqual([
+      { url: direct, kind, matched: true },
+      { url: master, kind: 'hls-master', matched: true },
+      { url: 'https://example.test/media.m3u8', kind: 'hls-media', matched: true },
+    ]);
+  },
+);

--- a/test/extension-manifest.test.ts
+++ b/test/extension-manifest.test.ts
@@ -95,6 +95,24 @@ test('preserves existing manifest associations when initialized again', () => {
   expect(findManifest(widevine)).toBe(url);
 });
 
+test('recovers manifest inspection from a throwing page-owned cache getter', () => {
+  Object.defineProperty(window, 'MANIFEST_LIST', {
+    configurable: true,
+    get() {
+      throw new Error('Page-owned getter');
+    },
+  });
+  const addEventListener = vi.spyOn(window, 'addEventListener');
+
+  expect(() => installManifestInspection()).not.toThrow();
+  expect(addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+  post(mpd(widevine));
+  expect(getManifestCapture(widevine)).toEqual({
+    mpd: url,
+    manifests: [{ url, kind: 'dash', matched: true }],
+  });
+});
+
 test.each([
   { pssh: widevine, scheme: PSSH_SYSTEM_IDS.widevine },
   { pssh: playready, scheme: PSSH_SYSTEM_IDS.playready },

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -290,3 +290,52 @@ test('does not forward a media segment with a manifest-looking URL', async () =>
   await Promise.resolve();
   expect(postMessage).not.toHaveBeenCalled();
 });
+
+test.each([url, new URL(url), new Request(url), '/manifest.mpd'])(
+  'preserves the original fetch URL across redirects: %#',
+  async (resource) => {
+    vi.stubGlobal('document', { baseURI: 'https://example.com/player' });
+    const response = makeResponse();
+    const finalUrl = 'https://cdn.example/redirected.mpd';
+    vi.spyOn(response, 'url', 'get').mockReturnValue(finalUrl);
+    const pending = Promise.withResolvers<Response>();
+    nativeFetch.mockReturnValue(pending.promise);
+    const fetching = fetch(resource);
+    // Relative URLs must resolve before the page changes its base during the request.
+    vi.stubGlobal('document', { baseURI: 'https://other.example/' });
+    pending.resolve(response);
+    expect(await fetching).toBe(response);
+    await vi.waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({ url: finalUrl, requestUrl: url, text: manifest }),
+        }),
+        '*',
+      ),
+    );
+  },
+);
+
+test('preserves the original XHR URL during redirects and reuse from load handlers', async () => {
+  vi.useFakeTimers();
+  vi.stubGlobal('document', { baseURI: 'https://example.com/player' });
+  const open = vi.spyOn(NativeXHR.prototype, 'open');
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', '/manifest.mpd');
+  expect(open).toHaveBeenCalledWith('GET', '/manifest.mpd', true, undefined, undefined);
+  const finalUrl = 'https://cdn.example/redirected.mpd';
+  Object.assign(xhr, {
+    responseURL: finalUrl,
+    responseType: 'arraybuffer',
+    response: new TextEncoder().encode(manifest).buffer,
+  });
+  xhr.addEventListener('load', () => xhr.open('GET', '/next.mpd'));
+  xhr.dispatchEvent(new Event('load'));
+  await vi.runAllTimersAsync();
+  expect(postMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      params: expect.objectContaining({ url: finalUrl, requestUrl: url, text: manifest }),
+    }),
+    '*',
+  );
+});

--- a/test/extension-network.test.ts
+++ b/test/extension-network.test.ts
@@ -247,3 +247,46 @@ test.each(['text', 'blob'] as const)(
     expect(postMessage).not.toHaveBeenCalled();
   },
 );
+
+test.each([
+  [
+    'https://example.com/live',
+    'Application/Vnd.Apple.MpegURL; charset=utf-8',
+    '#EXTM3U\n#EXTINF:4,\nsegment.ts',
+  ],
+  ['https://example.com/live', 'audio/x-mpegurl', '#EXTM3U\n#EXTINF:4,\nsegment.ts'],
+  ['https://example.com/live', 'text/plain', '#EXTM3U\n#EXTINF:4,\nsegment.ts'],
+  [
+    'https://example.com/LIVE.M3U8?token=abc',
+    'application/unknown',
+    '#EXTM3U\n#EXTINF:4,\nsegment.ts',
+  ],
+  ['https://example.com/video.ism/Manifest', '', '<SmoothStreamingMedia/>'],
+  ['https://example.com/live', 'application/vnd.ms-sstr+xml', '<SmoothStreamingMedia/>'],
+])(
+  'captures XHR stream manifests by MIME type or pathname: %s, %s',
+  async (responseURL, type, body) => {
+    const xhr = new XMLHttpRequest();
+    Object.assign(xhr, { responseURL, headers: `content-type: ${type}\r\n`, response: body });
+    xhr.dispatchEvent(new Event('load'));
+    await vi.waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({ url: responseURL, text: body }),
+        }),
+        '*',
+      ),
+    );
+  },
+);
+
+test('does not forward a media segment with a manifest-looking URL', async () => {
+  const xhr = new XMLHttpRequest();
+  Object.assign(xhr, {
+    responseURL: 'https://example.com/live.m3u8',
+    response: 'binary segment data',
+  });
+  xhr.dispatchEvent(new Event('load'));
+  await Promise.resolve();
+  expect(postMessage).not.toHaveBeenCalled();
+});

--- a/test/interception-scripts.test.ts
+++ b/test/interception-scripts.test.ts
@@ -43,9 +43,13 @@ test('updates existing registrations for settings changes and removes them when 
   const remove = vi.spyOn(browser.scripting, 'unregisterContentScripts').mockResolvedValue();
   await syncInterceptionScripts();
   expect(update).toHaveBeenCalledExactlyOnceWith([
-    expect.objectContaining({ js: ['eme-bootstrap.js'] }),
+    expect.objectContaining({ js: ['eme-bootstrap.js', 'network.js'] }),
   ]);
-  await settingsStorage.setValue({ ...defaultSettings, emeInterception: false });
+  await settingsStorage.setValue({
+    ...defaultSettings,
+    emeInterception: false,
+    requestInterception: false,
+  });
   await syncInterceptionScripts();
   expect(remove).toHaveBeenCalledExactlyOnceWith({ ids: ['okova-interception'] });
 });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { stat } from 'node:fs/promises';
+import { mkdir, stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { loadEnv } from 'vite';
 import { defineConfig } from 'wxt';
@@ -11,7 +11,7 @@ const devEnv = loadEnv('development', process.cwd(), 'WXT_');
 export default defineConfig({
   srcDir: './src/extension',
   hooks: {
-    'config:resolved': (wxt) => {
+    'config:resolved': async (wxt) => {
       if (wxt.config.command !== 'serve' || wxt.config.browser === 'firefox') return;
       // Chromium hashes the unpacked extension path, using UTF-16 on Windows.
       const isWindows = process.platform === 'win32';
@@ -24,6 +24,8 @@ export default defineConfig({
         .slice(0, 32)
         .replace(/[0-9a-f]/g, (digit) => String.fromCharCode(97 + parseInt(digit, 16)));
       const webExt = wxt.config.webExt.config;
+      // chrome-launcher opens its logs before Chromium can create a fresh profile.
+      if (webExt.chromiumProfile) await mkdir(webExt.chromiumProfile, { recursive: true });
       webExt.chromiumPref = {
         ...webExt.chromiumPref,
         'extensions.pinned_extensions': [extensionId],


### PR DESCRIPTION
## Summary
- Detect and retain DASH, HLS, and Smooth Streaming manifests associated with captured keys.
- Add manifest selection and editable download command generation to the key details view.
- Enable manifest URL filtering, validation, safe storage, and automatic request interception.
- Expand unit, integration, and end-to-end coverage for manifest capture and command building.

## Testing
- Added coverage for HLS, MSS, and DASH manifest inspection and association.
- Added download command URL validation and selected-manifest tests.
- Added end-to-end checks for manifest links, history filtering, and popup command generation.